### PR TITLE
Replace the complicated sed regexp with a simpler one and correct the se...

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -1297,16 +1297,17 @@ EOD;
 		$snort_misc_include_rules .= "include {$snortcfgdir}/classification.config\n";
 	if (is_dir("{$snortcfgdir}/preproc_rules")) {
 		if ($snortcfg['sensitive_data'] == 'on') {
-			$sedcmd = "s/^# alert\(.*\)classtype:sdf;\(.*\)/alert\1classtype:sdf\2/g";
+			$sedcmd = '/^#alert.*classtype:sdf/s/^#//';
 			if (file_exists("{$snortcfgdir}/preproc_rules/sensitive-data.rules"))
 				$snort_misc_include_rules .= "include \$PREPROC_RULE_PATH/sensitive-data.rules\n";
-		} else
-			$sedcmd = "s/^alert\(.*\)classtype:sdf;\(.*\)/# alert\1classtype:sdf\2/g";
+		} else {
+			$sedcmd = '/^alert.*classtype:sdf/s/^/#/';
+		}
 		if (file_exists("{$snortcfgdir}/preproc_rules/decoder.rules") &&
 		    file_exists("{$snortcfgdir}/preproc_rules/preprocessor.rules")) {
 			@file_put_contents("{$g['tmp_path']}/sedcmd", $sedcmd);
-			mwexec("/usr/bin/sed -I '' -e -f {$g['tmp_path']}/sedcmd {$snortcfgdir}/preproc_rules/preprocessor.rules");
-			mwexec("/usr/bin/sed -I '' -e -f {$g['tmp_path']}/sedcmd {$snortcfgdir}/preproc_rules/decoder.rules");
+			mwexec("/usr/bin/sed -I.bak -f {$g['tmp_path']}/sedcmd {$snortcfgdir}/preproc_rules/preprocessor.rules");
+			mwexec("/usr/bin/sed -I.bak -f {$g['tmp_path']}/sedcmd {$snortcfgdir}/preproc_rules/decoder.rules");
 			@unlink("{$g['tmp_path']}/sedcmd");
 
 			$snort_misc_include_rules .= "include \$PREPROC_RULE_PATH/decoder.rules\n";


### PR DESCRIPTION
...d cmd invocation. The trick is to find the line with an address expression, the rest is pretty generic. To test the approach copy a few lines from a rules file and call from the php-cli:

<?php
// Expression test for php or php-cli
// comment out expression
$sedcmd = '/^alert._classtype:sdf/s/^/#/';
file_put_contents('comment.sed', $sedcmd);
// uncomment expression
$sedcmd = '/^#alert._classtype:sdf/s/^#//';
file_put_contents('uncomment.sed', $sedcmd);
// call sed to comment and uncomment
exec("sed -f comment.sed test.rules > test-co.rules");
exec("sed -f uncomment.sed test-co.rules > test-uc.rules");
// perform a quick check: test.rules should be identical to test-uc.rules
exec("diff -u test.rules test-uc.rules > delta");
$delta = file_get_contents('delta');
unlink('delta');
echo "\n$delta\n";
?>
