### PR TITLE
squid 3.1.14.tbz does not exists in http://files.pfsense.org/packages/amd

### DIFF
--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -825,7 +825,7 @@
 		<required_version>2.0</required_version>
 		<maintainer>fernando@netfilter.com.br seth.mos@xs4all.nl mfuchs77@googlemail.com</maintainer>
 		<depends_on_package_base_url>http://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
-		<depends_on_package>squid-3.1.14.tbz</depends_on_package>
+		<depends_on_package>squid-3.1.9.tbz</depends_on_package>
 		<depends_on_package>squid_radius_auth-1.10.tbz</depends_on_package>
 		<depends_on_package>libwww-5.4.0_4.tbz</depends_on_package>
 		<!-- Do not add build paths please, it conflicts with squid 2.x -->


### PR DESCRIPTION
squid 3.1.14.tbz does not exists in http://files.pfsense.org/packages/amd64/8/All/
