### PR TITLE
Do not mix OpenVPN's secure modes

### DIFF
--- a/config/openvpn-client-export/openvpn-client-export.inc
+++ b/config/openvpn-client-export/openvpn-client-export.inc
@@ -725,7 +725,7 @@ function openvpn_client_export_sharedkey_config($srvid, $useaddr, $proxy, $zipco
 	$conf .= "persist-key\n";
 	$conf .= "proto {$proto}\n";
 	$conf .= "cipher {$cipher}\n";
-	$conf .= "client\n";
+	$conf .= "pull\n";
 	$conf .= "resolv-retry infinite\n";
 	$conf .= "remote {$server_host} {$server_port}\n";
 	if ($settings['local_network']) {

--- a/config/openvpn-client-export/openvpn-client-export.xml
+++ b/config/openvpn-client-export/openvpn-client-export.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
 	<name>OpenVPN Client Export</name>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<title>OpenVPN Client Export</title>
 	<include_file>/usr/local/pkg/openvpn-client-export.inc</include_file>
 	<backup_file></backup_file>


### PR DESCRIPTION
As noted in the forum [1] only one OpenVPN secure mode can be specified at a time. In the shared key configuration the secret mode is used. However the generated configuration also includes the "client" option which is an alias/shortcut for "pull" and "tls-client", where "tls-client" is another secret mode.

The patch removes the "client" alias and replaces it with the "pull" option only.

[1] http://forum.pfsense.org/index.php/topic,58180.0.html
