### PR TITLE
Changes to match 2.1 version.

### DIFF
--- a/config/squid3/proxy_monitor.sh
+++ b/config/squid3/proxy_monitor.sh
@@ -27,8 +27,7 @@
 #	POSSIBILITY OF SUCH DAMAGE.
 #
 
-IS_RUNNING=`ps awx |grep -c "[p]roxy_monitor.sh"`
-if [ $IS_RUNNING -gt 1 ]; then
+if [ `ps awx |grep -c "[p]roxy_monitor.sh"` -gt 2 ]; then
         exit 0
 fi
 


### PR DESCRIPTION
I am not sure why it does this, but it detects 2 of them when you start the script and one goes away in a few seconds.
This is tested to work after trying hard to find out why it is showing 2 proxy_monitor.sh scripts on script start up.
Only one should be starting.
