### PR TITLE
a step more to close the package

### DIFF
--- a/config/lcdproc-dev/lcdproc.inc
+++ b/config/lcdproc-dev/lcdproc.inc
@@ -240,18 +240,38 @@
 			$config_text .= "DriverPath=/usr/local/lib/lcdproc/\n";
 			$config_text .= "GoodBye=\"Thanks for using\"\n";
 			$config_text .= "GoodBye=\"    {$g['product_name']}     \"\n";
-			/* FIXME: Specific to the pyramid project */
-			$config_text .= "ToggleRotateKey=Enter\n";
-			$config_text .= "PrevScreenKey=Left\n";
-			$config_text .= "NextScreenKey=Right\n";
-			$config_text .= "ScrollUpKey=Up\n";
-			$config_text .= "ScrollDownKey=Down\n";
-			/* FIXME: pyramid test menu */
-			$config_text .= "[menu]\n";
-			$config_text .= "MenuKey=Escape\n";
-			$config_text .= "EnterKey=Enter\n";
-			$config_text .= "UpKey=Up\n";
-			$config_text .= "DownKey=Down\n";
+			if ($lcdproc_config[backlight] != "" && $lcdproc_config[backlight] != "default")
+			{
+				/* Backlight setting */
+				$config_text .= "Backlight={$lcdproc_config[backlight]}\n";				
+			}
+			if ($lcdproc_config[driver] == "sdeclcd")
+			{
+				/* Sdeclcd Keys settings */
+				$config_text .= "PrevScreenKey=Down\n";
+				$config_text .= "NextScreenKey=Up\n";
+				/* Sdeclcd Menu settings */
+				$config_text .= "[menu]\n";
+				$config_text .= "MenuKey=Left\n";
+				$config_text .= "EnterKey=Right\n";
+				$config_text .= "UpKey=Up\n";
+				$config_text .= "DownKey=Down\n";			
+			}
+			else
+			{
+				/* Generic Keys settings */
+				$config_text .= "ToggleRotateKey=Enter\n";
+				$config_text .= "PrevScreenKey=Left\n";
+				$config_text .= "NextScreenKey=Right\n";
+				$config_text .= "ScrollUpKey=Up\n";
+				$config_text .= "ScrollDownKey=Down\n";
+				/* Generic Menu settings */
+				$config_text .= "[menu]\n";
+				$config_text .= "MenuKey=Escape\n";
+				$config_text .= "EnterKey=Enter\n";
+				$config_text .= "UpKey=Up\n";
+				$config_text .= "DownKey=Down\n";
+			}
 			/* lcdproc default driver definitions */
 			switch($lcdproc_config[driver]) {
 				case "bayrad":
@@ -338,20 +358,6 @@
 					$config_text .= "DelayBus=true\n";
 					$config_text .= "Size={$lcdproc_config['size']}\n";
 					break;
-				case "hd44780 fast":
-					$config_text .= "[{$lcdproc_config['driver']}]\n";
-					$config_text .= "ConnectionType=lcd2usb\n";
-					$config_text .= "Charmap=hd44780_default\n";					
-					$config_text .= "Keypad=yes\n";
-					$config_text .= set_lcd_value("contrast", 1000, 850);
-					$config_text .= set_lcd_value("brightness", 1000, 800);
-					$config_text .= set_lcd_value("offbrightness", 1000, 0);
-					$config_text .= "Backlight=yes\n";
-					$config_text .= "OutputPort=no\n";
-					$config_text .= "DelayMult=1\n";
-					$config_text .= "DelayBus=no\n";
-					$config_text .= "Size={$lcdproc_config['size']}\n";
-					break;					
 				case "icp_a106":
 					$config_text .= "[{$lcdproc_config['driver']}]\n";
 					$config_text .= "Device={$realport}\n";

--- a/config/lcdproc-dev/lcdproc.xml
+++ b/config/lcdproc-dev/lcdproc.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
-	<title>Services: LCDproc 0.5.4 pkg v. 0.6</title>
+	<title>Services: LCDproc 0.5.4 pkg v. 0.7</title>
 	<name>lcdproc</name>
-	<version>0.5.4 pkg v. 0.6</version>
+	<version>0.5.4 pkg v. 0.7</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>
@@ -203,10 +203,6 @@
 					<value>hd44780</value>
 					<name>hd44780</name>
 				</option>
-				<option>
-					<value>hd44780 fast</value>
-					<name>hd44780 fast</name>
-				</option>				
 				<option>
 					<value>icp_a106</value>
 					<name>icp_a106</name>
@@ -546,6 +542,39 @@
 				</option>
 			</options>			
 			<default_value>-1</default_value>
+		</field>	
+		<field>
+			<fieldname>backlight</fieldname>
+			<fielddescr>Backlight</fielddescr>
+			<description>Set the backlight setting. If set to the default value, then the backlight setting of the display can be influenced by the clients. This option is not supported by all the LCD panels, leave "default" if unsure.</description>
+			<type>select</type>
+			<options>
+				<option>
+					<value>default</value>
+					<name>Default</name>
+				</option>
+				<option>
+					<value>on</value>
+					<name>On</name>
+				</option>
+				<option>
+					<value>off</value>
+					<name>Off</name>
+				</option>
+			</options>
+			<default_value>default</default_value>
+		</field>
+		<field>
+			<fieldname>outputleds</fieldname>
+			<fielddescr>Enable Output LEDs</fielddescr>
+			<description>Enable the Output LEDs present on some LCD panels. This feature is currently supported by the CFontz633 driver only. &lt;br&gt;
+				Each LED can be off or show two colors: RED (alarm) or GREEN (everything ok) and shows: &lt;br&gt;
+				LED1: NICs status (green: ok, red: at least one nic down);&lt;br&gt;
+				LED2: CARP status (green: master, red: backup, off: CARP not implemented);&lt;br&gt;
+				LED3: CPU status (green &lt; 50, red &gt; 50%);&lt;br&gt;
+				LED4: Gateway status (green: ok, red: at least one gateway not responding, off: no gateway configured).</description>
+			<type>checkbox</type>
+			<default_value>default</default_value>
 		</field>		
 	</fields>
 	<custom_php_command_before_form>

--- a/config/lcdproc-dev/lcdproc_screens.xml
+++ b/config/lcdproc-dev/lcdproc_screens.xml
@@ -2,7 +2,7 @@
 <packagegui>
 	<title>Services: LCDproc: Screens</title>
 	<name>lcdproc_screens</name>
-	<version>0.5.4 pkg v. 0.6</version>
+	<version>0.5.4 pkg v. 0.7</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -579,7 +579,7 @@
 		<descr>pfSense version of TinyDNS which features failover host support</descr>
 		<website>http://cr.yp.to/djbdns.html</website>
 		<category>Services</category>
-		<version>1.0.6.16</version>
+		<version>1.0.6.17</version>
 		<status>Beta</status>
 		<pkginfolink>http://doc.pfsense.org/index.php/Tinydns_package</pkginfolink>
 		<required_version>2.0</required_version>
@@ -805,7 +805,7 @@
 				Do not use together with freeradius package. Both are using the same XML files.]]></descr>
 		<pkginfolink>http://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
 		<category>System</category>
-		<version>2.1.12 pkg v1.4.4</version>
+		<version>2.1.12 pkg v1.4.6</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>
@@ -936,7 +936,7 @@
 	<package>
 		<name>squid-reverse</name>
 		<descr><![CDATA[High performance web proxy cache.<br>
-					   It combines squid as a proxy server with it's capabilities of actinge as a.<br>
+					   It combines squid as a proxy server with it's capabilities of acting as a<br>
 					   HTTP / HTTPS reverse proxy.<br>
 					   It includes an Exchange-Web-Access (OWA) Assistant.<br>
 					   squid-reverse replaces the squid-package (squid config is maintained).]]></descr>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -96,7 +96,7 @@
 	<package>
 		<name>squid-reverse</name>
 		<descr><![CDATA[High performance web proxy cache.<br>
-					   It combines squid as a proxy server with it's capabilities of actinge as a.<br>
+					   It combines squid as a proxy server with it's capabilities of acting as a<br>
 					   HTTP / HTTPS reverse proxy.<br>
 					   It includes an Exchange-Web-Access (OWA) Assistant.<br>
 					   squid-reverse replaces the squid-package (squid config is maintained).]]></descr>
@@ -634,7 +634,7 @@
 		<descr>pfSense version of TinyDNS which features failover host support</descr>
 		<website>http://cr.yp.to/djbdns.html</website>
 		<category>Services</category>
-		<version>1.0.6.16</version>
+		<version>1.0.6.17</version>
 		<status>Beta</status>
 		<pkginfolink>http://doc.pfsense.org/index.php/Tinydns_package</pkginfolink>
 		<required_version>2.0</required_version>
@@ -852,7 +852,7 @@
 				Do not use together with freeradius package. Both are using the same XML files.]]></descr>
 		<pkginfolink>http://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
 		<category>System</category>
-		<version>2.1.12 pkg v1.4.4</version>
+		<version>2.1.12 pkg v1.4.6</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>


### PR DESCRIPTION
- Removed driver "HD44780 fast" since the problem why this fork was created for has been solved in a different way
- Set the custom Keys and Menu section for the "sdelcd" driver
- Added the Blacklight setting. Now it is possible to optionally turn the blacklight on, off or (default) to leave it managed by the panel
- Added the "output led" support for the "CFontz633" driver. This is totally to test since my panel doesn't have any output led, worked almost blind.
