### PR TITLE
Fix equals check for pfblocker rule loading

### DIFF
--- a/config/pf-blocker/pfblocker.inc
+++ b/config/pf-blocker/pfblocker.inc
@@ -483,7 +483,7 @@ function sync_package_pfblocker($cron="") {
 				# top of the list for each interface, after any built-in rules (e.g. anti-lockout)
 				$found_new_interface = TRUE;
 				foreach ($interfaces_processed as $processed_interface){
-					if ($processed_interface = $rule['interface']){
+					if ($processed_interface == $rule['interface']){
 						$found_new_interface = FALSE;
 					}
 				}


### PR DESCRIPTION
Sorry guys - I missed out an equals sign here, the logic ended up only applying rules to the first interface, and not for others.
