### PR TITLE
Check to be sure file exists before reading and include flowbits rule file if missing in snort.conf

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -755,9 +755,10 @@ function snort_build_sid_msg_map($rules_path, $sid_file) {
              if (stristr($file, "deleted"))
                   continue;
 
-             /* Read the file into an array, skipping empty lines.   */
+             /* Read the file into an array, skipping missing files. */
 	     if (!file_exists($file))
 			continue;
+
              $rules_array = file($file, FILE_SKIP_EMPTY_LINES);
              $record = "";
              $b_Multiline = false;
@@ -948,13 +949,11 @@ function snort_load_rules_map($rules_path) {
 		if (stristr($file, "deleted"))
 			continue;
 
-		/* Read the file contents into an array, skipping   */
-		/* empty lines.                                     */
+		/* Read the file contents into an array, skipping    */
+		/* missing files.                                    */
 		if (!file_exists($file))
 			continue;
 
-	     if (!file_exists($file))
-			continue;
 		$rules_array = file($file, FILE_SKIP_EMPTY_LINES);
 		$record = "";
 		$b_Multiline = false;
@@ -1331,7 +1330,7 @@ function snort_load_vrt_policy($policy) {
 
 	/* Release memory we no longer need. */
 	unset($all_rules_map, $arulem, $arulem2);
-	
+
 	/* Return all the rules that match the policy. */
 	return $vrt_policy_rules;
 }
@@ -1347,6 +1346,10 @@ function snort_write_enforcing_rules_file(&$rule_map, $rule_path) {
 	global $snort_enforcing_rules_file;
 
 	$rule_file = "/snort.rules";
+
+	/* If the $rule_map array is empty, then exit.  */
+	if (empty($rule_map))
+		return;
 
 	/* See if we were passed a directory or full    */
 	/* filename to write the rules to, and adjust   */
@@ -2153,8 +2156,10 @@ EOD;
 		/* Create an array with the full path filenames of the enabled  */
 		/* rule category files if we have any.                          */
 		if (!empty($snortcfg['rulesets'])) {
-			foreach (explode("||", $snortcfg['rulesets']) as $file)
-				$enabled_files[] = "{$snortdir}/rules/" . $file;
+			foreach (explode("||", $snortcfg['rulesets']) as $file) {
+				if (file_exists("{$snortdir}/rules/" . $file))
+					$enabled_files[] = "{$snortdir}/rules/" . $file;
+			}
 
 			/* Load our rules map in preparation for writing the enforcing rules file. */
 			$enabled_rules = snort_load_rules_map($enabled_files);

--- a/config/snort/snort_check_for_rule_updates.php
+++ b/config/snort/snort_check_for_rule_updates.php
@@ -335,8 +335,10 @@ function snort_apply_customizations($snortcfg, $if_real) {
 		/* Create an array with the full path filenames of the enabled  */
 		/* rule category files if we have any.                          */
 		if (!empty($snortcfg['rulesets'])) {
-			foreach (explode("||", $snortcfg['rulesets']) as $file)
-				$enabled_files[] = "{$snortdir}/rules/" . $file;
+			foreach (explode("||", $snortcfg['rulesets']) as $file) {
+				if (file_exists())
+					$enabled_files[] = "{$snortdir}/rules/" . $file;
+			}
 
 			/* Load our rules map in preparation for writing the enforcing rules file. */
 			$enabled_rules = snort_load_rules_map($enabled_files);
@@ -369,6 +371,11 @@ function snort_apply_customizations($snortcfg, $if_real) {
 			log_error('Resolving and auto-enabling flowbit required rules for ' . snort_get_friendly_interface($snortcfg['interface']) . '...');
 			$enabled_files[] = "{$snortdir}/snort_{$snortcfg['uuid']}_{$if_real}/rules/{$snort_enforcing_rules_file}";
 			snort_write_flowbit_rules_file(snort_resolve_flowbits($enabled_files), "{$snortdir}/snort_{$snortcfg['uuid']}_{$if_real}/rules/{$flowbit_rules_file}");
+			if (file_exists("{$snortdir}/snort_{$snortcfg['uuid']}_{$if_real}/rules/{$flowbit_rules_file}")) {
+				exec("/usr/bin/grep 'include \$RULE_PATH/{$flowbit_rules_file}' {$snortdir}/snort_{$snortcfg['uuid']}_{$if_real}/snort.conf", $out, $rval);
+				if (empty($out))
+					file_put_contents("{$snortdir}/snort_{$snortcfg['uuid']}_{$if_real}/snort.conf", "include \$RULE_PATH/{$flowbit_rules_file}\n", FILE_APPEND);
+			}
 		}
 
 		/* Build a new sid-msg.map file from the enabled rules. */

--- a/config/snort/snort_rules.php
+++ b/config/snort/snort_rules.php
@@ -100,7 +100,7 @@ if ($currentruleset != 'custom.rules') {
 	if (substr($currentruleset, 0, 10) == "IPS Policy")
 		$rules_map = snort_load_vrt_policy($a_rule[$id]['ips_policy']);
 	elseif (!file_exists($rulefile))
-		$input_errors[] = "{$currentruleset} seems to be missing!!! Please go to the Category tab and save again the rule to regenerate it.";
+		$input_errors[] = "{$currentruleset} seems to be missing!!! Please go to the Category tab and save the rule set again to regenerate it.";
 	else
 		$rules_map = snort_load_rules_map($rulefile);
 }

--- a/config/snort/snort_rulesets.php
+++ b/config/snort/snort_rulesets.php
@@ -230,7 +230,9 @@ function enable_change()
 	<table id="maintable" class="tabcont" width="100%" border="0" cellpadding="0" cellspacing="0">
 <?php 
 	$isrulesfolderempty = glob("{$snortdir}/rules/*.rules");
-	$iscfgdirempty = glob("{$snortdir}/snort_{$snort_uuid}_{$if_real}/rules/*.rules");
+	$iscfgdirempty = array();
+	if (file_exists("{$snortdir}/snort_{$snort_uuid}_{$if_real}/rules/custom.rules"))
+		$iscfgdirempty = (array)("{$snortdir}/snort_{$snort_uuid}_{$if_real}/rules/custom.rules");
 	if (empty($isrulesfolderempty) && empty($iscfgdirempty)):
 ?>
 		<tr>


### PR DESCRIPTION
# Change Log

January 23, 2013
1.  Add checks for existence of rules files prior to attempting
    to read them to prevent errors during intial startup of Snort
    following a remove and re-install (or after initial install).
2.  Add a check in the automated rules update function to 
    ensure the flowbit rules file is included in snort.conf if the 
    auto-flowbit resolution feature is enabled.  This addresses 
    a problem during initial Rules Update after install of Snort 
    where rules directory is empty and thus the snort.conf 
    file does not include any rules files.
3.  Added similar checks for missing rules files in the RULES 
    and CATEGORIES tabs to prevent errors after initial 
    Snort install but prior to downloading the first set of rules.

These fixes address the issues reported by users on the 
pfSense forums after the last release of the Snort 2.5.3
package.
