### PR TITLE
Update LCDProc to version 0.5.5 and an easy change

### DIFF
--- a/config/lcdproc-dev/lcdproc.xml
+++ b/config/lcdproc-dev/lcdproc.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
-	<title>Services: LCDproc 0.5.4 pkg v. 0.7</title>
+	<title>Services: LCDproc 0.5.5 pkg v. 0.8</title>
 	<name>lcdproc</name>
-	<version>0.5.4 pkg v. 0.7</version>
+	<version>0.5.5 pkg v. 0.8</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>
@@ -257,7 +257,7 @@
 				</option>				
 				<option>
 					<value>sdeclcd</value>
-					<name>sdeclcd (x86 only)</name>
+					<name>Watchguard Firebox with SDEC (x86 only)</name>
 				</option>				
 				<option>
 					<value>sed1330</value>

--- a/config/lcdproc-dev/lcdproc_screens.xml
+++ b/config/lcdproc-dev/lcdproc_screens.xml
@@ -2,7 +2,7 @@
 <packagegui>
 	<title>Services: LCDproc: Screens</title>
 	<name>lcdproc_screens</name>
-	<version>0.5.4 pkg v. 0.7</version>
+	<version>0.5.5 pkg v. 0.8</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1016,14 +1016,13 @@
 		<descr>LCD display driver - Development version</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.4 pkg v. 0.6</version>
+		<version>lcdproc-0.5.5 pkg v. 0.8</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>michele@nt2.it</maintainer>
 		<pkginfolink>http://forum.pfsense.org/index.php/topic,44034.0.html</pkginfolink>		
 		<depends_on_package_base_url>http://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
-		<depends_on_package>lcdproc-0.5.4.tbz</depends_on_package>
-		<depends_on_package_pbi>lcdproc-0.5.4-i386.pbi</depends_on_package_pbi>
+		<depends_on_package>lcdproc-0.5.5.tbz</depends_on_package>
 		<config_file>http://www.pfsense.org/packages/config/lcdproc-dev/lcdproc.xml</config_file>
 		<configurationfile>lcdproc.xml</configurationfile>
 		<build_port_path>/usr/ports/sysutils/lcdproc</build_port_path>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -989,14 +989,13 @@
 		<descr>LCD display driver - Development version</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.4 pkg v. 0.6</version>
+		<version>lcdproc-0.5.5 pkg v. 0.8</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>michele@nt2.it</maintainer>
 		<pkginfolink>http://forum.pfsense.org/index.php/topic,44034.0.html</pkginfolink>		
 		<depends_on_package_base_url>http://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
-		<depends_on_package>lcdproc-0.5.4.tbz</depends_on_package>
-		<depends_on_package_pbi>lcdproc-0.5.4-amd64.pbi</depends_on_package_pbi>
+		<depends_on_package>lcdproc-0.5.5.tbz</depends_on_package>
 		<config_file>http://www.pfsense.org/packages/config/lcdproc-dev/lcdproc.xml</config_file>
 		<configurationfile>lcdproc.xml</configurationfile>
 		<build_port_path>/usr/ports/sysutils/lcdproc</build_port_path>


### PR DESCRIPTION
Updates LCDProc to 0.5.5 (very experimental)
Rename the sdelcd driver to "Watchguard Firebox w/ SDEC LCD"

Thanks,
Michele
