### PR TITLE
Rub out extra "default_value" accidentally added with "en" language change

### DIFF
--- a/config/squid-reverse/squid.xml
+++ b/config/squid-reverse/squid.xml
@@ -345,7 +345,7 @@
 			<fieldname>error_language</fieldname>
 			<description>Select the language in which the proxy server will display error messages to users.</description>
 			<type>select</type>
-			<default_value>en</default_value></default_value>
+			<default_value>en</default_value>
 		</field>
 		<field>
 			<fielddescr>Disable X-Forward</fielddescr>


### PR DESCRIPTION
Don't know how I managed to paste an extra bit in there!
