### PR TITLE
bandwidthd - replace deprecated split with explode

### DIFF
--- a/config/bandwidthd/bandwidthd.inc
+++ b/config/bandwidthd/bandwidthd.inc
@@ -97,7 +97,7 @@ function bandwidthd_install_config() {
 		log_error("You should specify an interface for bandwidthd to listen on. Exiting.");
 	}
 
-	$subnets_custom = split(';',str_replace(' ','',$config['installedpackages']['bandwidthd']['config'][0]['subnets_custom']));
+	$subnets_custom = explode(';',str_replace(' ','',$config['installedpackages']['bandwidthd']['config'][0]['subnets_custom']));
 
 	/* initialize to "" */
 	$subnets = "";


### PR DESCRIPTION
The split function is deprecated in PHP 5.3. For this simple use, the explode function does the same thing.
http://forum.pfsense.org/index.php/topic,55187.0.html
