### PR TITLE
Adding Zabbix-2 Agent and Zabbix-2 Proxy to the amd64 repo

### DIFF
--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1775,5 +1775,44 @@
 		<config_file>http://www.pfsense.com/packages/config/syslog-ng/syslog-ng.xml</config_file>
 		<configurationfile>syslog-ng.xml</configurationfile>
 	</package>
+	<package>
+		<name>Zabbix-2 Agent</name>
+		<descr>Monitoring agent.</descr>
+		<category>Services</category>
+		<config_file>http://www.pfsense.org/packages/config/zabbix2-agent/zabbix2-agent.xml</config_file>
+		<version>zabbix2-agent-2.0.4 pkg v0.3</version>
+		<status>BETA</status>
+		<required_version>2.0</required_version>
+		<configurationfile>zabbix2-agent.xml</configurationfile>
+		<maintainer>dbaio@bsd.com.br</maintainer>
+		<build_port_path>/usr/ports/net-mgmt/zabbix2-agent</build_port_path>
+		<build_pbi>
+			<custom_name>zabbix2-agent</custom_name>
+			<port>net-mgmt/zabbix2-agent</port>
+		</build_pbi>
+		<depends_on_package_base_url>http://www.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
+		<depends_on_package>zabbix2-agent-2.0.4.tbz</depends_on_package>
+		<depends_on_package_pbi>zabbix2-agent-2.0.4-amd64.pbi</depends_on_package_pbi>
+	</package>
+	<package>
+		<name>Zabbix-2 Proxy</name>
+		<descr>Monitoring agent proxy.</descr>
+		<category>Services</category>
+		<config_file>http://www.pfsense.org/packages/config/zabbix2-proxy/zabbix2-proxy.xml</config_file>
+		<version>zabbix2-proxy-2.0.4 pkg v0.3</version>
+		<status>BETA</status>
+		<required_version>2.0</required_version>
+		<configurationfile>zabbix2-proxy.xml</configurationfile>
+		<maintainer>dbaio@bsd.com.br</maintainer>
+		<build_port_path>/usr/ports/net-mgmt/zabbix2-proxy</build_port_path>
+		<build_pbi>
+			<custom_name>zabbix2-proxy</custom_name>
+			<port>net-mgmt/zabbix2-proxy</port>
+		</build_pbi>
+		<build_options>OPTIONS_SET+= SQLITE;OPTIONS_UNSET+= MYSQL JABBER LDAP</build_options>
+		<depends_on_package_base_url>http://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
+		<depends_on_package>zabbix2-proxy-2.0.4.tbz</depends_on_package>
+		<depends_on_package_pbi>zabbix2-proxy-2.0.4-amd64.pbi</depends_on_package_pbi>
+	</package>
 </packages>
 </pfsensepkgs>


### PR DESCRIPTION
Hi... Both packages were tested with amd64 environment.
