### PR TITLE
Improve cron stop checks

### DIFF
--- a/config/cron/cron.inc
+++ b/config/cron/cron.inc
@@ -82,7 +82,7 @@ function cron_install_command()
 	write_rcfile(array(
 		"file" => "cron.sh",
 		"start" => "/usr/sbin/cron -s &",
-		"stop" => "kill -9 `cat /var/run/cron.pid`"
+		"stop" => "[ -f \"/var/run/cron.pid\" ] && kill -9 `cat /var/run/cron.pid`; rm -f /var/run/cron.pid;"
 		)
 	);
 


### PR DESCRIPTION
Having an OCD day - cleaning up "noise" output on the console!
If cron.pid did not exist, an error was emitted - that could happen when a stop is done at package install, before it was ever started. If cron is stopped, cron.pid was left behind. Another attempt to stop emits an error about the pid in cron.pid not existing.
This extra checking avoids any error messages if stop is called before start, or stop is called twice.

Prior to this change, here is some sample console output during cron package reinstall after firmware upgrade:
...
Backing up libraries...
Removing package...
Removing Cron components...
Configuration... done.
Cleaning up... done.
Beginning package installation for Cron . 100%
Installing Cron and its dependencies. 100% 100% 100% 100%cat: /var/run/cron.pid: No such file or directory
usage: kill [-s signal_name] pid ...
       kill -l [exit_status]
       kill -signal_name pid ...
       kill -signal_number pid ...
...
