### PR TITLE
squid: added variable for "maximum_object_size_in_memory $max_objsize_in_

### DIFF
--- a/config/squid/squid_cache.xml
+++ b/config/squid/squid_cache.xml
@@ -136,6 +136,14 @@
 			<default_value>4</default_value>
 		</field>
 		<field>
+			<fielddescr>Maximum object size in RAM</fielddescr>
+			<fieldname>maximum_objsize_in_mem</fieldname>
+			<description>Objects smaller than the size specified (in kilobytes) will be saved in RAM. Default is 32.</description>
+			<type>input</type>
+			<required/>
+			<default_value>32</default_value>
+		</field>		
+		<field>
 			<fielddescr>Level 1 subdirectories</fielddescr>
 			<fieldname>level1_subdirs</fieldname>
 			<description>Each level-1 directory contains 256 subdirectories, so a value of 256 level-1 directories will use a total of 65536 directories for the hard disk cache.  This will significantly slow down the startup process of the proxy service, but can speed up the caching under certain conditions.</description>


### PR DESCRIPTION
squid: added variable for "maximum_object_size_in_memory $max_objsize_in_mem KB" so the size could be changed from GUI.
