### PR TITLE
LCDProc: Again on the service start/stop/restart

### DIFF
--- a/config/lcdproc-dev/lcdproc.inc
+++ b/config/lcdproc-dev/lcdproc.inc
@@ -503,17 +503,15 @@
 while [ `ps auxw |awk '/lcdproc_client.ph[p]/ {print $2}'| wc -l` != 0  ];
 do
 	ps auxw |awk '/lcdproc_client.ph[p]/ {print $2}'|xargs kill
-	sleep 2
 done
 while [ `ps auxw |awk '/LCD[d]/ {print $2}'| wc -l` != 0  ]; 
 do
 	ps auxw |awk '/LCD[d]/ {print $2}'|xargs kill
-	sleep 2
 done
 EOD;
 			$start = $stop ."\n";
 			$start .= "\t/usr/bin/nice -20 /usr/local/sbin/LCDd -c ". LCDPROC_CONFIG ."\n";
-			$start .= "\t/usr/bin/nice -20 /usr/local/bin/php -f /usr/local/pkg/lcdproc_client.php\n";
+			$start .= "\t/usr/bin/nice -20 /usr/local/bin/php -f /usr/local/pkg/lcdproc_client.php &\n";
 			/* write out the configuration */
 			conf_mount_rw();
 			lcdproc_write_config(LCDPROC_CONFIG, $config_text);

--- a/config/lcdproc-dev/lcdproc.xml
+++ b/config/lcdproc-dev/lcdproc.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
-	<title>Services: LCDproc 0.5.5 pkg v. 0.9.3</title>
+	<title>Services: LCDproc 0.5.5 pkg v. 0.9.4</title>
 	<name>lcdproc</name>
-	<version>0.5.5 pkg v. 0.9.3</version>
+	<version>0.5.5 pkg v. 0.9.4</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>

--- a/config/lcdproc-dev/lcdproc_client.php
+++ b/config/lcdproc-dev/lcdproc_client.php
@@ -42,15 +42,15 @@
 		if (isset($config['system']['maximumstates']) and $config['system']['maximumstates'] > 0)
 			$maxstates="/{$config['system']['maximumstates']}";
 		else
-			$maxstates="/10000";
-
+			$maxstates="/". pfsense_default_state_size();
+			
 		$curentries = `/sbin/pfctl -si |grep current`;
 		if (preg_match("/([0-9]+)/", $curentries, $matches)) {
 			$curentries = $matches[1];
 		}
 		return $curentries . $maxstates;
 	}
-
+		
 	function disk_usage() {
 		$dfout = "";
 		exec("/bin/df -h | /usr/bin/grep -w '/' | /usr/bin/awk '{ print $5 }' | /usr/bin/cut -d '%' -f 1", $dfout);

--- a/config/lcdproc-dev/lcdproc_screens.xml
+++ b/config/lcdproc-dev/lcdproc_screens.xml
@@ -2,7 +2,7 @@
 <packagegui>
 	<title>Services: LCDproc: Screens</title>
 	<name>lcdproc_screens</name>
-	<version>0.5.5 pkg v. 0.9.3</version>
+	<version>0.5.5 pkg v. 0.9.4</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1023,7 +1023,7 @@
 		<descr>LCD display driver - Development version</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.5 pkg v. 0.9.3</version>
+		<version>lcdproc-0.5.5 pkg v. 0.9.4</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>michele@nt2.it</maintainer>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -989,7 +989,7 @@
 		<descr>LCD display driver - Development version</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.5 pkg v. 0.9.3</version>
+		<version>lcdproc-0.5.5 pkg v. 0.9.4</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<maintainer>michele@nt2.it</maintainer>


### PR DESCRIPTION
- The Client now runs in background (added a trailing & at the end of the command that runs the client);
- Removed the delays in the script during the service stop;
- Fixed the "default max states" information when it is not defined explicitally in the advanced configuration.

Thanks,
Michele
