### PR TITLE
Change the way we keep only one going and no more.

### DIFF
--- a/config/squid-reverse/proxy_monitor.sh
+++ b/config/squid-reverse/proxy_monitor.sh
@@ -27,8 +27,7 @@
 #	POSSIBILITY OF SUCH DAMAGE.
 #
 
-IS_RUNNING=`ps awx |grep -c "[p]roxy_monitor.sh"`
-if [ $IS_RUNNING -gt 1 ]; then
+if [ `pgrep -f "proxy_monitor.sh"|wc -l` -ge 1 ]; then
         exit 0
 fi
 


### PR DESCRIPTION
Test and reboot tested. Only 1 starts up. Theoretically, it should not even start 1, but if I set it to greater than 1, 2 opens up and remains open. I guess it is preloading the variables?
Just have to watch the behavior and see if that ever changes. 
