### PR TITLE
Add a matching conf_mount_ro call for squid

### DIFF
--- a/config/squid/squid.inc
+++ b/config/squid/squid.inc
@@ -1469,5 +1469,6 @@ if [ -z "`ps auxw | grep "[s]quid -D"|awk '{print $2}'`" ];then
 EOD;
 	conf_mount_rw();
 	write_rcfile($rc);
+	conf_mount_ro();
 }
 ?>


### PR DESCRIPTION
After write_rcfile() we need to conf_mount_ro() so that the mount reference count is decremented, otherwise the filesystem will get left in read-write mode on nanobsd.
Note: in squid_resync there is already a correct pair of conf_mount_rw() and conf_mount_ro(), so no need to touch that for squid(2).
