### PR TITLE
Fix urlfilter_enable typo

### DIFF
--- a/config/squid/squid_ng.inc
+++ b/config/squid/squid_ng.inc
@@ -47,7 +47,7 @@ function global_write_squid_config()
     $active_interface      = $config['installedpackages']['squid']['config'][0]['active_interface'];
     $transparent_proxy     = $config['installedpackages']['squid']['config'][0]['transparent_proxy'];
     $log_enabled           = $config['installedpackages']['squid']['config'][0]['log_enabled'];
-    $urlfier_enable        = $config['installedpackages']['squid']['config'][0]['urlfilter_enable'];
+    $urlfilter_enable      = $config['installedpackages']['squid']['config'][0]['urlfilter_enable'];
     $accesslog_disabled    = $config['installedpackages']['squid']['config'][0]['accesslog_disabled'];
     $log_query_terms       = $config['installedpackages']['squid']['config'][0]['log_query_terms'];
     $log_user_agents       = $config['installedpackages']['squid']['config'][0]['log_user_agents'];
@@ -560,7 +560,7 @@ function global_write_squid_config()
 
 		$config_array[] = 'acl pf_banned_ip src "/usr/local/etc/squid/advanced/acls/src_banned_ip.acl"' . "\n";
 	}
-	unset($banned_ip_addr);
+	unset($banned_ip_array);
 	unset($banned_ip_addr);
 	unset($ind_banned_ip);
 


### PR DESCRIPTION
I noticed this typo while looking at other code. I guess that when people have set the urlfilter_enable checkbox, it has not been actually implementing it all this time. Maybe nobody actually uses this option?
The question is, what if someone has checked this box and now the code is fixed and it suddenly starts working? Will that make a problem for anyone?
Also noticed a repeated unset command that I fixed up.
I suspect that this little fix is not worth a version bump.
