### PR TITLE
sed with invalid args called, either -e for expression or -f for file, b...

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -1305,8 +1305,8 @@ EOD;
 		if (file_exists("{$snortcfgdir}/preproc_rules/decoder.rules") &&
 		    file_exists("{$snortcfgdir}/preproc_rules/preprocessor.rules")) {
 			@file_put_contents("{$g['tmp_path']}/sedcmd", $sedcmd);
-			mwexec("/usr/bin/sed -I '' -e -f {$g['tmp_path']}/sedcmd {$snortcfgdir}/preproc_rules/preprocessor.rules");
-			mwexec("/usr/bin/sed -I '' -e -f {$g['tmp_path']}/sedcmd {$snortcfgdir}/preproc_rules/decoder.rules");
+			mwexec("/usr/bin/sed -I.bak -f {$g['tmp_path']}/sedcmd {$snortcfgdir}/preproc_rules/preprocessor.rules");
+			mwexec("/usr/bin/sed -I.bak -f {$g['tmp_path']}/sedcmd {$snortcfgdir}/preproc_rules/decoder.rules");
 			@unlink("{$g['tmp_path']}/sedcmd");
 
 			$snort_misc_include_rules .= "include \$PREPROC_RULE_PATH/decoder.rules\n";


### PR DESCRIPTION
...ut not both. -I.bak to suggest an extensions .bak for the unaltered file.
