### PR TITLE
Fix for empty array condition.

### DIFF
--- a/config/widget-snort/snort_alerts.widget.php
+++ b/config/widget-snort/snort_alerts.widget.php
@@ -29,14 +29,14 @@ global $config, $g;
 
 /* array sorting */
 function sksort(&$array, $subkey="id", $sort_ascending=false) {
-	if (count($array)) {
-		$temp_array[key($array)] = array_shift($array);
-	};
         /* an empty array causes sksort to fail - this test alleviates the error */
 	if(empty($array))
         {
         return false;
         }
+	if (count($array)) {
+		$temp_array[key($array)] = array_shift($array);
+	};
 	foreach ($array as $key => $val){
 		$offset = 0;
 		$found = false;


### PR DESCRIPTION
error message:
Warning: Invalid argument supplied for foreach() in
/usr/local/www/widgets/widgets/snort_alerts.widget.php on line 36
