### PR TITLE
updates to dns-server package. (fixes dnscache)

### DIFF
--- a/config/tinydns/tinydns.inc
+++ b/config/tinydns/tinydns.inc
@@ -169,10 +169,11 @@ function tinydns_custom_php_deinstall_command() {
 
 	conf_mount_rw();
 	/* destroy all daemontools items */
+	exec("/usr/local/bin/svc -xk {$g['varetc_path']}/tinydns*");
+	exec("/usr/local/bin/svc -xk {$g['varetc_path']}/dnscache*");
 	exec("/usr/local/etc/rc.d/tinydns.sh stop");
 	exec("/usr/local/etc/rc.d/svscan.sh stop");
 	exec("/usr/bin/killall supervise");
-	exec("/usr/bin/killall tinydns");	
 	exec("/usr/sbin/pw groupdel Gtinydns");
 	exec("/usr/sbin/pw groupdel Gdnscache");
 	exec("/usr/sbin/pw groupdel Gdnslog");
@@ -231,7 +232,8 @@ function tinydns_custom_php_changeip_command() {
 	}
 
 	exec("echo {$dnsserverip} > {$g['varetc_path']}/tinydns/env/IP");
-	exec("/usr/bin/killall -9 tinydns");
+	exec("/usr/local/bin/svc -xk {$g['varrun_path']}/service/tinydns");
+		
 
 	if(!empty($config['installedpackages']['tinydns']['config'][0]['enableforwarding'])) {
 		$interfaces = explode(",", $config['installedpackages']['tinydns']['config'][0]['interface']);
@@ -257,25 +259,47 @@ function tinydns_custom_php_changeip_command() {
 			$dnsuserip = $arr[0];
 			//exec("/bin/mkdir -p {$g['varetc_path']}/dnscache{$dnsidx}");
 			exec("/usr/local/bin/dnscache-conf Gdnscache Gdnslog {$g['varetc_path']}/dnscache{$dnsidx} {$dnscacheip}");
-			exec("/bin/ln -s {$g['varetc_path']}/dnscache{$dnsidx} {$g['varrun_path']}/service/");
+
 			if (!is_dir("{$g['varetc_path']}/dnscache{$dnsidx}/env"))
 				exec("/bin/mkdir -p {$g['varetc_path']}/dnscache{$dnsidx}/env");
 			exec("echo {$dnscacheip} > {$g['varetc_path']}/dnscache{$dnsidx}/env/IP");
 			tinydns_dnscache_forwarding_servers($dnsidx);
 			if (!is_dir("{$g['varetc_path']}/dnscache{$dnsidx}/root/ip"))
 				exec("/bin/mkdir -p {$g['varetc_path']}/dnscache{$dnsidx}/root/ip");
-			exec("/usr/bin/touch {$g['varetc_path']}/dnscache{$dnsidx}/root/ip/{$dnsuserip}");
+
+			/* tell dnscache to answer queries */
+			if ( $config['installedpackages']['tinydns']['config'][0]['dnscache_listen'] != "" ) {
+				$dnscache_listen_ips = explode (" ", $config['installedpackages']['tinydns']['config'][0]['dnscache_listen']);
+
+				foreach ($dnscache_listen_ips as $dnscache_listen_ip) {
+					exec("/usr/bin/touch {$g['varetc_path']}/dnscache{$dnsidx}/root/ip/{$dnscache_listen_ip}");
+				}
+
+			} else {
+				exec("/usr/bin/touch {$g['varetc_path']}/dnscache{$dnsidx}/root/ip/{$dnscacheip}");
+			}
+
 			tinydns_create_soa_domain_list($dnsserverip, $dnsidx);
+
+			/* setup symlink to start dnscache */
+			exec("/bin/ln -s {$g['varetc_path']}/dnscache{$dnsidx} {$g['varrun_path']}/service/");
+			
+			exec("/usr/local/bin/svc -xk {$g['varetc_path']}/dnscache{$dnsidx}");
 		}
-		exec("/usr/bin/killall -9 dnscache");
 	} else {
 		$interfaces = explode(",", $$config['installedpackages']['tinydns']['config'][0]['interface']);
 		foreach ($interfaces as $dnsidx => $dnsif) {
 			if(is_dir("{$g['varetc_path']}/dnscache{$dnsidx}"))
 				dnscache_use_root_servers($dnsidx);
 		}
-		exec("/usr/bin/killall -9 dnscache");
+		exec("/usr/local/bin/svc -xk {$g['varetc_path']}/dnscache*");
 	}
+
+	/* a wee bit of magic - something seems to start up a broken dnscache, the below kills it, and svc restarts it correctly. */ 
+	exec ("ps aux | grep multilog |  awk '{print $2}' | xargs -n1 kill -9");
+	exec ("ps aux | grep dnscache |  awk '{print $2}' | xargs -n1 kill -9");
+	exec ("ps aux | grep tinydns |  awk '{print $2}' | xargs -n1 kill -9");
+
 	conf_mount_ro();
 	filter_configure();
 }

--- a/config/tinydns/tinydns.xml
+++ b/config/tinydns/tinydns.xml
@@ -184,6 +184,12 @@
 			<required>on</required>
 		</field>
 		<field>
+			<fielddescr>Respond to IP</fielddescr>
+			<fieldname>dnscache_listen</fieldname>
+			<description>IP Addresses allowed to query against dnscache. Leave blank to set as the IP address of the interface where dnscache is running. To answer quieries from 192.168.1.0/24 enter 192.168.1, to answer queries from 10.0.0.0/8 enter 10, Separate entries with a space, do not enter a trailing period.</description>
+			<type>input</type>
+		</field>
+		<field>
 		 	<fielddescr>Register DHCP static mappings with server</fielddescr>
 			<fieldname>regdhcpstatic</fieldname>
 			<description>Register static DHCP leases with TinyDNS server using the Fully Qualified Domain Name specified in System: General.</description>


### PR DESCRIPTION
removes the gratioutous use of killall and kill -9 in place of using the native svc tool for stopping & restarting tinydns/dnscache
includes an ugly hack to get dnscache to start correctly (something is starting it manually by the looks of it, but i cannot figure out what)
adds the option to allow dnscache to answer queries from more than just the interface on which it is running.
