### PR TITLE
Fix creation of acl noauth

### DIFF
--- a/config/squid/squid.inc
+++ b/config/squid/squid.inc
@@ -1041,9 +1041,12 @@ function squid_resync_auth() {
 			$conf .= "http_access allow $acl\n";
 	}
 	else {
-		$noauth = implode(' ', explode("\n", base64_decode($settings['no_auth_hosts'])));
+		$noauth = base64_decode($settings['no_auth_hosts']);
 		if (!empty($noauth)) {
-			$conf .= "acl noauth src $noauth\n";
+	      foreach (split("\n", $noauth) as $host) {
+		      $host = trim($host);	
+				$conf .= "acl noauth src $host\n";
+			}
 			$valid_acls[] = 'noauth';
 		}
 


### PR DESCRIPTION
Error:
acl noauth src 192.168.1.50/32^M 192.168.6.0/24^M
