### PR TITLE
Many improvements for stability and optimization.

### DIFF
--- a/config/lcdproc-dev/lcdproc.inc
+++ b/config/lcdproc-dev/lcdproc.inc
@@ -2,7 +2,8 @@
 /* $Id$ */
 /*
         lcdproc.inc
-        Copyright (C) 2007 Seth Mos <seth.mos@xs4all.nl>
+        Copyright (C) 2007 Seth Mos <seth.mos@xs4all.nl>, 
+		Copyright (C) 2012 Michele Di Maria <michele@nt2.it>
         All rights reserved.
 
         Redistribution and use in source and binary forms, with or without
@@ -31,7 +32,6 @@
 	require_once("service-utils.inc");
 	/* LCDproc */
 	define('LCDPROC_RCFILE', '/usr/local/etc/rc.d/lcdproc.sh');
-	define('LCDPROC_CLIENT', '/tmp/lcdclient.sh');
 	define('LCDPROC_CONFIG','/usr/local/etc/LCDd.conf');
 	define('LCDPROC_HOST','localhost');
 	define('LCDPROC_PORT','13666');
@@ -228,24 +228,26 @@
 					return;
 			}
 			$config_text = "[server]\n";
+			$config_text .= "DriverPath=/usr/local/lib/lcdproc/\n";			
 			$config_text .= "Driver={$lcdproc_config[driver]}\n";
 			$config_text .= "Bind=127.0.0.1\n";
 			$config_text .= "Port=13666\n";
 			$config_text .= "ReportLevel=3\n";
 			$config_text .= "ReportToSyslog=yes\n";
-			$config_text .= "WaitTime={$lcdproc_config[refresh_frequency]}\n";
 			$config_text .= "User=nobody\n";
+			$config_text .= "Foreground=no\n";			
+			$config_text .= "Hello=\"LCDproc is\"\n";
+			$config_text .= "Hello=\"  starting...\"\n";			
 			$config_text .= "ServerScreen=no\n";
-			$config_text .= "Foreground=no\n";
-			$config_text .= "TitleSpeed=5\n";
-			$config_text .= "DriverPath=/usr/local/lib/lcdproc/\n";
 			$config_text .= "GoodBye=\"Thanks for using\"\n";
 			$config_text .= "GoodBye=\"    {$g['product_name']}     \"\n";
+			$config_text .= "WaitTime={$lcdproc_config[refresh_frequency]}\n";
 			if ($lcdproc_config[backlight] != "" && $lcdproc_config[backlight] != "default")
 			{
 				/* Backlight setting */
 				$config_text .= "Backlight={$lcdproc_config[backlight]}\n";				
 			}
+			$config_text .= "Heartbeat=off\n";
 			if ($lcdproc_config[driver] == "sdeclcd")
 			{
 				/* Sdeclcd Keys settings */
@@ -500,33 +502,22 @@
 				$config_text .= "Speed={$port_speed}\n";
 			}			
 			/* generate rc file start and stop */
-			$client_script = <<<EOD
-#!/bin/sh
-/usr/local/bin/php -f /usr/local/pkg/lcdproc_client.php	
-sleep 1
+			$stop = <<<EOD
+if [ `ps auxw |awk '/lcdproc_client.ph[p]/ {print $2}'| wc -l` != 0  ]; then
+	ps auxw |awk '/lcdproc_client.ph[p]/ {print $2}'|xargs kill -9 
+	sleep 2
+fi
+while [ `ps auxw |awk '/LCD[d]/ {print $2}'| wc -l` != 0  ]; 
+do
+	ps auxw |awk '/LCD[d]/ {print $2}'|xargs kill -9 
+	sleep 1
 done
 EOD;
-			/* generate rc file start and stop */
-			$stop = <<<EOD
-if [ `ps auxw |awk '/lcdclient.s[h]/ {print $2}'| wc -l` != 0  ]; then
-	ps auxw |awk '/lcdclient.s[h]/ {print $2}'|xargs kill -9
-	sleep 1
-fi
-if [ `ps auxw |awk '/lcdproc_client.ph[p]/ {print $2}'| wc -l` != 0  ]; then
-	ps auxw |awk '/lcdproc_client.ph[p]/ {print $2}'|xargs kill -9
-	sleep 1
-fi
-if [ `ps auxw |awk '/LCD[d]/ {print $2}'| wc -l` != 0  ]; then
-	ps auxw |awk '/LCD[d]/ {print $2}'|xargs kill -9
-	sleep 1
-fi
-EOD;
 			$start = $stop ."\n";
-			$start .= "\t/usr/local/sbin/LCDd -c ". LCDPROC_CONFIG ."\n";
-			$start .= "\t". LCDPROC_CLIENT ." &\n";
+			$start .= "\t/usr/bin/nice -20 /usr/local/sbin/LCDd -c ". LCDPROC_CONFIG ."\n";
+			$start .= "\t/usr/bin/nice -20 /usr/local/bin/php -f /usr/local/pkg/lcdproc_client.php\n";
 			/* write out the configuration */
 			conf_mount_rw();
-			lcdproc_write_script(LCDPROC_CLIENT, $client_script);
 			lcdproc_write_config(LCDPROC_CONFIG, $config_text);
 			write_rcfile(array(
 					'file' => 'lcdproc.sh',
@@ -552,7 +543,6 @@ EOD;
 				stop_service(LCDPROC_SERVICE_NAME);
 				conf_mount_rw();
 				unlink(LCDPROC_RCFILE);
-				unlink(LCDPROC_CLIENT);
 				unlink(LCDPROC_CONFIG);
 				conf_mount_ro();
 			}

--- a/config/lcdproc-dev/lcdproc.xml
+++ b/config/lcdproc-dev/lcdproc.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
-	<title>Services: LCDproc 0.5.5 pkg v. 0.9.2</title>
+	<title>Services: LCDproc 0.5.5 pkg v. 0.9.3</title>
 	<name>lcdproc</name>
-	<version>0.5.5 pkg v. 0.9.2</version>
+	<version>0.5.5 pkg v. 0.9.3</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>

--- a/config/lcdproc-dev/lcdproc_screens.xml
+++ b/config/lcdproc-dev/lcdproc_screens.xml
@@ -2,7 +2,7 @@
 <packagegui>
 	<title>Services: LCDproc: Screens</title>
 	<name>lcdproc_screens</name>
-	<version>0.5.5 pkg v. 0.9.2</version>
+	<version>0.5.5 pkg v. 0.9.3</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1023,7 +1023,7 @@
 		<descr>LCD display driver - Development version</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.5 pkg v. 0.9.2</version>
+		<version>lcdproc-0.5.5 pkg v. 0.9.3</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>michele@nt2.it</maintainer>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -989,7 +989,7 @@
 		<descr>LCD display driver - Development version</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.5 pkg v. 0.9.2</version>
+		<version>lcdproc-0.5.5 pkg v. 0.9.3</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>michele@nt2.it</maintainer>


### PR DESCRIPTION
- Improved the reception of data from LCDd. Now there's a cycle that run until there's no more data do receive. Before that there was the possibility of a buffer overflow in LCDd. The timeout of the receiving socket is 25ms.
- Optimized the number of commands sent to LCDd every cycle. Now it is sent only the half;
- Rewritten with better code the error handling;
- Increased to 3 the number of attempts the client performs to reconnect to LCDd in case of disconnection;
- Simplified the startup scripts. Now lcdproc_client.sh is not generated/run anymore, since the error handling is managed by the client;
- Changed the startup scripts to run both LCDd then the client as "nice" process;
- Capped the wait time between each client cycle to 5 seconds. It still is calculated as the refresh frequency \* the number of screen activated, but now it's capped;
- Increased to 8000 chars the trunk of data received from LCDd;
- Improved the "service stop" script. Now it cycle until LCDd is definitely killed and works even if LCDd is hung;
- Added a "welcome" string on the panel at the LCDd startup;
