### PR TITLE
Allow lcdproc_client to run forever

### DIFF
--- a/config/lcdproc-dev/lcdproc_client.php
+++ b/config/lcdproc-dev/lcdproc_client.php
@@ -911,6 +911,8 @@
 			lcdproc_warn("Failed to connect to LCDd process $errstr ($errno)");
 			$lcdproc_connect_errors++;
 		} else {			
+			/* Allow the script to run forever (0) */
+			set_time_limit(0);
 			build_interface($lcd);
 			loop_status($lcd);
 			fclose($lcd);


### PR DESCRIPTION
In 2.1 a CPU time limit of 900 seconds is set for PHP scripts. Normal scripts used by the GUI should do their thing and finish. But lcdproc needs to run "forever" in the background.
See forum thread: http://forum.pfsense.org/index.php/topic,54242.0.html
Note: This is a change for lcdproc-dev. If the original lcdproc is being maintained for 2.1 then a similar change is needed in that package version.
