### PR TITLE
Update config/quagga_ospfd/quagga_ospfd.inc

### DIFF
--- a/config/quagga_ospfd/quagga_ospfd.inc
+++ b/config/quagga_ospfd/quagga_ospfd.inc
@@ -1,7 +1,7 @@
 <?php
 /*
 	quagga_ospfd.inc
-	Copyright (C) 2010 Ermal Luçi
+	Copyright (C) 2010 Ermal Luï¿½i
 	Copyright (C) 2012 Jim Pingle
 	part of pfSense
 	All rights reserved.
@@ -110,9 +110,9 @@ function quagga_ospfd_install_conf() {
 				}
 				if ($conf['md5password'] && !empty($conf['password'])) {
 					$conffile .= "  ip ospf authentication message-digest\n";
-					$conffile .= "  ip ospf message-digest-key 1 md5 \"" . substr($conf['password'], 0, 15) . "\"\n";
+					$conffile .= "  ip ospf message-digest-key 1 md5 " . substr($conf['password'], 0, 15) . "\n";
 				} else if (!empty($conf['password'])) {
-					$conffile .= "  ip ospf authentication-key \"" . substr($conf['password'], 0, 8) . "\"\n";
+					$conffile .= "  ip ospf authentication-key \" . substr($conf['password'], 0, 8) . "\n";
 				}
 				if (!empty($conf['routerpriorityelections'])) {
 					$conffile .= "  ip ospf priority {$conf['routerpriorityelections']}\n";


### PR DESCRIPTION
OSPF passwords are in Quagga configuration surrounded by quotes, which is
result in MD5 authentication failures where other side like Cisco routers defined the password 
without quotes.
