### PR TITLE
Add GTP preprocessor and http_inspect_server profile options to PREPROCESSORS tab

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -1977,7 +1977,8 @@ function snort_generate_conf($snortcfg) {
 		"DCERPC_NCACN_IP_TCP" => "139,445", "DCERPC_NCADG_IP_UDP" => "138,1024:",
 		"DCERPC_NCACN_IP_LONG" => "135,139,445,593,1024:", "DCERPC_NCACN_UDP_LONG" => "135,1024:",
 		"DCERPC_NCACN_UDP_SHORT" => "135,593,1024:", "DCERPC_NCACN_TCP" => "2103,2105,2107",
-		"DCERPC_BRIGHTSTORE" => "6503,6504", "DNP3_PORTS" => "20000", "MODBUS_PORTS" => "502"
+		"DCERPC_BRIGHTSTORE" => "6503,6504", "DNP3_PORTS" => "20000", "MODBUS_PORTS" => "502",
+		"GTP_PORTS" => "2123,2152,3386"
 	);
 
 	$portvardef = "";
@@ -2002,6 +2003,10 @@ EOD;
 	if ((!empty($snortcfg['server_flow_depth'])) || ($snortcfg['server_flow_depth'] == '0'))
 		$def_server_flow_depth_type = $snortcfg['server_flow_depth'];
 
+	$http_server_profile = "all";
+	if (!empty($snortcfg['http_server_profile']))
+		$http_server_profile = $snortcfg['http_server_profile'];
+
 	$def_client_flow_depth_type = '300';
 	if ((!empty($snortcfg['client_flow_depth'])) || ($snortcfg['client_flow_depth'] == '0'))
 		$def_client_flow_depth_type = $snortcfg['client_flow_depth'];
@@ -2017,7 +2022,7 @@ EOD;
 # HTTP Inspect  #
 preprocessor http_inspect: global iis_unicode_map unicode.map 1252 compress_depth 65535 decompress_depth 65535
 
-preprocessor http_inspect_server: server default profile all {$noalert_http_inspect}\
+preprocessor http_inspect_server: server default profile {$http_server_profile} {$noalert_http_inspect}\
 	ports  { {$http_ports} }  \
 	http_methods { GET POST PUT SEARCH MKCOL COPY MOVE LOCK UNLOCK NOTIFY POLL BCOPY BDELETE BMOVE LINK UNLINK OPTIONS HEAD DELETE TRACE TRACK CONNECT SOURCE SUBSCRIBE UNSUBSCRIBE PROPFIND PROPPATCH BPROPFIND BPROPPATCH RPC_CONNECT PROXY_SUCCESS BITS_POST CCM_POST SMS_POST RPC_IN_DATA RPC_OUT_DATA RPC_ECHO_DATA } \
 	server_flow_depth {$def_server_flow_depth_type} \
@@ -2221,6 +2226,14 @@ preprocessor modbus: \
 	
 EOD;
 
+	/* def gtp_preprocessor */
+	$gtp_ports = str_replace(",", " ", $snort_ports['GTP_PORTS']);
+	$gtp_preproc = <<<EOD
+# GTP preprocessor #
+preprocessor gtp: ports { {$gtp_ports} }
+	
+EOD;
+
 	$def_ssl_ports_ignore = str_replace(",", " ", $snort_ports['ssl_ports']);
 	$ssl_preproc = <<<EOD
 # Ignore SSL and Encryption  #
@@ -2267,11 +2280,11 @@ EOD;
 	$snort_preproc_libs = array(
 		"dce_rpc_2" => "dce2_preproc", "dns_preprocessor" => "dns_preproc", "ftp_preprocessor" => "ftptelnet_preproc", "imap_preproc" => "imap_preproc",
 		"pop_preproc" => "pop_preproc", "reputation_preproc" => "reputation_preproc", "sensitive_data" => "sdf_preproc", 
-		"sip_preproc" => "sip_preproc", "smtp_preprocessor" => "smtp_preproc", "ssh_preproc" => "ssh_preproc", 
+		"sip_preproc" => "sip_preproc", "gtp_preproc" => "gtp_preproc", "smtp_preprocessor" => "smtp_preproc", "ssh_preproc" => "ssh_preproc", 
 		"ssl_preproc" => "ssl_preproc", "dnp3_preproc" => "dnp3_preproc", "modbus_preproc" => "modbus_preproc"
 	);
 	$snort_preproc = array (
-		"perform_stat", "http_inspect", "other_preprocs", "ftp_preprocessor", "smtp_preprocessor", "ssl_preproc", "sip_preproc",
+		"perform_stat", "http_inspect", "other_preprocs", "ftp_preprocessor", "smtp_preprocessor", "ssl_preproc", "sip_preproc", "gtp_preproc",
 		"sf_portscan", "dce_rpc_2", "dns_preprocessor", "sensitive_data", "pop_preproc", "imap_preproc", "dnp3_preproc", "modbus_preproc"
 	);
 	$snort_preprocessors = "";
@@ -2368,6 +2381,9 @@ config disable_ttcp_alerts
 config disable_tcpopt_alerts
 config disable_ipopt_alerts
 config disable_decode_drops
+
+# Enable the GTP decoder  #
+config enable_gtp
 
 # Configure PCRE match limitations
 config pcre_match_limit: 3500

--- a/config/snort/snort_define_servers.php
+++ b/config/snort/snort_define_servers.php
@@ -75,7 +75,7 @@ $snort_ports = array(
 "sip_ports" => "5060,5061", "auth_ports" => "113", "finger_ports" => "79",
 "irc_ports" => "6665,6666,6667,6668,6669,7000", "smb_ports" => "139,445",
 "nntp_ports" => "119", "rlogin_ports" => "513", "rsh_ports" => "514",
-"ssl_ports" => "443,465,563,636,989,990,992,993,994,995",
+"ssl_ports" => "443,465,563,636,989,990,992,993,994,995", "GTP_PORTS" => "2123,2152,3386",
 "file_data_ports" => "\$HTTP_PORTS,110,143", "shellcode_ports" => "!80",
 "sun_rpc_ports" => "111,32770,32771,32772,32773,32774,32775,32776,32777,32778,32779",
 "DCERPC_NCACN_IP_TCP" => "139,445", "DCERPC_NCADG_IP_UDP" => "138,1024:",

--- a/config/snort/snort_preprocessors.php
+++ b/config/snort/snort_preprocessors.php
@@ -56,6 +56,7 @@ if (isset($id) && $a_nat[$id]) {
 	/* new options */
 	$pconfig['perform_stat'] = $a_nat[$id]['perform_stat'];
 	$pconfig['server_flow_depth'] = $a_nat[$id]['server_flow_depth'];
+	$pconfig['http_server_profile'] = $a_nat[$id]['http_server_profile'];
 	$pconfig['client_flow_depth'] = $a_nat[$id]['client_flow_depth'];
 	$pconfig['max_queued_bytes'] = $a_nat[$id]['max_queued_bytes'];
 	$pconfig['max_queued_segs'] = $a_nat[$id]['max_queued_segs'];
@@ -75,6 +76,7 @@ if (isset($id) && $a_nat[$id]) {
 	$pconfig['sip_preproc'] = $a_nat[$id]['sip_preproc'];
 	$pconfig['dnp3_preproc'] = $a_nat[$id]['dnp3_preproc'];
 	$pconfig['modbus_preproc'] = $a_nat[$id]['modbus_preproc'];
+	$pconfig['gtp_preproc'] = $a_nat[$id]['gtp_preproc'];
 }
 
 if ($_POST) {
@@ -88,6 +90,7 @@ if ($_POST) {
 	if (!$input_errors) {
 		/* post new options */
 		if ($_POST['server_flow_depth'] != "") { $natent['server_flow_depth'] = $_POST['server_flow_depth']; }else{ $natent['server_flow_depth'] = ""; }
+		if ($_POST['http_server_profile'] != "") { $natent['http_server_profile'] = $_POST['http_server_profile']; }else{ $natent['http_server_profile'] = "all"; }
 		if ($_POST['client_flow_depth'] != "") { $natent['client_flow_depth'] = $_POST['client_flow_depth']; }else{ $natent['client_flow_depth'] = ""; }
 		if ($_POST['max_queued_bytes'] != "") { $natent['max_queued_bytes'] = $_POST['max_queued_bytes']; }else{ $natent['max_queued_bytes'] = ""; }
 		if ($_POST['max_queued_segs'] != "") { $natent['max_queued_segs'] = $_POST['max_queued_segs']; }else{ $natent['max_queued_segs'] = ""; }
@@ -116,6 +119,7 @@ if ($_POST) {
 		$natent['modbus_preproc'] = $_POST['modbus_preproc'] ? 'on' : 'off';
 		$natent['sip_preproc'] = $_POST['sip_preproc'] ? 'on' : 'off';
 		$natent['modbus_preproc'] = $_POST['modbus_preproc'] ? 'on' : 'off';
+		$natent['gtp_preproc'] = $_POST['gtp_preproc'] ? 'on' : 'off';
 
 		if (isset($id) && $a_nat[$id])
 			$a_nat[$id] = $natent;
@@ -221,7 +225,7 @@ include_once("head.inc");
 			<tr>
 				<td><input name="server_flow_depth" type="text" class="formfld"
 					id="flow_depth" size="6"
-					value="<?=htmlspecialchars($pconfig['server_flow_depth']);?>"> <?php echo gettext("<strong>-1</strong> " .
+					value="<?=htmlspecialchars($pconfig['server_flow_depth']);?>">&nbsp;&nbsp;<?php echo gettext("<strong>-1</strong> " .
 				"to <strong>65535</strong> (<strong>-1</strong> disables HTTP " .
 				"inspect, <strong>0</strong> enables all HTTP inspect)"); ?></td>
 			</tr>
@@ -230,6 +234,23 @@ include_once("head.inc");
 		"performance may increase by adjusting this value."); ?><br>
 		<?php echo gettext("Setting this value too low may cause false negatives. Values above 0 " .
 		"are specified in bytes.  Recommended setting is maximum (65535). Default value is <strong>300</strong>"); ?><br>
+		</td>
+	</tr>
+	<tr>
+		<td width="22%" valign="top" class="vncell"><?php echo gettext("HTTP server profile"); ?> </td>
+		<td width="78%" class="vtable">
+			<select name="http_server_profile" class="formselect" id="http_server_profile">
+			<?php
+			$profile = array('All', 'Apache', 'IIS', 'IIS_4.0', 'IIS_5.0');
+			foreach ($profile as $val): ?>
+			<option value="<?=strtolower($val);?>"
+			<?php if (strtolower($val) == $pconfig['http_server_profile']) echo "selected"; ?>>
+				<?=gettext($val);?></option>
+				<?php endforeach; ?>
+			</select>&nbsp;&nbsp;<?php echo gettext("Choose the profile type of the protected web server."); ?><br>
+			<?php echo gettext(" The default is <strong>All</strong>.  "); ?>
+			<?php echo gettext("IIS_4.0 and IIS_5.0 are identical to IIS except they alert on the "); ?>
+			<?php echo gettext("double decoding vulnerability present in those two versions."); ?><br>
 		</td>
 	</tr>
 	<tr>
@@ -348,7 +369,7 @@ include_once("head.inc");
 		<td width="78%" class="vtable">
 			<input name="pscan_ignore_scanners" type="text" size="40" autocomplete="off"  class="formfldalias" id="pscan_ignore_scanners"
 			value="<?=$pconfig['pscan_ignore_scanners'];?>"> <br><?php echo gettext("Ignores the specified entity as a source of scan alerts.  Entity must be a defined alias.");?><br>
-			<?php echo gettext("Default value: \$HOME_NET"); ?><?php echo gettext("  Leave " .
+			<?php echo gettext("Default value: \$HOME_NET."); ?><?php echo gettext("  Leave " .
 			"blank for default value."); ?>
 		</td>
 	<tr>
@@ -416,6 +437,15 @@ include_once("head.inc");
 			<?php if ($pconfig['sip_preproc']=="on") echo "checked"; ?>
 			onClick="enable_change(false)"><br>
 		<?php echo gettext("The SIP preprocessor decodes SIP traffic and detects some vulnerabilities."); ?></td>
+	</tr>
+	<tr>
+		<td width="22%" valign="top" class="vncell"><?php echo gettext("Enable"); ?> <br>
+		<?php echo gettext("GTP Detection"); ?></td>
+		<td width="78%" class="vtable"><input name="gtp_preproc"
+			type="checkbox" value="on"
+			<?php if ($pconfig['gtp_preproc']=="on") echo "checked"; ?>
+			onClick="enable_change(false)"><br>
+		<?php echo gettext("The GTP preprocessor decodes GPRS Tunneling Protocol traffic and detects intrusion attempts."); ?></td>
 	</tr>
 	<tr>
 		<td width="22%" valign="top" class="vncell"><?php echo gettext("Enable"); ?> <br>


### PR DESCRIPTION
February 1, 2013
# Change Log

Added new GUI configuration option to PREPROCESSORS tab for the GTP 
preprocessor.  Customization for GTP ports was added to the VARIABLES 
tab.  The GTP decoder was also enabled in snort.conf.  GTP is the GPRS 
Tunneling Protocol.

Added an addtional option under the http_inspect preprocessor to allow the 
selection of a profile to associate with the protected/screened web server.  
The five server profile options are:

```
All (default if no other is chosen)
Apache
IIS
IIS_4.0
IIS_5.0
```

Choosing a server profile allows Snort to automatically select certain 
options tailored for the target platform.  See the Snort manual for details.
