### PR TITLE
Killing existing radiusd processes before starting "radiusd -s". Bug #1218

### DIFF
--- a/config/freeradius.inc
+++ b/config/freeradius.inc
@@ -26,8 +26,8 @@ function freeradius_install_command() {
 
 	$rcfile = array();
 	$rcfile['file'] = 'radiusd.sh';
-	$rcfile['start'] = 'radiusd -s &';
-	$rcfile['stop'] = 'killall radiusd';
+	$rcfile['start'] = 'killall -9 radiusd  ; sleep 5 && radiusd -s &';;
+	$rcfile['stop'] = 'killall -9 radiusd ; sleep 5';
         conf_mount_rw();
 	write_rcfile($rcfile);
         conf_mount_ro();


### PR DESCRIPTION
Killing existing radiusd processes before starting "radiusd -s". This should prevent "Error: There appears to be another RADIUS server running on the authentication port 1812" after a reboot of pfsense. This works in my scenario and perhaps resolves problems posted in "Bug #1218"
