### PR TITLE
openvpn-client-export, added option to include OpenVPNManager in windows setup.

### DIFF
--- a/config/openvpn-client-export/openvpn-client-export.inc
+++ b/config/openvpn-client-export/openvpn-client-export.inc
@@ -61,7 +61,7 @@ function openvpn_client_export_deinstall() {
 	conf_mount_ro();
 }
 
-function openvpn_client_export_prefix($srvid) {
+function openvpn_client_export_prefix($srvid, $usrid = null) {
 	global $config;
 
 	// lookup server settings
@@ -74,8 +74,13 @@ function openvpn_client_export_prefix($srvid) {
 	$host = empty($config['system']['hostname']) ? "openvpn" : $config['system']['hostname'];
 	$prot = ($settings['protocol'] == 'UDP' ? 'udp' : $settings['protocol']);
 	$port = $settings['local_port'];
+	
+	$username = "";
+	//$config['openvpn']['openvpn-server'];
+	if ($usrid && is_numeric($usrid))
+		$username = "-".$config['system']['user'][$usrid]['name'];
 
-	return "{$host}-{$prot}-{$port}";
+	return "{$host}-{$prot}-{$port}{$username}";
 }
 
 function openvpn_client_pem_to_pk12($outpath, $outpass, $crtpath, $keypath, $capath = false) {
@@ -151,7 +156,7 @@ function openvpn_client_export_validate_config($srvid, $usrid, $crtid) {
 	return array($settings, $server_cert, $server_ca, $servercn, $user, $cert, $nokeys);
 }
 
-function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, $nokeys = false, $proxy, $expformat = "baseconf", $outpass = "", $skiptls=false, $doslines=false, $advancedoptions = "") {
+function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, $nokeys = false, $proxy, $expformat = "baseconf", $outpass = "", $skiptls=false, $doslines=false, $openvpnmanager, $advancedoptions = "") {
 	global $config, $input_errors, $g;
 
 	$nl = ($doslines) ? "\r\n" : "\n";
@@ -211,7 +216,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $quotese
 		$conf .= "http-proxy {$proxy['ip']} {$proxy['port']} ";
 		if ($proxy['proxy_authtype'] != "none") {
 			if (!isset($proxy['passwdfile']))
-				$proxy['passwdfile'] = openvpn_client_export_prefix($srvid) . "-proxy";
+				$proxy['passwdfile'] = openvpn_client_export_prefix($srvid, $usrid) . "-proxy";
 			$conf .= " {$proxy['passwdfile']} {$proxy['proxy_authtype']}";
 		}
 		$conf .= "{$nl}";
@@ -226,7 +231,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $quotese
 	}
 
 	// add key settings
-	$prefix = openvpn_client_export_prefix($srvid);
+	$prefix = openvpn_client_export_prefix($srvid, $usrid);
 	$cafile = "{$prefix}-ca.crt";
 	if($nokeys == false) {
 		if ($expformat == "inline") {
@@ -295,8 +300,28 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $quotese
 		$conf .= "comp-lzo{$nl}";
 	if ($settings['passtos'])
 		$conf .= "passtos{$nl}";
+
+	if ($openvpnmanager)
+	{
+		$conf .= $nl;
+		$conf .= "# dont terminate service process on wrong password, ask again{$nl}";
+		$conf .= "auth-retry interact{$nl}";
+		$conf .= "# open management channel{$nl}";
+		$conf .= "management 127.0.0.1 166{$nl}";
+		$conf .= "# wait for management to explicitly start connection{$nl}";
+		$conf .= "management-hold{$nl}";
+		$conf .= "# query management channel for user/pass{$nl}";
+		$conf .= "management-query-passwords{$nl}";
+		$conf .= "# disconnect VPN when managment program connection is closed{$nl}";
+		$conf .= "management-signal{$nl}";
+		$conf .= "# forget password when management disconnects{$nl}";
+		$conf .= "management-forget-disconnect{$nl}";
+		$conf .= $nl;
+	};
 		
 	// add advanced options
+	$advancedoptions = str_replace("\r\n", "\n", $advancedoptions);
+	$advancedoptions = str_replace("\n", $nl, $advancedoptions);
 	$advancedoptions = str_replace(";", $nl, $advancedoptions);
 	$conf .= $advancedoptions;
 	$conf .= $nl;
@@ -411,7 +436,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $quotese
 	}
 }
 
-function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, $outpass, $proxy, $advancedoptions, $openvpn_version = "2.1") {
+function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, $outpass, $proxy, $openvpnmanager, $advancedoptions, $openvpn_version = "2.1") {
 	global $config, $g, $input_errors;
 	$uname_p = trim(exec("uname -p"));
 
@@ -453,7 +478,7 @@ function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $quot
 	exec("/bin/cp {$tempdir}/{$client_install_exe} {$tempdir}/openvpn-install.exe");
 
 	// write configuration file
-	$prefix = openvpn_client_export_prefix($srvid);
+	$prefix = openvpn_client_export_prefix($srvid, $usrid);
 	$cfgfile = "{$confdir}/{$prefix}-config.ovpn";
 	if (!empty($proxy) && $proxy['proxy_authtype'] != "none") {
 		$proxy['passwdfile'] = "{$prefix}-password";
@@ -461,7 +486,7 @@ function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $quot
 		$pwdfle .= "{$proxy['password']}\r\n";
 		file_put_contents("{$confdir}/{$proxy['passwdfile']}", $pwdfle);
 	}
-	$conf = openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken,  $nokeys, $proxy, "", "baseconf", false, true, $advancedoptions);
+	$conf = openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken,  $nokeys, $proxy, "", "baseconf", false, true, $openvpnmanager, $advancedoptions);
 	if (!$conf) {
 		$input_errors[] = "Could not create a config to export.";
 		return false;
@@ -493,13 +518,28 @@ function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $quot
 	// 7zip the configuration data
 	chdir($tempdir);
 	$files  = "config ";
-	$files .= "procchain.exe ";
+	if ($openvpnmanager)
+		$files .= "OpenVPNManager ";
+	//$files .= "procchain.exe ";
 	$files .= "openvpn-install.exe ";
 	$files .= "openvpn-postinstall.exe ";
-	if ($usetoken)
+	/*if ($usetoken)
 		$files .= "procchain-import";
 	else
-		$files .= "procchain-standard";
+		$files .= "procchain-standard";*/
+	if ($usetoken)
+		$procchain = 	';!@Install@!UTF-8!
+RunProgram="openvpn-postinstall.exe /Import"
+;!@InstallEnd@!'
+;
+	else
+		$procchain = 	';!@Install@!UTF-8!
+RunProgram="openvpn-postinstall.exe"
+;!@InstallEnd@!'
+;
+	file_put_contents("{$tempdir}/7zipConfig",$procchain);
+	//$files .= "procchain ";
+	
 
 	if(file_exists("/usr/pbi/p7zip-{$uname_p}/bin/7z"))
 		exec("/usr/pbi/p7zip-{$uname_p}/bin/7z -y a archive.7z {$files}");
@@ -509,18 +549,18 @@ function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $quot
 	// create the final installer
 	$outfile = "{$tempdir}-install.exe";
 	chdir($g['tmp_path']);
-	if ($usetoken)
-		exec("/bin/cat {$tempdir}/7zS.sfx {$tempdir}/config-import {$tempdir}/archive.7z > {$outfile}");
-	else
-		exec("/bin/cat {$tempdir}/7zS.sfx {$tempdir}/config-standard {$tempdir}/archive.7z > {$outfile}");
+	//if ($usetoken)
+		//exec("/bin/cat {$tempdir}/7zS.sfx {$tempdir}/config-import {$tempdir}/archive.7z > {$outfile}");
+	//else
+	exec("/bin/cat {$tempdir}/7zS.sfx {$tempdir}/7zipConfig {$tempdir}/archive.7z > {$outfile}");
 
 	// cleanup
-	exec("/bin/rm -r {$tempdir}");
+	//exec("/bin/rm -r {$tempdir}");
 
 	return $outfile;
 }
 
-function viscosity_openvpn_client_config_exporter($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, $outpass, $proxy, $advancedoptions) {
+function viscosity_openvpn_client_config_exporter($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, $outpass, $proxy, $openvpnmanager, $advancedoptions) {
 	global $config, $g;
 	$uname_p = trim(exec("uname -p"));
 
@@ -547,7 +587,7 @@ function viscosity_openvpn_client_config_exporter($srvid, $usrid, $crtid, $usead
 	$tempdir = $tempdir . "/Viscosity.visc/";
 
 	// write cofiguration file
-	$prefix = openvpn_client_export_prefix($srvid);
+	$prefix = openvpn_client_export_prefix($srvid, $usrid);
 	if (!empty($proxy) && $proxy['proxy_authtype'] != "none") {
 		$proxy['passwdfile'] = "config-password";
 		$pwdfle = "{$proxy['user']}\n";
@@ -555,7 +595,7 @@ function viscosity_openvpn_client_config_exporter($srvid, $usrid, $crtid, $usead
 		file_put_contents("{$tempdir}/{$proxy['passwdfile']}", $pwdfle);
 	}
 
-	$conf = openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, true, $proxy, "baseconf", "", true, $advancedoptions);
+	$conf = openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, true, $proxy, "baseconf", "", true, $openvpnmanager, $advancedoptions);
 	if (!$conf)
 		return false;
 

--- a/config/openvpn-client-export/source/dotnet2.nsh
+++ b/config/openvpn-client-export/source/dotnet2.nsh
@@ -1,0 +1,93 @@
+; Plugin for installing .NET Framework v2.0
+; Written by Christopher St. John
+; for EncounterPRO Healthcare Resources, Inc.
+
+!ifndef DOTNET2_INCLUDED
+!define DOTNET2_INCLUDED
+
+; -----------------------------------------
+; Includes
+    !include "WordFunc.nsh"
+    !insertmacro VersionCompare
+    !include LogicLib.nsh
+
+; -----------------------------------------
+; Defines
+    ; Direct-download location of .NET 2.0 redist
+    !define BASE_URL http://download.microsoft.com/download
+    !define URL_DOTNET_1033 "${BASE_URL}/5/6/7/567758a3-759e-473e-bf8f-52154438565a/dotnetfx.exe"
+    
+; -----------------------------------------
+; Variables
+    Var DotNetVersion2
+    Var InstallDotNet2
+    
+; -----------------------------------------
+; Functions
+Function GetDotNETVersion2
+  Push $0
+  Push $1
+
+  System::Call "mscoree::GetCORVersion(w .r0, i 1024, *i r2) i .r1"
+  StrCmp $1 0 +2
+    StrCpy $0 0
+  
+  Pop $1
+  Exch $0
+FunctionEnd
+
+; -----------------------------------------
+; Macros
+!macro CheckForDotNET2
+    ; Check .NET version
+    StrCpy $InstallDotNET2 "No"
+    Call GetDotNETVersion2
+    Pop $0
+    StrCpy $DotNetVersion2 $0
+  
+    ${If} $0 == "not found"
+        StrCpy $InstallDotNET2 "Yes"
+        MessageBox MB_OK|MB_ICONINFORMATION "Installer requires that the .NET Framework 2.0 is installed. The .NET Framework will be downloaded and installed automatically during installation."
+        Return
+    ${EndIf}
+
+    StrCpy $0 $0 "" 1 # skip "v"
+
+    ${VersionCompare} $0 "2.0" $1
+    ${If} $1 == 2
+        StrCpy $InstallDotNET2 "Yes"
+        MessageBox MB_OK|MB_ICONINFORMATION "Installer requires that the .NET Framework 2.0 is installed. The .NET Framework will be downloaded and installed automatically during installation."
+        Return
+    ${EndIf}
+!macroend
+
+!macro InstallDotNET2
+    ; Get .NET if required
+    ${If} $InstallDotNET2 == "Yes"
+        DetailPrint "Downloading .NET Framework v2.0..."
+        ;SetDetailsView hide
+        NSISdl::download /TIMEOUT=30000 "${URL_DOTNET_1033}" "$INSTDIR\dotnetfx.exe"
+        Pop $1
+
+        ${If} $1 != "success"
+            DetailPrint "Download failed: $1"
+            Delete "$INSTDIR\dotnetfx.exe"
+            Abort "Installation Cancelled"
+        ${EndIf}
+
+        DetailPrint "Installing .NET Framework v2.0..."
+        ExecWait '"$INSTDIR\dotnetfx.exe" /q:a /c:"install /passive"' $1
+        ${If} $1 == 0
+            DetailPrint ".NET Framework v2.0 successfully installed."
+        ${ElseIf} $1 == 3010
+            MessageBox MB_OK ".NET Framework v2.0 has been installed and requires a reboot.  Please restart the computer and run this installer again."
+            Abort ".NET Framework v2.0 requires reboot."
+        ${Else}
+            MessageBox MB_OK ".NET Framework v2.0 reports a failure during installation ($1).  Please try to install .NET Framework v2.0 via Windows Update before running this installer again."
+            Abort ".NET Framework v2.0 installation failed ($1)."
+        ${EndIf}
+        Delete "$INSTDIR\dotnetfx.exe"  
+    ${EndIf}
+!macroend
+
+!endif

--- a/config/openvpn-client-export/source/openvpn-postinstall.nsi
+++ b/config/openvpn-client-export/source/openvpn-postinstall.nsi
@@ -5,7 +5,10 @@
 ;--------------------------------
 ;Include Modern UI
 
-  !include "MUI.nsh"
+Var /GLOBAL mui.FinishPage.Run
+!define MUI_FINISHPAGE_RUN_VARIABLES
+
+  !include "MUI2.nsh"
   !include "FileFunc.nsh"
   !include "LogicLib.nsh"
 
@@ -19,6 +22,7 @@
 
   ShowInstDetails show
 
+  !include "dotnet2.nsh"
 ;--------------------------------
 ;Include Settings
 ;--------------------------------
@@ -30,7 +34,25 @@
 ;Pages
 ;--------------------------------
 
+!define WELCOME_TITLE 'Welcome to OpenVPN installer.'
+
+!define WELCOME_TEXT "This wizard will guide you through the installation of the OpenVPN client and configuration.$\r$\n$\r$\n\
+This wil automaticaly install the configuration files needed for your connection. \
+And if needed install the required DotNet2 framework."
+  !define MUI_WELCOMEPAGE_TITLE '${WELCOME_TITLE}'
+  ;!define MUI_WELCOMEPAGE_TITLE_3LINES
+  !define MUI_WELCOMEPAGE_TEXT '${WELCOME_TEXT}'
+  !insertmacro MUI_PAGE_WELCOME
+  
   !insertmacro MUI_PAGE_INSTFILES
+  
+  
+  !define MUI_FINISHPAGE_RUN "C:\User\test.lnk"
+  !define MUI_FINISHPAGE_RUN_TEXT "Start OpenVPNManager."
+  !define MUI_FINISHPAGE_RUN_FUNCTION "LaunchLink"
+  !define MUI_PAGE_CUSTOMFUNCTION_SHOW finish_show
+  !insertmacro MUI_PAGE_FINISH
+  
   !insertmacro Locate
   !insertmacro GetParameters
   !insertmacro GetOptions
@@ -46,55 +68,128 @@
 ;--------------------------------
 
 Function .onInit
-
+  Var /GLOBAL BINPATH
   Var /GLOBAL CONFPATH
-  ReadRegStr $CONFPATH HKLM "Software\OpenVPN" "config_dir"
-
+  Var /GLOBAL OpenVPNManager
+  !insertmacro CheckForDotNET2
 FunctionEnd
 
 Function CopyConfFile
-
   CopyFiles $R9 $CONFPATH\$R7
   Push $0
-
 FunctionEnd
 
 Function ImportConfFile
-
   ExecWait "rundll32.exe cryptext.dll,CryptExtAddPFX $R9"
   Push $0
-
 FunctionEnd
 
+Function CopyOpenVPNManager
+  DetailPrint "Installing OpenVPNManager..."
+  DetailPrint "Installing in: $BINPATH\OpenVPNManager\"
+  CreateDirectory "$BINPATH\OpenVPNManager"
+  CreateDirectory "$BINPATH\OpenVPNManager\config"
+  CopyFiles ".\OpenVPNManager\*.*" "$BINPATH\OpenVPNManager"
+  CreateShortcut "$desktop\OpenVPNManager.lnk" "$BINPATH\OpenVPNManager\OpenVPNManager.exe"
+  Push $0
+FunctionEnd
+
+Function finish_show
+  ${If} $OpenVPNManager != "true"
+	;If OpenVPNManager is not installed then dont give the option to run it. (hide and uncheck the checkbox)
+	ShowWindow $mui.FinishPage.Run 0
+	${NSD_Uncheck} $mui.FinishPage.Run
+  ${EndIf}
+FunctionEnd
+
+Function LaunchLink
+  ExecShell "" "$desktop\OpenVPNManager.lnk"
+FunctionEnd
 ;--------------------------------
 ;Installer Sections
 ;--------------------------------
 
-Section "Imort Configuration" SectionImport
+Section "Import Configuration" SectionImport
+	!insertmacro InstallDotNet2
 
-  DetailPrint "Installing configuration files ..."
-  ${Locate} ".\config" "/L=F /M=*.ovpn" "CopyConfFile"
+	IfFileExists ".\OpenVPNManager" InstallOpenVPNManager1 DontInstallOpenVPNManager1
+	InstallOpenVPNManager1:
+		strcpy $OpenVPNManager true
+		Goto OpenVPNManagerDone1
+	DontInstallOpenVPNManager1:
+		strcpy $OpenVPNManager false
+	OpenVPNManagerDone1:
+	
+	
+	ClearErrors
+	ReadRegStr $BINPATH HKLM "Software\OpenVPN" ""
+	IfErrors OpenVPNInstall OpenVPNAlreadyInstalled
+	OpenVPNInstall:
+		DetailPrint "Pausing installation while OpenVPN installer runs."
+		ExecWait '".\openvpn-install.exe"' $1
+		${if} $OpenVPNManager == "true"
+			SetShellVarContext all
+			Delete "$desktop\OpenVPN GUI.lnk"
+			SetShellVarContext current
+		${Endif}
+		Pop $0
+	OpenVPNAlreadyInstalled:
 
-  DetailPrint "Installing certificate and key files ..."
-  ${Locate} ".\config" "/L=F /M=*.crt" "CopyConfFile"
-  ${Locate} ".\config" "/L=F /M=*.key" "CopyConfFile"
+	ClearErrors
+	ReadRegStr $BINPATH HKLM "Software\OpenVPN" ""
+	IfErrors OpenVPNnotFound OpenVPNok
+	OpenVPNnotFound:
+		Abort "OpenVPN installation not found, installation aborted."
+	OpenVPNok:
+		DetailPrint "Completed OpenVPN installation."
 
-  ${GetParameters} $R0
-  ${GetOptions} $R0 "/Import" $R1
-  IfErrors p12_copy p12_import
+	${If} $OpenVPNManager == "true"
+		strcpy $OpenVPNManager true
+		StrCpy $CONFPATH "$BINPATH\OpenVPNManager\config"
+		call "CopyOpenVPNManager"
+	${Else}
+		strcpy $OpenVPNManager false
+		ClearErrors
+		ReadRegStr $CONFPATH HKLM "Software\OpenVPN" "config_dir"
+		IfErrors configNotFound configFound
+		configNotFound:
+			ReadRegStr $CONFPATH HKLM "Software\OpenVPN" ""
+			StrCpy $CONFPATH "$CONFPATH\config"
+		configFound:
+		
+	${Endif}
 
-  p12_copy:
-  ${Locate} ".\config" "/L=F /M=*.p12" "CopyConfFile"
-  Goto p12_done
+	DetailPrint "Installing configuration files ..."
+	${Locate} ".\config" "/L=F /M=*.ovpn" "CopyConfFile"
 
-  p12_import:
-  ${Locate} ".\config" "/L=F /M=*.p12" "ImportConfFile"
-  Goto p12_done
-
-  p12_done:
+	DetailPrint "Installing certificate and key files ..."
+	${Locate} ".\config" "/L=F /M=*.crt" "CopyConfFile"
+	${Locate} ".\config" "/L=F /M=*.key" "CopyConfFile"
+  
+	${If} $OpenVPNManager == "true"
+		DetailPrint "Registering OpenVPNManager service..."
+		ExecWait '"$BINPATH\OpenVPNManager\OpenVPNManager.exe" /install'
+		DetailPrint "Starting OpenVPNManager service..."
+		SimpleSC::StartService "OpenVPNManager" "" 30
+		Pop $0
+	${Else}
+		;DetailPrint "Starting OpenVPN Service..."
+		;SimpleSC::StartService "OpenVPNService" "" 30
+		;Pop $0
+	${Endif}
+  
+	${GetParameters} $R0
+	${GetOptions} $R0 "/Import" $R1
+	IfErrors p12_copy p12_import
+	p12_copy:
+		${Locate} ".\config" "/L=F /M=*.p12" "CopyConfFile"
+		Goto p12_done
+	p12_import:
+		${Locate} ".\config" "/L=F /M=*.p12" "ImportConfFile"
+		Goto p12_done
+	p12_done:
 
 SectionEnd
-
 ;--------------------------------
 ;Descriptions
 ;--------------------------------

--- a/config/openvpn-client-export/vpn_openvpn_export.php
+++ b/config/openvpn-client-export/vpn_openvpn_export.php
@@ -136,6 +136,7 @@ if (!empty($act)) {
 	} else
 		$useaddr = $_GET['useaddr'];
 	$advancedoptions = $_GET['advancedoptions'];
+	$openvpnmanager = $_GET['openvpnmanager'];
 
 	$quoteservercn = $_GET['quoteservercn'];
 	$usetoken = $_GET['usetoken'];
@@ -171,7 +172,7 @@ if (!empty($act)) {
 		}
 	}
 
-	$exp_name = openvpn_client_export_prefix($srvid);
+	$exp_name = openvpn_client_export_prefix($srvid, $usrid);
 
 	if(substr($act, 0, 4) == "conf") {
 		switch ($act) {
@@ -203,17 +204,17 @@ if (!empty($act)) {
 				$exp_name = urlencode($exp_name."-config.ovpn");
 				$expformat = "baseconf";
 		}
-		$exp_path = openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, $nokeys, $proxy, $expformat, $password, false, false, $advancedoptions);
+		$exp_path = openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, $nokeys, $proxy, $expformat, $password, false, false, $openvpnmanager, $advancedoptions);
 	}
 
 	if($act == "visc") {
 		$exp_name = urlencode($exp_name."-Viscosity.visc.zip");
-		$exp_path = viscosity_openvpn_client_config_exporter($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, $password, $proxy,  $advancedoptions);
+		$exp_path = viscosity_openvpn_client_config_exporter($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, $password, $proxy, $openvpnmanager, $advancedoptions);
 	}
 
 	if(substr($act, 0, 4) == "inst") {
 		$exp_name = urlencode($exp_name."-install.exe");
-		$exp_path = openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, $password, $proxy, $advancedoptions, substr($act, 5));
+		$exp_path = openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $quoteservercn, $usetoken, $password, $proxy, $openvpnmanager, $advancedoptions, substr($act, 5));
 	}
 
 	if (!$exp_path) {
@@ -303,6 +304,9 @@ function download_begin(act, i, j) {
 	var usepass = 0;
 	if (document.getElementById("usepass").checked)
 		usepass = 1;
+	var openvpnmanager = 0;
+	if (document.getElementById("openvpnmanager").checked)
+		openvpnmanager = 1;
 
 	var pass = document.getElementById("pass").value;
 	var conf = document.getElementById("conf").value;
@@ -366,6 +370,7 @@ function download_begin(act, i, j) {
 	}
 	dlurl += "&useaddr=" + escape(useaddr);
 	dlurl += "&quoteservercn=" + escape(quoteservercn);
+	dlurl += "&openvpnmanager=" + escape(openvpnmanager);
 	dlurl += "&usetoken=" + escape(usetoken);
 	if (usepass)
 		dlurl += "&password=" + escape(pass);
@@ -726,6 +731,25 @@ function useproxy_changed(obj) {
 									</td>
 								</tr>
 							</table>
+									</td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+					<tr>
+						<td width="22%" valign="top" class="vncell">Management&nbsp;Interface<br/>OpenVPNManager</td>
+						<td width="78%" class="vtable">
+							<table border="0" cellpadding="2" cellspacing="0">
+								<tr>
+									<td>
+										<input name="openvpnmanager" id="openvpnmanager" type="checkbox" value="yes">
+									</td>
+									<td>
+										<span class="vexpl">
+											 This will change the generated .ovpn configuration to allow for usage of the management interface.
+											 And include the OpenVPNManager program in the "Windows Installers". With this OpenVPN can be used also by non-administrator users.
+											 This is also usefull for Windows7/Vista systems where elevated permissions are needed to add routes to the system.
+										</span>
 									</td>
 								</tr>
 							</table>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1381,7 +1381,7 @@
 		<depends_on_package_pbi>zip-3.0-i386.pbi p7zip-9.20.1-i386.pbi</depends_on_package_pbi>
 		<build_port_path>/usr/ports/archivers/p7zip</build_port_path>
 		<build_port_path>/usr/ports/archivers/zip</build_port_path>
-		<version>0.25</version>
+		<version>0.26</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<config_file>http://www.pfsense.com/packages/config/openvpn-client-export/openvpn-client-export.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1368,7 +1368,7 @@
 		<depends_on_package_pbi>p7zip-9.20.1-amd64.pbi zip-3.0-amd64.pbi</depends_on_package_pbi>
 		<build_port_path>/usr/ports/archivers/p7zip</build_port_path>
 		<build_port_path>/usr/ports/archivers/zip</build_port_path>
-		<version>0.25</version>
+		<version>0.26</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<config_file>http://www.pfsense.com/packages/config/openvpn-client-export/openvpn-client-export.xml</config_file>


### PR DESCRIPTION
openvpn-client-export, added option to include OpenVPNManager in windows setup, this solves the issues with Windows7/Vista client machines where elevated permissions are required by running OpenVPN as a service.

PS, this needs some new binary files in "http://files.pfsense.com/packages/openvpn-client-export/openvpn-client-export.tgz", this should be done before commiting this to the main tree.
