### PR TITLE
Only add swapstate_check to cron item list once

### DIFF
--- a/config/squid-reverse/squid.inc
+++ b/config/squid-reverse/squid.inc
@@ -1829,7 +1829,7 @@ function squid_do_xmlrpc_sync($sync_to_ip, $username, $password) {
 		log_error("squid XMLRPC sync successfully completed with {$url}:{$port}.");
 	}
 	
-	/* tell squid to reload our settings on the destionation sync host. */
+	/* tell squid to reload our settings on the destination sync host. */
 	$method = 'pfsense.exec_php';
 	$execcmd  = "require_once('/usr/local/pkg/squid.inc');\n";
 	$execcmd .= "squid_resync();";


### PR DESCRIPTION
When squid3 is installed, swapstate_check is getting added to the cron item list (and thus to /etc/crontab) twice. Removal of squid.inc line 704 fixes this.
The other changes are just lining up tab indenting and fixing some spelling/grammar in text strings and comments.
