### PR TITLE
Make sure we change ['disabled'] flag in rules_map when commenting/un-commenting rules

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -1200,7 +1200,7 @@ function snort_find_flowbit_required_rules(&$all_rules, &$unchecked_flowbits) {
 						else {
 							/* If rule is disabled, remove leading '#' to enable it */
 							$required_flowbits_rules[$k1][$k2]['rule'] = ltrim(substr($rule2['rule'], strpos($rule2['rule'], "#") + 1));
-							$required_flowbits_rules[$k1][$k2]['disabled'] = 1;
+							$required_flowbits_rules[$k1][$k2]['disabled'] = 0;
 						}
 					}
 				}


### PR DESCRIPTION
February 1, 2013

Change Log

Add fixes in the functions where we comment or un-comment rules to enable 
or disable them so that the corresponding ['disabled'] attribute in the rule map 
array is updated.

In the new preprocessor rule options dependency function, make a check first 
thing for already disabled rules and skip checking them against rule options 
because they are already disabled.
