### PR TITLE
Bug #2285: Do not run code in swapstate_check.php when there is no Squid cache

### DIFF
--- a/config/pf-blocker/pfblocker.inc
+++ b/config/pf-blocker/pfblocker.inc
@@ -368,26 +368,25 @@ function sync_package_pfblocker() {
 			}
 		}
 		#update pfsense alias table
-		if (is_array($config['aliases']['alias'])){
+		if (is_array($config['aliases']['alias']))
 			$aliases=$config['aliases']['alias'];
-			foreach($aliases as $cbalias){
-				if (preg_match("/pfBlocker/",$cbalias['name'])){
-					#mark pfctl aliastable for cleaning
-					if (!in_array($cbalias['name'], $aliases_list)) 
-							$aliases_list[]=$cbalias['name']; #mark aliastable for cleaning
-					#remove previous aliastable file if alias is not defined any more
-					if (!in_array($cbalias['name'], $new_aliases_list))
-						unlink_if_exists("/var/db/aliastables/".$cbalias['name'].".txt");
+		foreach($aliases as $cbalias){
+			if (preg_match("/pfBlocker/",$cbalias['name'])){
+				#mark pfctl aliastable for cleaning
+				if (!in_array($cbalias['name'], $aliases_list)) 
+						$aliases_list[]=$cbalias['name']; #mark aliastable for cleaning
+				#remove previous aliastable file if alias is not defined any more
+				if (!in_array($cbalias['name'], $new_aliases_list))
+					unlink_if_exists("/var/db/aliastables/".$cbalias['name'].".txt");
+			}
+			else{
+				$new_aliases[]=	$cbalias;
+				if (file_exists($pfb_alias_dir.'/'.$alias.'.txt') && $message ==""){
+				preg_match("/(\d+)/",exec("/usr/bin/wc -l ".$pfb_alias_dir.'/'.$alias.'.txt'),$matches);
 				}
-				else{
-					$new_aliases[]=	$cbalias;
-					if (file_exists($pfb_alias_dir.'/'.$alias.'.txt') && $message ==""){
-					preg_match("/(\d+)/",exec("/usr/bin/wc -l ".$pfb_alias_dir.'/'.$alias.'.txt'),$matches);
-					}
-					if (($matches[1] * 2.1)>= $table_limit )
-						#alias table too large
-	    				$message= $alias .' alias table is too large. Reduce networks in list or increase "Firewall Maximum Table Entries" value to at least '. (int)($matches[1] * 2.1) .' in "system - advanced - Firewall/NAT".';
-				}
+				if (($matches[1] * 2.1)>= $table_limit )
+					#alias table too large
+    				$message= $alias .' alias table is too large. Reduce networks in list or increase "Firewall Maximum Table Entries" value to at least '. (int)($matches[1] * 2.1) .' in "system - advanced - Firewall/NAT".';
 			}
 		}
 		#apply new alias table to xml


### PR DESCRIPTION
This change handles the case when Squid has no disk cache (e.g. typically on nanobsd/embedded). In this case, swapstate_check.php now just does nothing, exiting quietly.
Previously it logged a message about filesize($swapstate) failing, because the file does not exist when there is no cache.
