### PR TITLE
To keep proxy_monitor.sh from starting more than one.

### DIFF
--- a/config/squid-reverse/proxy_monitor.sh
+++ b/config/squid-reverse/proxy_monitor.sh
@@ -27,6 +27,11 @@
 #	POSSIBILITY OF SUCH DAMAGE.
 #
 
+IS_RUNNING=`ps awx |grep -c "[p]roxy_monitor.sh"`
+if [ $IS_RUNNING -gt 0 ]; then
+        exit 0
+fi
+
 set -e
 
 LOOP_SLEEP=55


### PR DESCRIPTION
This will keep proxy_monitor.sh from starting too many times. Before, it started a new instance everytime squid3 was restarted (even on IP change from filter reload).
