### PR TITLE
Fix prefix for sqpmon.sh fetch 

### DIFF
--- a/config/squid/squid.xml
+++ b/config/squid/squid.xml
@@ -134,7 +134,7 @@
 		<item>http://www.pfsense.org/packages/config/squid/squid_users.xml</item>
 	</additional_files_needed>
 	<additional_files_needed>
-	    <prefix>/usr/local/pkg</prefix>
+	    <prefix>/usr/local/pkg/</prefix>
 	    <chmod>0755</chmod>
 		<item>http://www.pfsense.org/packages/config/squid/sqpmon.sh</item>
 	</additional_files_needed>


### PR DESCRIPTION
Stared at this for a while until I noticed that all the others had a terminating slash. This will make sqpmon.sh download into the correct dir!
