### PR TITLE
Fix tinydns load balancing reverse behavior

### DIFF
--- a/config/tinydns/tinydns.inc
+++ b/config/tinydns/tinydns.inc
@@ -564,7 +564,7 @@ function tinydns_create_zone_file() {
 						else
 							$wanpingthreshold = "";
 						$status = tinydns_get_record_status($row['failoverip'], $pingthreshold, $wanpingthreshold);
-						if($status == "DOWN") {
+						if($status == "UP") {
 							$record_data = tinydns_get_rowline_data($row['failoverip'], $domain['recordtype'], $ttl, $hostname, "", $domain['rdns'], $dist, $domain['src_port'], $domain['src_weight'], $domain['src_priority'], $domain['src_timestamp']);
 							fwrite($fd, $record_data . "\n");
 						}


### PR DESCRIPTION
I created a bug report for this at redmine:

http://redmine.pfsense.org/issues/1735

This fixes load balancing bug where pfsense load balances when the failover IP is down and not load balancing when both IPs are up.
