### PR TITLE
freeradius2 updates pkg v1.3.9

### DIFF
--- a/config/freeradius2/freeradius.inc
+++ b/config/freeradius2/freeradius.inc
@@ -38,6 +38,12 @@
 
 require_once('config.inc');
 require_once('service-utils.inc');
+require_once("util.inc");
+require_once("functions.inc");
+require_once("pkg-utils.inc");
+require_once("globals.inc");
+require_once("filter.inc");
+require_once("services.inc");
 
 define('RADDB', '/usr/local/etc/raddb');
 
@@ -124,8 +130,7 @@ function freeradius_settings_resync() {
 		$varsqlconfincludecounter = '$INCLUDE sql/mysql/counter.conf';
 		$varsqlconfinstantiate = 'sql';
 	}
-
-	if ($sqlconf['varsqlconfincludeenable'] == 'Disable') {
+	else {
 		$varsqlconfinclude = '#$INCLUDE sql.conf';
 		$varsqlconfincludecounter = '#$INCLUDE sql/mysql/counter.conf';
 		$varsqlconfinstantiate = '#sql';
@@ -291,6 +296,7 @@ EOD;
 	conf_mount_rw();
 	file_put_contents(RADDB . '/radiusd.conf', $conf);
 	conf_mount_ro();
+	
 	restart_service("freeradius");
 }
 
@@ -388,7 +394,8 @@ EOD;
 	file_put_contents($filename, $conf);
 	chmod($filename, 0600);
 	conf_mount_ro();
-
+	
+	freeradius_sync_on_changes();
 	restart_service('freeradius');
 }
 
@@ -411,26 +418,14 @@ function freeradius_clients_resync() {
 
 client $varclientshortname {
 	$varclientipversion = $varclientip
-
-		### udp or tcp - udp is default
 	proto = $varclientproto
 	secret = $varclientsharedsecret
-
-		### RFC5080: User Message-Authenticator in Access-Request. But older sqitches, accesspoints, NAS do not include that. Default: no
 	require_message_authenticator = $varrequiremessageauthenticator
-
-		### Takes only effect if you use TCP as protocol. This is the mirror of "max_requests" from "Settings" tab. Default 16
 	max_connections = $varclientmaxconnections
 	shortname = $varclientshortname
-
-		### Optional: Used by checkrad.pl for simultaneous use checks. Default: other
 	nastype = $varclientnastype
-
-		### Optional: will be used in future releases
 	#login = !root
 	#password = someadminpas
-							
-		### Additional configuration needed. See: raddb/sites-available/originate-coa
 	#virtual_server = home1
 	#coa_server = coa
 }
@@ -452,6 +447,8 @@ EOD;
 	conf_mount_rw();
 	file_put_contents(RADDB . '/clients.conf', $conf);
 	conf_mount_ro();
+	
+	freeradius_sync_on_changes();
 	restart_service("freeradius");
 }
 
@@ -1792,4 +1789,140 @@ function freeradius_allcertcnf_resync() {
 		restart_service('freeradius');
 		}
 }
+
+// ##### The following part is based on the code of pfblocker #####
+
+/* Uses XMLRPC to synchronize the changes to a remote node */
+function freeradius_sync_on_changes() {
+	global $config, $g;
+	$varsyncenablexmlrpc = $config['installedpackages']['freeradiussync']['config'][0]['varsyncenablexmlrpc'];	
+	
+	// if checkbox is NOT checked do nothing
+	if(!$varsyncenablexmlrpc) {
+		return;
+	}
+	
+	log_error("freeRADIUS is starting XMLRPC process (freeradius_do_xmlrpc_sync).");	
+	
+	// if checkbox is checked get IP and password of the destination hosts
+	foreach ($config['installedpackages']['freeradiussync']['config'] as $rs ){
+		foreach($rs['row'] as $sh){
+		$sync_to_ip = $sh['varsyncipaddress'];
+		$password   = $sh['varsyncpassword'];
+		if($password && $sync_to_ip)
+			freeradius_do_xmlrpc_sync($sync_to_ip, $password);
+		}
+	}
+	log_error("freeRADIUS has finished XMLRPC process (freeradius_do_xmlrpc_sync).");
+}
+
+/* Do the actual XMLRPC sync */
+function freeradius_do_xmlrpc_sync($sync_to_ip, $password) {
+	global $config, $g;
+
+	if(!$password)
+		return;
+
+	if(!$sync_to_ip)
+		return;
+	
+	// Check and choose correct protocol type, port number and IP address
+	$xmlrpc_sync_neighbor = $sync_to_ip;
+    if($config['system']['webgui']['protocol'] != "") {
+		$synchronizetoip = $config['system']['webgui']['protocol'];
+		$synchronizetoip .= "://";
+    }
+    $port = $config['system']['webgui']['port'];
+    /* if port is empty lets rely on the protocol selection */
+    if($port == "") {
+		if($config['system']['webgui']['protocol'] == "http") 
+			$port = "80";
+		else 
+			$port = "443";
+    }
+	$synchronizetoip .= $sync_to_ip;
+
+	/* xml will hold the sections to sync */
+	$xml = array();
+	$xml['freeradius'] = $config['installedpackages']['freeradius'];
+	$xml['freeradiusclients'] = $config['installedpackages']['freeradiusclients'];
+	
+	/* assemble xmlrpc payload */
+	$params = array(
+		XML_RPC_encode($password),
+		XML_RPC_encode($xml)
+	);
+
+	/* set a few variables needed for sync code borrowed from filter.inc */
+	$url = $synchronizetoip;
+	log_error("Beginning freeRADIUS XMLRPC sync with {$url}:{$port}.");
+	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
+	$msg = new XML_RPC_Message($method, $params);
+	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
+	$cli->setCredentials('admin', $password);
+		if($g['debug'])
+			$cli->setDebug(1);
+		/* send our XMLRPC message and timeout after 250 seconds */
+		$resp = $cli->send($msg, "250");
+		if(!$resp) {
+			$error = "A communications error occurred while freeRADIUS was attempting XMLRPC sync with {$url}:{$port}.";
+			log_error($error);
+			file_notice("sync_settings", $error, "freeradius Settings Sync", "");
+		} elseif($resp->faultCode()) {
+			$cli->setDebug(1);
+			$resp = $cli->send($msg, "250");
+			$error = "An error code was received while freeRADIUS XMLRPC was attempting to sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+			log_error($error);
+			file_notice("sync_settings", $error, "freeradius Settings Sync", "");
+		} else {
+			log_error("freeRADIUS XMLRPC has synced data successfully with {$url}:{$port}.");
+		}
+	
+	/* tell freeradius to reload our settings on the destionation sync host. */
+	$method = 'pfsense.exec_php';
+	$execcmd  = "require_once('/usr/local/pkg/freeradius.inc');\n";
+	// pfblocker just needed one fuction to reload after XMLRPC. freeRADIUS needs more so we point to a fuction below which contains all fuctions
+	$execcmd .= "freeradius_all_after_XMLRPC_resync();";
+	
+	/* assemble xmlrpc payload */
+	$params = array(
+		XML_RPC_encode($password),
+		XML_RPC_encode($execcmd)
+	);
+
+	log_error("freeRADIUS XMLRPC is reloading data on {$url}:{$port}.");
+	$msg = new XML_RPC_Message($method, $params);
+	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
+	$cli->setCredentials('admin', $password);
+		$resp = $cli->send($msg, "250");
+		if(!$resp) {
+			$error = "A communications error occurred while freeRADIUS was attempting XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
+			log_error($error);
+			file_notice("sync_settings", $error, "freeradius Settings Sync", "");
+		} elseif($resp->faultCode()) {
+			$cli->setDebug(1);
+			$resp = $cli->send($msg, "250");
+			$error = "An error code was received while freeRADIUS XMLRPC was attempting to sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+			log_error($error);
+			file_notice("sync_settings", $error, "freeradius Settings Sync", "");
+		} else {
+			log_error("freeRADIUS XMLRPC has reloaded data successfully on {$url}:{$port} (pfsense.exec_php).");
+		}
+
+}
+
+// ##### The part above is based on the code of pfblocker #####
+
+// This function restarts all other needed functions after XMLRPC so that the content of .XML + .INC will be written in the files (clients.conf, users)
+// Adding more functions will increase the to sync
+function freeradius_all_after_XMLRPC_resync() {
+	
+	freeradius_users_resync();
+	freeradius_clients_resync();
+	
+	log_error("freeRADIUS has finished XMLRPC process. It should be OK. For more information look at the host which started sync.");
+	
+	exec("/usr/local/etc/rc.d/radiusd onerestart");
+}
+
 ?>

--- a/config/freeradius2/freeradius.xml
+++ b/config/freeradius2/freeradius.xml
@@ -65,7 +65,7 @@
 		<tab>
 			<text>Users</text>
 			<url>/pkg.php?xml=freeradius.xml</url>
-			<active/>
+		<active/>
 		</tab>
 		<tab>
 			<text>NAS / Clients</text>
@@ -94,6 +94,10 @@
 		<tab>
 			<text>View config</text>
 			<url>/freeradius_view_config.php</url>
+		</tab>
+		<tab>
+			<text>XMLRPC Sync</text>
+			<url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
 		</tab>
 	</tabs>
 	<additional_files_needed>
@@ -134,6 +138,11 @@
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
 		<chmod>0755</chmod>
+		<item>http://www.pfsense.org/packages/config/freeradius2/freeradiussync.xml</item>
+	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/usr/local/pkg/</prefix>
+		<chmod>0755</chmod>
 		<item>http://www.pfsense.org/packages/config/freeradius2/freeradius.inc</item>
 	</additional_files_needed>
 	<adddeleteeditpagefields>
@@ -142,16 +151,12 @@
 			<fieldname>varusersusername</fieldname>
 		</columnitem>
 		<columnitem>
-			<fielddescr>Description</fielddescr>
-			<fieldname>description</fieldname>
+			<fielddescr>Simult. Connections</fielddescr>
+			<fieldname>varuserssimultaneousconnect</fieldname>
 		</columnitem>
 		<columnitem>
 			<fielddescr>IP Address</fielddescr>
 			<fieldname>varusersframedipaddress</fieldname>
-		</columnitem>
-		<columnitem>
-			<fielddescr>Simultaneous Connections</fielddescr>
-			<fieldname>varuserssimultaneousconnect</fieldname>
 		</columnitem>
 		<columnitem>
 			<fielddescr>Expiration Date</fielddescr>
@@ -168,6 +173,10 @@
 		<columnitem>
 			<fielddescr>VLAN ID</fielddescr>
 			<fieldname>varusersvlanid</fieldname>
+		</columnitem>
+		<columnitem>
+			<fielddescr>Description</fielddescr>
+			<fieldname>description</fieldname>
 		</columnitem>
 	</adddeleteeditpagefields>
 	<fields>
@@ -310,10 +319,6 @@
 		freeradius_sqlconf_resync();
 		freeradius_settings_resync();
 		freeradius_serverdefault_resync();
-		freeradius_clientcertcnf_resync();
-		freeradius_servercertcnf_resync();
-		freeradius_cacertcnf_resync();
-		freeradius_allcertcnf_resync();
 		exec("rm -f /usr/local/etc/raddb/sites-enabled/control-socket");
 		exec("rm -f /usr/local/etc/raddb/sites-enabled/inner-tunnel");
 	</custom_php_install_command>

--- a/config/freeradius2/freeradius_view_config.php
+++ b/config/freeradius2/freeradius_view_config.php
@@ -59,7 +59,7 @@ else{
 	if(strstr($pfSversion, "1.2"))
 		$one_two = true;
 	
-	$pgtitle = "Services: freeRADIUS View Configuration";
+	$pgtitle = "FreeRADIUS: View Configuration";
 	include("head.inc");
 	
 	?>
@@ -87,6 +87,7 @@ else{
 		$tab_array[] = array(gettext("SQL"), false, "/pkg_edit.php?xml=freeradiussqlconf.xml&id=0");
 		$tab_array[] = array(gettext("Certificates"), false, "/pkg_edit.php?xml=freeradiuscerts.xml&id=0");
 		$tab_array[] = array(gettext("View config"), true, "/freeradius_view_config.php");
+		$tab_array[] = array(gettext("XMLRPC Sync"), false, "/pkg_edit.php?xml=freeradiussync.xml&amp;id=0");
 		display_top_tabs($tab_array);
 	?>
 			</td></tr>

--- a/config/freeradius2/freeradiuscerts.xml
+++ b/config/freeradius2/freeradiuscerts.xml
@@ -78,10 +78,14 @@
 			<text>Certificates</text>
 			<url>/pkg_edit.php?xml=freeradiuscerts.xml&amp;id=0</url>
 			<active/>
-		</tab>
+		</tab>		
 		<tab>
 			<text>View config</text>
 			<url>/freeradius_view_config.php</url>
+		</tab>
+		<tab>
+			<text>XMLRPC Sync</text>
+			<url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
 		</tab>
 	</tabs>
 	<fields>
@@ -174,7 +178,7 @@
 			<fielddescr>Key Creation Algorithm</fielddescr>
 			<fieldname>varcertsdefaultmd</fieldname>
 			<description><![CDATA[Choose the algotithem which should be used to create the key.<br>
-								There seems to be some OS do not support all algorithms. (Default: md5)]]></description>
+								There seems to be some OS which do not support all algorithms. (Default: md5)]]></description>
 			<type>select</type>
 			<default_value>md5</default_value>
 					<options>
@@ -273,11 +277,9 @@
 		</field>
 	</fields>
 	<custom_delete_php_command>
-	freeradius_allcertcnf_resync();
-	freeradius_eapconf_resync();
+		freeradius_allcertcnf_resync();
 	</custom_delete_php_command>
 	<custom_php_resync_config_command>
-	freeradius_allcertcnf_resync();
-	freeradius_eapconf_resync();
+		freeradius_allcertcnf_resync();
 	</custom_php_resync_config_command>
 </packagegui>

--- a/config/freeradius2/freeradiusclients.xml
+++ b/config/freeradius2/freeradiusclients.xml
@@ -82,7 +82,11 @@
 			<text>View config</text>
 			<url>/freeradius_view_config.php</url>
 		</tab>
-	</tabs>
+		<tab>
+			<text>XMLRPC Sync</text>
+			<url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
+		</tab>
+</tabs>
 	<adddeleteeditpagefields>
 		<columnitem>
 			<fielddescr>Client IP Address</fielddescr>

--- a/config/freeradius2/freeradiuseapconf.xml
+++ b/config/freeradius2/freeradiuseapconf.xml
@@ -46,7 +46,7 @@
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiuseapconf</name>
 	<version>none</version>
-	<title>FreeRADIUS: Settings</title>
+	<title>FreeRADIUS: EAP</title>
 	<aftersaveredirect>pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</aftersaveredirect>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>
 	<tabs>
@@ -82,6 +82,10 @@
 		<tab>
 			<text>View config</text>
 			<url>/freeradius_view_config.php</url>
+		</tab>
+		<tab>
+			<text>XMLRPC Sync</text>
+			<url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
 		</tab>
 	</tabs>
 	<fields>

--- a/config/freeradius2/freeradiusinterfaces.xml
+++ b/config/freeradius2/freeradiusinterfaces.xml
@@ -82,6 +82,10 @@
 			<text>View config</text>
 			<url>/freeradius_view_config.php</url>
 		</tab>
+		<tab>
+			<text>XMLRPC Sync</text>
+			<url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
+		</tab>
 	</tabs>
 	<adddeleteeditpagefields>
 		<columnitem>

--- a/config/freeradius2/freeradiussettings.xml
+++ b/config/freeradius2/freeradiussettings.xml
@@ -83,6 +83,10 @@
 			<text>View config</text>
 			<url>/freeradius_view_config.php</url>
 		</tab>
+		<tab>
+			<text>XMLRPC Sync</text>
+			<url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
+		</tab>
 	</tabs>
 	<fields>
 		<field>

--- a/config/freeradius2/freeradiussqlconf.xml
+++ b/config/freeradius2/freeradiussqlconf.xml
@@ -83,6 +83,10 @@
 			<text>View config</text>
 			<url>/freeradius_view_config.php</url>
 		</tab>
+		<tab>
+			<text>XMLRPC Sync</text>
+			<url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
+		</tab>
 	</tabs>
 	<fields>
 		<field>

--- a/config/freeradius2/freeradiussync.xml
+++ b/config/freeradius2/freeradiussync.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<packagegui>
+	<copyright>
+	<![CDATA[
+/* $Id$ */
+/* ========================================================================== */
+/*
+    pfblocker_sync.xml
+    part of the pfblocker package for pfSense
+    Copyright (C) 2011 Marcello Coutinho
+    All rights reserved.            
+                                                                  */
+/* ========================================================================== */
+/*
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+                                                                              */
+/* ========================================================================== */
+	]]></copyright>
+	<description><![CDATA[Describe your package here]]></description>
+	<requirements>Describe your package requirements here</requirements>
+	<faq>Currently there are no FAQ items provided.</faq>
+	<name>freeradiussync</name>
+	<version>2.1.12</version>
+	<title>FreeRADIUS: XMLRPC Sync</title>
+	<include_file>/usr/local/pkg/freeradius.inc</include_file>
+	<menu>
+		<name>FreeRADIUS</name>
+		<tooltiptext>Modify FreeRADIUS users, clients, and settings.</tooltiptext>
+		<section>Services</section>
+		<url>/pkg.php?xml=freeradiussync.xml</url>
+	</menu>
+	<service>
+		<name>FreeRADIUS</name>
+		<rcfile>radiusd.sh</rcfile>
+		<executable>radiusd</executable>
+		<description><![CDATA[The FreeRADIUS daemon.]]></description>
+	</service>
+	<tabs>
+		<tab>
+			<text>Users</text>
+			<url>/pkg.php?xml=freeradius.xml</url>
+		</tab>
+		<tab>
+			<text>NAS / Clients</text>
+			<url>/pkg.php?xml=freeradiusclients.xml</url>
+		</tab>
+		<tab>
+			<text>Interfaces</text>
+			<url>/pkg.php?xml=freeradiusinterfaces.xml</url>
+		</tab>
+		<tab>
+			<text>Settings</text>
+			<url>/pkg_edit.php?xml=freeradiussettings.xml&amp;id=0</url>
+		</tab>
+		<tab>
+			<text>EAP</text>
+			<url>/pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</url>
+		</tab>
+		<tab>
+			<text>SQL</text>
+			<url>/pkg_edit.php?xml=freeradiussqlconf.xml&amp;id=0</url>
+		</tab>
+		<tab>
+			<text>Certificates</text>
+			<url>/pkg_edit.php?xml=freeradiuscerts.xml&amp;id=0</url>
+		</tab>		
+		<tab>
+			<text>View config</text>
+			<url>/freeradius_view_config.php</url>
+		</tab>
+		<tab>
+			<text>XMLRPC Sync</text>
+			<url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
+			<active/>
+		</tab>
+	</tabs>
+	<fields>
+		<field>
+			<name>freeRADIUS XMLRPC Sync</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Automatically sync freeRADIUS configuration changes?</fielddescr>
+			<fieldname>varsyncenablexmlrpc</fieldname>
+			<description><![CDATA[All changes will be synced immediately to the IPs listed below if this option is checked.<br>
+						<b>Important:</b> Only <b>Users</b> and <b>NAS / Clients</b> will be synced.]]></description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Destination Server</fielddescr>
+			<fieldname>none</fieldname>
+			<type>rowhelper</type>
+			<rowhelper>
+				<rowhelperfield>
+					<fielddescr>Destination IP Address</fielddescr>
+					<fieldname>varsyncipaddress</fieldname>
+					<description><![CDATA[IP Address of the destination host.]]></description>
+					<type>input</type>
+					<size>20</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Destination Admin Password</fielddescr>
+					<fieldname>varsyncpassword</fieldname>
+					<description><![CDATA[Password of the user "admin" on the destination host.]]></description>
+					<type>password</type>
+					<size>20</size>
+				</rowhelperfield>
+			</rowhelper>
+		</field>
+	</fields>
+	<custom_delete_php_command>
+		freeradius_sync_on_changes();
+	</custom_delete_php_command>	
+	<custom_php_resync_config_command>
+		freeradius_sync_on_changes();
+	</custom_php_resync_config_command>
+</packagegui>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -792,7 +792,7 @@
 				Do not use together with freeradius package. Both are using the same XML files.]]></descr>
 		<pkginfolink>http://forum.pfsense.org/index.php/topic,43675.0.html</pkginfolink>
 		<category>System</category>
-		<version>2.1.12 pkg v1.3.8</version>
+		<version>2.1.12 pkg v1.3.9</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -834,7 +834,7 @@
 				Do not use together with freeradius package. Both are using the same XML files.]]></descr>
 		<pkginfolink>http://forum.pfsense.org/index.php/topic,43675.0.html</pkginfolink>
 		<category>System</category>
-		<version>2.1.12 pkg v1.3.8</version>
+		<version>2.1.12 pkg v1.3.9</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>


### PR DESCRIPTION
- small changes in if/else syntax (freeradius.inc)
- deleted uneccessary <custom_php_resync_config_command> entries (freeradiuscerts.xml)
- fixed some typos in description and titel (eap, view config)
- cosmetic fix: changed order of columns (users)
- added XMLRPC Sync for syncing "users" and "NAS / clients" with other hosts. No other parts of freeradius2 config will be synced.
