### PR TITLE
Make matching conf_mount_ro calls during squid3 installation

### DIFF
--- a/config/squid-reverse/squid.inc
+++ b/config/squid-reverse/squid.inc
@@ -1465,8 +1465,8 @@ function squid_resync() {
 				sleep(1);
 		}
 		filter_configure();
-		conf_mount_ro();
 	}
+	conf_mount_ro();
 }
 
 function squid_print_javascript_auth() {
@@ -1796,6 +1796,7 @@ if [ -z "`ps auxw | grep "[s]quid "|awk '{print $2}'`" ];then
 EOD;
 	conf_mount_rw();
 	write_rcfile($rc);
+	conf_mount_ro();
 }
 
 /* Uses XMLRPC to synchronize the changes to a remote node */


### PR DESCRIPTION
After initial installation of squid3 (squid-reverse folder) the shared-memory section mount count is left at 3. This means that on nanobsd the CF card is left mounted read-write. This condition will persist until the next reboot, because there is nothing to decrement the count.
I have found 2 places here that do not match up conf_mount_rw and conf_mount_ro calls. There might be 1 more somewhere (or one of these routines is called twice during installation). I can check that when this change is committed and I can do another install from scratch.
