### PR TITLE
The unpacking of the archives has been reversed, as it seems that the la...

### DIFF
--- a/config/snort/snort_check_for_rule_updates.php
+++ b/config/snort/snort_check_for_rule_updates.php
@@ -164,6 +164,31 @@ $sedcmd .= "s/^\\talert/alert/g\n";
 $sedcmd .= "s/^[ \\t]*alert/alert/g\n";
 @file_put_contents("{$snortdir}/tmp/sedcmd", $sedcmd);
 
+
+/* Untar emergingthreats rules to tmp */
+if ($emergingthreats == 'on') {
+	if (file_exists("{$tmpfname}/{$emergingthreats_filename}")) {
+		update_status(gettext("Extracting rules..."));
+		exec("/usr/bin/tar xzf {$tmpfname}/{$emergingthreats_filename} -C {$snortdir} rules/");
+	}
+
+	/* make shure default rules are in the right format */
+	exec("/usr/bin/sed -I '' -f {$snortdir}/tmp/sedcmd {$snortdir}/rules/emerging*.rules");
+
+	/*  Copy emergingthreats md5 sig to snort dir */
+	if (file_exists("{$tmpfname}/$emergingthreats_filename_md5")) {
+		update_status(gettext("Copying md5 sig to snort directory..."));
+		@copy("{$tmpfname}/$emergingthreats_filename_md5", "{$snortdir}/$emergingthreats_filename_md5");
+	}
+
+	if ($snortdownload == 'off') {
+		foreach (array("classification.config", "reference.config", "sid-msg.map", "unicode.map") as $file) {
+			if (file_exists("{$snortdir}/rules/{$file}"))
+				@copy("{$snortdir}/rules/{$file}", "{$snortdir}/{$file}");
+		}
+	}
+}
+
 /* Untar snort rules file individually to help people with low system specs */
 if ($snortdownload == 'on') {
 	if (file_exists("{$tmpfname}/{$snort_filename}")) {
@@ -245,29 +270,6 @@ if ($snortdownload == 'on') {
 	}
 }
 
-/* Untar emergingthreats rules to tmp */
-if ($emergingthreats == 'on') {
-	if (file_exists("{$tmpfname}/{$emergingthreats_filename}")) {
-		update_status(gettext("Extracting rules..."));
-		exec("/usr/bin/tar xzf {$tmpfname}/{$emergingthreats_filename} -C {$snortdir} rules/");
-	}
-
-	/* make shure default rules are in the right format */
-	exec("/usr/bin/sed -I '' -f {$snortdir}/tmp/sedcmd {$snortdir}/rules/emerging*.rules");
-
-	/*  Copy emergingthreats md5 sig to snort dir */
-	if (file_exists("{$tmpfname}/$emergingthreats_filename_md5")) {
-		update_status(gettext("Copying md5 sig to snort directory..."));
-		@copy("{$tmpfname}/$emergingthreats_filename_md5", "{$snortdir}/$emergingthreats_filename_md5");
-	}
-
-	if ($snortdownload == 'off') {
-		foreach (array("classification.config", "reference.config", "sid-msg.map", "unicode.map") as $file) {
-			if (file_exists("{$snortdir}/rules/{$file}"))
-				@copy("{$snortdir}/rules/{$file}", "{$snortdir}/{$file}");
-		}
-	}
-}
 
 /*  remove old $tmpfname files */
 if (is_dir($tmpfname)) {


### PR DESCRIPTION
...st classification.config will get used by the system. Since the ET rules do not have definitions for the new classification types, but the Snort.org rules do, the ET rules should be unpacked first.

This is not really a solution, but seems to work.
