### PR TITLE
Other improvements / new features

### DIFF
--- a/config/lcdproc-dev/lcdproc.inc
+++ b/config/lcdproc-dev/lcdproc.inc
@@ -49,7 +49,7 @@
 		if((int)exec('pgrep LCDd | wc -l') > 0)
 			return true;
 		return false;
-	}	
+	}
 
 	function lcdproc_write_config($file, $text) {
 		$handle = fopen($file, 'w');
@@ -75,16 +75,16 @@
 	function before_form_lcdproc($pkg) {
 		global $config;
 
-		config_lock();		
-		
+		config_lock();
+
 		config_unlock();
 	}
 
 	function before_form_lcdproc_screens($pkg) {
 		global $config;
 
-		config_lock();		
-		
+		config_lock();
+
 		config_unlock();
 	}
 
@@ -147,6 +147,9 @@
 					continue;
 					break;
 				case "20x4":
+					continue;
+					break;
+				case "40x2":
 					continue;
 					break;
 				default:
@@ -228,12 +231,12 @@
 			$config_text .= "DownKey=Down\n";
 
 			/* lcdproc default driver definitions */
-			switch($lcdproc_config[driver]) {	
+			switch($lcdproc_config[driver]) {
 				case "bayrad":
 					$config_text .= "[{$lcdproc_config['driver']}]\n";
 					$config_text .= "Device={$realport}\n";
 					$config_text .= "Speed=9600\n";
-					break;				
+					break;
 				case "CFontz":
 					$config_text .= "[{$lcdproc_config['driver']}]\n";
 					$config_text .= "Device={$realport}\n";
@@ -292,6 +295,18 @@
 					$config_text .= "OffBrightness=0\n";
 					$config_text .= "Brightness=500\n";
 					break;
+				case "EyeboxOne":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					$config_text .= "Backlight=yes\n";
+					$config_text .= "Speed=19200\n";
+					break;
+				case "glk":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					$config_text .= "Contrast=560\n";
+					$config_text .= "Speed=19200\n";
+					break;
 				case "hd44780":
 					$config_text .= "[{$lcdproc_config['driver']}]\n";
 					$config_text .= "driverpath=/usr/local/lib/lcdproc/\n";
@@ -307,13 +322,78 @@
 					$config_text .= "DelayMult=1\n";
 					$config_text .= "DelayBus=true\n";
 					$config_text .= "Size={$lcdproc_config['size']}\n";
-					break;						
+					break;
+				case "icp_a106":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					break;
+				case "IOWarrior":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Size={$lcdproc_config['size']}\n";
+					break;
+				case "lb216":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					$config_text .= "Brightness=255\n";
+					$config_text .= "Speed=9600\n";
+					$config_text .= "Reboot=no\n";
+					break;
+				case "lcdm001":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					break;
+				case "lcterm":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					$config_text .= "Size={$lcdproc_config['size']}\n";
+					break;
+				case "MD8800":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					$config_text .= "Size={$lcdproc_config['size']}\n";
+					$config_text .= "Brightness=1000\n";
+					$config_text .= "OffBrightness=0\n";
+					break;
+				case "ms6931":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					$config_text .= "Brightness=255\n";
+					$config_text .= "Reboot=no\n";
+					break;
+				case "mtc_s16209x":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					$config_text .= "Brightness=255\n";
+					$config_text .= "Reboot=no\n";
+					break;
+				case "MtxOrb":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					$config_text .= "Size={$lcdproc_config['size']}\n";
+					$config_text .= "Contrast=480\n";
+					$config_text .= "Type=lcd\n";
+					$config_text .= "hasAdjustableBacklight=yes\n";
+					$config_text .= "Reboot=no\n";
+					$config_text .= "Brightness=1000\n";
+					$config_text .= "OffBrightness=0\n";
+					$config_text .= "Speed=19200\n";
+					break;
 				case "nexcom":
 					$config_text .= "[{$lcdproc_config['driver']}]\n";
 					$config_text .= "driverpath =/usr/local/lib/lcdproc/\n";
 					$config_text .= "Device={$realport}\n";
 					$config_text .= "Size={$lcdproc_config['size']}\n";
-					break;		
+					break;
+				case "NoritakeVFD":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					$config_text .= "Size={$lcdproc_config['size']}\n";
+					$config_text .= "Brightness=1000\n";
+					$config_text .= "OffBrightness=0\n";
+					$config_text .= "Speed=9600\n";
+					$config_text .= "Parity=0\n";
+					$config_text .= "Reboot=no\n";
+					break;
 				case "picolcd":
 					$config_text .= "[{$lcdproc_config['driver']}]\n";
 					$config_text .= "driverpath=/usr/local/lib/lcdproc/\n";
@@ -336,15 +416,47 @@
 					$config_text .= "Device={$realport}\n";
 					$config_text .= "Size={$lcdproc_config['size']}\n";
 					break;
+				case "sed1330":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					break;
+				case "sed1520":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					break;
+				case "serialPOS":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					$config_text .= "Size={$lcdproc_config['size']}\n";
+					$config_text .= "Type=AEDEX\n";
+					$config_text .= "Speed=9600\n";
+					break;
+				case "serialVFD":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "use_parallel=no\n";
+					$config_text .= "Device={$realport}\n";
+					$config_text .= "Size={$lcdproc_config['size']}\n";
+					$config_text .= "Type=0\n";  //Just the first
+					$config_text .= "Brightness=1000\n";
+					$config_text .= "OffBrightness=0\n";
+					$config_text .= "Speed=9600\n";
+					$config_text .= "ISO_8859_1=yes\n";
+					break;
+				case "shuttleVFD":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					break;
 				case "SureElec":
 					$config_text .= "[{$lcdproc_config['driver']}]\n";
 					$config_text .= "driverpath =/usr/local/lib/lcdproc/\n";
 					$config_text .= "Device={$realport}\n";
 					$config_text .= "Size={$lcdproc_config['size']}\n";
-					$config_text .= "Edition=2\n";					
+					$config_text .= "Edition=2\n";
 					$config_text .= "Contrast=200\n";
-					$config_text .= "Brightness=480\n";	
+					$config_text .= "Brightness=480\n";
 					$config_text .= "Speed=19200\n";
+					break;
+				case "sli":
+					$config_text .= "[{$lcdproc_config['driver']}]\n";
+					$config_text .= "Device={$realport}\n";
+					$config_text .= "Speed=9600\n";
 					break;
 				default:
 					lcdproc_warn("The chosen lcdproc driver is not a valid choice");
@@ -370,12 +482,12 @@ EOD;
 			$stop = <<<EOD
 
 if [ `ps auxw |awk '/LCD[d]/ {print $2}'| wc -l` != 0  ]; then
-	ps auxw |awk '/LCD[d]/ {print $2}'|xargs kill 
-	sleep 1	
+	ps auxw |awk '/LCD[d]/ {print $2}'|xargs kill
+	sleep 1
 fi
 if [ `ps auxw |awk '/lcdclient.s[h]/ {print $2}'| wc -l` != 0  ]; then
 	ps auxw |awk '/lcdclient.s[h]/ {print $2}'|xargs kill
-	sleep 1	
+	sleep 1
 fi
 
 EOD;

--- a/config/lcdproc-dev/lcdproc.xml
+++ b/config/lcdproc-dev/lcdproc.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
-	<title>Services: LCDproc 0.5.4 pkg v. 0.1</title>
+	<title>Services: LCDproc 0.5.4 pkg v. 0.3</title>
 	<name>lcdproc</name>
-	<version>0.5.4 pkg v. 0.2</version>
+	<version>0.5.4 pkg v. 0.3</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>

--- a/config/lcdproc-dev/lcdproc_screens.xml
+++ b/config/lcdproc-dev/lcdproc_screens.xml
@@ -2,7 +2,7 @@
 <packagegui>
 	<title>Services: LCDproc: Screens</title>
 	<name>lcdproc_screens</name>
-	<version>0.5.2_1-p9</version>
+	<version>0.5.4 pkg v. 0.3</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>
@@ -92,7 +92,18 @@
 			<fielddescr>Enable CPU Frequency</fielddescr>
 			<fieldname>scr_cpufrequency</fieldname>
 			<type>checkbox</type>
-		</field>		
+		</field>
+		<field>
+			<fielddescr>Enable Interface Traffic</fielddescr>
+			<fieldname>scr_traffic</fieldname>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr> > interface selected</fielddescr>
+			<fieldname>scr_traffic_interface</fieldname>
+			<type>interfaces_selection</type>
+			<description>If Interface Traffic is enabled, here you specify which interface to monitor</description>
+		</field>				
 	</fields>
 	<custom_php_command_before_form>
 		before_form_lcdproc_screens(&amp;$pkg);

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -79,8 +79,8 @@
 		<descr>The Reliable, High Performance TCP/HTTP Load Balancer</descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.4.18 pkg v.1.0</version>
-		<status>Release</status>
+		<version>0.30</version>
+		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<config_file>http://www.pfsense.com/packages/config/haproxy/haproxy.xml</config_file>
 		<depends_on_package_base_url>http://e-sac.siteseguro.ws/pfsense/8/All/</depends_on_package_base_url>
@@ -367,7 +367,7 @@
 		<pkginfolink>http://forum.pfsense.org/index.php/topic,40622.0.html</pkginfolink>
 		<depends_on_package_base_url>http://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
 		<depends_on_package>postfix-2.8.5,1.tbz</depends_on_package>
-		<version>2.8.5,1 pkg v.2.3.2</version>
+		<version>2.8.5,1 pkg v.2.3.1</version>
 		<status>RC1</status>
 		<required_version>2.0</required_version>
 		<configurationfile>postfix.xml</configurationfile>
@@ -384,12 +384,8 @@
 		<pkginfolink>http://forum.pfsense.org/index.php/topic,43687.0.html</pkginfolink>
 		<depends_on_package_base_url>http://e-sac.siteseguro.ws/pfsense/8/All/</depends_on_package_base_url>
 		<depends_on_package>MailScanner-4.83.5.tbz</depends_on_package>
-		<depends_on_package>perl-5.12.4_3.tbz</depends_on_package>
-		<depends_on_package>pyzor-0.5.0_1.tbz</depends_on_package>
-		<depends_on_package>p5-Mail-SPF-2.007.tbz</depends_on_package>
-		<depends_on_package>p5-IP-Country-2.27.tbz</depends_on_package>
-		<version>4.83.5 pkg v.0.2</version>
-		<status>beta</status>
+		<version>4.83.5 pkg v.0.1</version>
+		<status>alpha</status>
 		<required_version>2.0</required_version>
 		<configurationfile>mailscanner.xml</configurationfile>
 		<build_port_path>/usr/ports/mail/mailscanner</build_port_path>
@@ -976,7 +972,7 @@
 		<descr>LCD display driver - Development version</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.4 pkg v. 0.2</version>
+		<version>lcdproc-0.5.4 pkg v. 0.3</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>michele@nt2.it</maintainer>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -158,8 +158,8 @@
 		<descr>The Reliable, High Performance TCP/HTTP Load Balancer</descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.4.18 pkg v.1.0</version>
-		<status>Release</status>
+		<version>0.30</version>
+		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<config_file>http://www.pfsense.com/packages/config/haproxy/haproxy.xml</config_file>
 		<configurationfile>haproxy.xml</configurationfile>
@@ -455,7 +455,7 @@
 		<depends_on_package>postfix-2.8.7,1.tbz</depends_on_package>
 		<depends_on_package>perl-5.12.4_3.tbz</depends_on_package>
 		<depends_on_package_pbi>postfix-2.8.5-amd64.pbi</depends_on_package_pbi>
-		<version>2.8.7,1 pkg v.2.3.2</version>
+		<version>2.8.7,1 pkg v.2.3.1</version>
 		<status>RC1</status>
 		<required_version>2.0</required_version>
 		<configurationfile>postfix.xml</configurationfile>
@@ -472,11 +472,8 @@
 		<pkginfolink>http://forum.pfsense.org/index.php/topic,43687.0.html</pkginfolink>
 		<depends_on_package_base_url>http://e-sac.siteseguro.ws/pfsense/8/amd64/All/</depends_on_package_base_url>
 		<depends_on_package>MailScanner-4.83.5.tbz</depends_on_package>
-		<depends_on_package>pyzor-0.5.0_1.tbz</depends_on_package>
-		<depends_on_package>p5-Mail-SPF-2.007.tbz</depends_on_package>
-		<depends_on_package>p5-IP-Country-2.27.tbz</depends_on_package>
-		<version>4.83.5 pkg v.0.2</version>
-		<status>beta</status>
+		<version>4.83.5 pkg v.0.1</version>
+		<status>alpha</status>
 		<required_version>2.0</required_version>
 		<configurationfile>mailscanner.xml</configurationfile>
 		<build_port_path>/usr/ports/mail/mailscanner</build_port_path>
@@ -826,34 +823,6 @@
 		<after_install_info>Please visit Services: freeRADIUS</after_install_info>
 	</package>
 	<package>
-		<name>freeradius2-experimental-modules</name>
-		<website>http://www.freeradius.org/</website>
-		<descr><![CDATA[A free implementation of the RADIUS protocol.<br>
-				Do not use together with freeradius package. Both are using the same XML files.<br>
-				With experimental modules.]]></descr>
-		<pkginfolink>http://forum.pfsense.org/index.php/topic,43675.0.html</pkginfolink>
-		<category>System</category>
-		<version>2.1.12 pkg v1.1.1</version>
-		<status>BETA</status>
-		<required_version>2.0</required_version>
-		<maintainer>Nachtfalke</maintainer>
-		<depends_on_package_base_url>http://ftp.freebsd.org/pub/FreeBSD/ports/amd64/packages-8-stable/All/</depends_on_package_base_url>
-		<depends_on_package>freeradius-2.1.12.tbz</depends_on_package>
-		<depends_on_package>python27-2.7.2_3.tbz</depends_on_package>
-		<depends_on_package>perl-5.12.4_3.tbz</depends_on_package>
-		<depends_on_package>libltdl-2.4_1.tbz</depends_on_package>
-		<depends_on_package>gdbm-1.9.1.tbz</depends_on_package>
-		<config_file>http://www.pfsense.org/packages/config/freeradius2/freeradius.xml</config_file>
-		<configurationfile>freeradius.xml</configurationfile>
-		<build_port_path>/usr/ports/net/freeradius2</build_port_path>
-		<build_port_path>/usr/ports/lang/python27</build_port_path>
-		<build_port_path>/usr/ports/lang/perl5.12</build_port_path>
-		<build_port_path>/usr/ports/devel/libltdl</build_port_path>
-		<build_port_path>/usr/ports/databases/gdbm</build_port_path>
-		<after_install_info>Please visit Services: freeRADIUS</after_install_info>
-		<build_options>WITH_LDAP=yes WITH_KERBEROS=yes WITH_EXPERIMENTAL=yes</build_options>
-	</package>
-	<package>
 		<name>bandwidthd</name>
 		<website>http://bandwidthd.sourceforge.net/</website>
 		<descr>BandwidthD tracks usage of TCP/IP network subnets and builds html files with graphs to display utilization. Charts are built by individual IPs, and by default display utilization over 2 day, 8 day, 40 day, and 400 day periods. Furthermore, each ip address's utilization can be logged out at intervals of 3.3 minutes, 10 minutes, 1 hour or 12 hours in cdf format, or to a backend database server. HTTP, TCP, UDP, ICMP, VPN, and P2P traffic are color coded.</descr>
@@ -975,7 +944,7 @@
 		<descr>LCD display driver - Development version</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.4 pkg v. 0.2</version>
+		<version>lcdproc-0.5.4 pkg v. 0.3</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>michele@nt2.it</maintainer>


### PR DESCRIPTION
- Added 40x2 display size (I found out that some display has this size)
- I managed in the code ALL the drivers available in the package. Consider that before this change only 12 drivers on 35 were supported. Now all the selectable panels are supposed to work, with the default configuration values. If someone has problems with the new added drivers please let me know
- I added the IN/OUT statistics for a selectable interface. For the selected interface IN and OUT bytes are shown
- In the summary (visible to the ones that have a 4 line display) I added, if the width of the panel is bigger than 16 rows, the frequency in percent currently used
- I reduced the CPU interval in the load calculation from 1s to 250ms. This because setting the refresh of the panel to 1 second was actually 2 seconts (1 to wait for the refresh, 1 to wait for the CPU calculation)
