### PR TITLE
Update config/squid-reverse/proxy_monitor.sh

### DIFF
--- a/config/squid-reverse/proxy_monitor.sh
+++ b/config/squid-reverse/proxy_monitor.sh
@@ -28,7 +28,7 @@
 #
 
 IS_RUNNING=`ps awx |grep -c "[p]roxy_monitor.sh"`
-if [ $IS_RUNNING -gt 0 ]; then
+if [ $IS_RUNNING -gt 1 ]; then
         exit 0
 fi
 


### PR DESCRIPTION
Pasted with the wrong value. You must count the one that is executing otherwise the first will not start.
