### PR TITLE
Change in # of lines to display in squid logs.

### DIFF
--- a/config/squid-reverse/squid_monitor.php
+++ b/config/squid-reverse/squid_monitor.php
@@ -115,7 +115,8 @@ include("head.inc");
 							<option value="15">15 lines</option>
 							<option value="20">20 lines</option>
 							<option value="25">25 lines</option>
-							<option value="30">30 lines</option>
+							<option value="100">100 lines</option>
+							<option value="200">200 lines</option>
 						</select>
 						<br/>
 						<span class="vexpl">


### PR DESCRIPTION
Removed 30 line option from Max lines to be displayed.
Added 100 line option to Max. lines to be displayed.
Added 200 line option to Max. lines to be displayed.
Tested on i386 configuration.
