### PR TITLE
Some changes / requests from the forum

### DIFF
--- a/config/lcdproc-dev/lcdproc.inc
+++ b/config/lcdproc-dev/lcdproc.inc
@@ -2,7 +2,7 @@
 /* $Id$ */
 /*
         lcdproc.inc
-        Copyright (C) 2007 Seth Mos <seth.mos@dds.nl>
+        Copyright (C) 2007 Seth Mos <seth.mos@xs4all.nl>
         All rights reserved.
 
         Redistribution and use in source and binary forms, with or without
@@ -237,6 +237,7 @@
 			$config_text .= "User=nobody\n";
 			$config_text .= "ServerScreen=no\n";
 			$config_text .= "Foreground=no\n";
+			$config_text .= "TitleSpeed=10\n";
 			$config_text .= "DriverPath=/usr/local/lib/lcdproc/\n";
 			$config_text .= "GoodBye=\"Thanks for using\"\n";
 			$config_text .= "GoodBye=\"    {$g['product_name']}     \"\n";
@@ -501,23 +502,24 @@
 			/* generate rc file start and stop */
 			$client_script = <<<EOD
 #!/bin/sh
-# script starts a lcd client and always keeps it active.
+# script starts a lcd client and always keeps it active for 3 attemps
 counter=1
-while [ "\$counter" -ne 0 ]
+while [ \$counter -le 3 ]
 do
 	# loop the client to drive the display
-	/usr/local/bin/php -f /usr/local/pkg/lcdproc_client.php
+	/usr/local/bin/php -f /usr/local/pkg/lcdproc_client.php	
+	counter=\$(( \$counter + 1 ))
 	sleep 1
 done
 EOD;
 			/* generate rc file start and stop */
 			$stop = <<<EOD
 if [ `ps auxw |awk '/lcdclient.s[h]/ {print $2}'| wc -l` != 0  ]; then
-	ps auxw |awk '/lcdclient.s[h]/ {print $2}'|xargs kill
+	ps auxw |awk '/lcdclient.s[h]/ {print $2}'|xargs kill -9
 	sleep 1
 fi
 if [ `ps auxw |awk '/LCD[d]/ {print $2}'| wc -l` != 0  ]; then
-	ps auxw |awk '/LCD[d]/ {print $2}'|xargs kill
+	ps auxw |awk '/LCD[d]/ {print $2}'|xargs kill -9
 	sleep 1
 fi
 EOD;

--- a/config/lcdproc-dev/lcdproc.xml
+++ b/config/lcdproc-dev/lcdproc.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
-	<title>Services: LCDproc 0.5.5 pkg v. 0.8</title>
+	<title>Services: LCDproc 0.5.5 pkg v. 0.9</title>
 	<name>lcdproc</name>
-	<version>0.5.5 pkg v. 0.8</version>
+	<version>0.5.5 pkg v. 0.9</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>
@@ -55,7 +55,7 @@
 	</service>
 	<fields>
 		<field>
-			<fielddescr>Enable LCDproc</fielddescr>
+			<fielddescr>Enable LCDproc at startup</fielddescr>
 			<fieldname>enable</fieldname>
 			<type>checkbox</type>
 		</field>

--- a/config/lcdproc-dev/lcdproc_client.php
+++ b/config/lcdproc-dev/lcdproc_client.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /*
         lcdproc_client.php
-        Copyright (C) 2007 Seth Mos <seth.mos@dds.nl>
+        Copyright (C) 2007 Seth Mos <seth.mos@xs4all.nl>
         All rights reserved.
 
         Redistribution and use in source and binary forms, with or without
@@ -97,13 +97,14 @@
 
 	function get_uptime_stats() {
 		exec("/usr/bin/uptime", $output, $ret);
+		$temp = explode(",", $output[0]);
 		if(stristr($output[0], "day")) {
-			$temp = explode(" ", $output[0]);
-			$status = "$temp[2] $temp[3] $temp[4] $temp[5] $temp[6] $temp[7] ". substr($temp[8], 0, -1);
+			$status = "$temp[0] $temp[1]";
 		} else {
-			$temp = explode(" ", $output[0]);
-			$status = "$temp[2] $temp[3] $temp[4] $temp[5] $temp[6] ". substr($temp[7], 0, -1);
+			$status = "$temp[0] ";
 		}
+		$status = trim(str_replace("  ", " ", $status));
+		$status = substr($status, strpos($status, "up ") + 3);		
 		return($status);
 	}
 

--- a/config/lcdproc-dev/lcdproc_screens.xml
+++ b/config/lcdproc-dev/lcdproc_screens.xml
@@ -2,7 +2,7 @@
 <packagegui>
 	<title>Services: LCDproc: Screens</title>
 	<name>lcdproc_screens</name>
-	<version>0.5.5 pkg v. 0.8</version>
+	<version>0.5.5 pkg v. 0.9</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1015,7 +1015,7 @@
 		<descr>LCD display driver - Development version</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.5 pkg v. 0.8</version>
+		<version>lcdproc-0.5.5 pkg v. 0.9</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>michele@nt2.it</maintainer>
@@ -1026,6 +1026,7 @@
 		<configurationfile>lcdproc.xml</configurationfile>
 		<build_port_path>/usr/ports/sysutils/lcdproc</build_port_path>
 		<build_options>WITH_USB=true</build_options>
+		<after_install_info>Please set the service options in Services-LCDproc before running the service.</after_install_info>
 	</package>		
 	<package>
 		<name>arpwatch</name>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -988,7 +988,7 @@
 		<descr>LCD display driver - Development version</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.5 pkg v. 0.8</version>
+		<version>lcdproc-0.5.5 pkg v. 0.9</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>michele@nt2.it</maintainer>
@@ -999,6 +999,7 @@
 		<configurationfile>lcdproc.xml</configurationfile>
 		<build_port_path>/usr/ports/sysutils/lcdproc</build_port_path>
 		<build_options>WITH_USB=true</build_options>
+		<after_install_info>Please set the service options in Services-LCDproc before running the service.</after_install_info>
 	</package>		
 	<package>
 		<name>arpwatch</name>


### PR DESCRIPTION
- Fix the uptime screen
- In the settings, "Enable LCDproc" becomes "Enable LCDproc at startup"
- Added "After Install Info" message
- Limited the client loop to three times. After three errors connecting to the LCDd service the client will end

Thanks,
Michele
