### PR TITLE
Patch classification.config for ET rules

### DIFF
--- a/config/snort/snort_check_for_rule_updates.php
+++ b/config/snort/snort_check_for_rule_updates.php
@@ -170,6 +170,19 @@ if ($emergingthreats == 'on') {
 	if (file_exists("{$tmpfname}/{$emergingthreats_filename}")) {
 		update_status(gettext("Extracting rules..."));
 		exec("/usr/bin/tar xzf {$tmpfname}/{$emergingthreats_filename} -C {$snortdir}/tmp/emerging rules/");
+		// begin patch
+		// ET rules currently don't know anything about the sensitive data preprocessor:
+		// add a proper type declaration to avoid runtime errors.
+		// The extra declaration is only needed when the sensitive data preproc is enabled and the Snort.org
+		// rules are not used.
+		$classif = "{$snortdir}/tmp/emerging/rules/classification.config";
+		$extra = "config classification: sdf,Sensitive Data was Transmitted Across the Network,2\n";
+		if (file_exists($classif)) {
+			@file_put_contents($classif, $extra, LOCK_EX | FILE_APPEND);
+		}
+		unset($extra);
+		unset($classif);
+		// end of patch
 
 		$files = glob("{$snortdir}/tmp/emerging/rules/*.rules");
 		foreach ($files as $file) {


### PR DESCRIPTION
Add the sdf type declaration at the end of the classification.config file. Patching is required when only the ET rules are used and the sensitive data preprocessor is activated. The default classification.config has the necessary declaration, but gets overwritten if the Snort.org rules are not downloaded as well.
