### PR TITLE
Changes to improve stability

### DIFF
--- a/config/lcdproc-dev/lcdproc.inc
+++ b/config/lcdproc-dev/lcdproc.inc
@@ -237,7 +237,7 @@
 			$config_text .= "User=nobody\n";
 			$config_text .= "ServerScreen=no\n";
 			$config_text .= "Foreground=no\n";
-			$config_text .= "TitleSpeed=10\n";
+			$config_text .= "TitleSpeed=5\n";
 			$config_text .= "DriverPath=/usr/local/lib/lcdproc/\n";
 			$config_text .= "GoodBye=\"Thanks for using\"\n";
 			$config_text .= "GoodBye=\"    {$g['product_name']}     \"\n";
@@ -502,14 +502,8 @@
 			/* generate rc file start and stop */
 			$client_script = <<<EOD
 #!/bin/sh
-# script starts a lcd client and always keeps it active for 3 attemps
-counter=1
-while [ \$counter -le 3 ]
-do
-	# loop the client to drive the display
-	/usr/local/bin/php -f /usr/local/pkg/lcdproc_client.php	
-	counter=\$(( \$counter + 1 ))
-	sleep 1
+/usr/local/bin/php -f /usr/local/pkg/lcdproc_client.php	
+sleep 1
 done
 EOD;
 			/* generate rc file start and stop */

--- a/config/lcdproc-dev/lcdproc.xml
+++ b/config/lcdproc-dev/lcdproc.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
-	<title>Services: LCDproc 0.5.5 pkg v. 0.9</title>
+	<title>Services: LCDproc 0.5.5 pkg v. 0.9.1</title>
 	<name>lcdproc</name>
-	<version>0.5.5 pkg v. 0.9</version>
+	<version>0.5.5 pkg v. 0.9.1</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>

--- a/config/lcdproc-dev/lcdproc_screens.xml
+++ b/config/lcdproc-dev/lcdproc_screens.xml
@@ -2,7 +2,7 @@
 <packagegui>
 	<title>Services: LCDproc: Screens</title>
 	<name>lcdproc_screens</name>
-	<version>0.5.5 pkg v. 0.9</version>
+	<version>0.5.5 pkg v. 0.9.1</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1023,7 +1023,7 @@
 		<descr>LCD display driver - Development version</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.5 pkg v. 0.9</version>
+		<version>lcdproc-0.5.5 pkg v. 0.9.1</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>michele@nt2.it</maintainer>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -989,7 +989,7 @@
 		<descr>LCD display driver - Development version</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.5 pkg v. 0.9</version>
+		<version>lcdproc-0.5.5 pkg v. 0.9.1</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>michele@nt2.it</maintainer>


### PR DESCRIPTION
- Added a 20ms delay between each command sent from the client to LCDproc.
- Better managed errors. Now the client resets the error counter every successful communication session with LCDproc (before was a global counter). The error counter is managed inside the client (lcdproc_client.php).
- Because of the above change, now the "client script" (lcdclient.sh) do not cycle anymore.

Thanks,
Michele
