### PR TITLE
GUI form typo fix for lcdproc-dev

### DIFF
--- a/config/lcdproc-dev/lcdproc.xml
+++ b/config/lcdproc-dev/lcdproc.xml
@@ -431,7 +431,7 @@
 		</field>
 		<field>
 			<fieldname>offbrightness</fieldname>
-			<fielddescr>Offrightness</fielddescr>
+			<fielddescr>Off brightness</fielddescr>
 			<description>Set the off-brightness of the LCD panel. This value is used when the display is normally switched off in case LCDd is inactive. This option is not supported by all the LCD panels, leave "default" if unsure.</description>
 			<type>select</type>
 			<options>


### PR DESCRIPTION
A mindless little change - but since I just got a Firebox, tried this, and noticed the GUI text error, thought it may as well be fixed.
Also, this form has a mix of conventions for the field labels "Com Port" "Port speed"... That mix happens in lots of GUI forms. I wonder what the pfSense project standard is - each word starts in uppercase, or just the first word? e.g. The OpenVPN Server form has "Concurrent connections" and "Duplicate Connections", and subheadings "Tunnel Settings" and "Advanced configuration".
