### PR TITLE
updated HAProxy package to work with pfSense 2.1

### DIFF
--- a/config/haproxy/haproxy.inc
+++ b/config/haproxy/haproxy.inc
@@ -58,6 +58,9 @@ $a_acltypes[] = array('name' => 'path_contains', 'descr' => 'Path contains',
 $a_acltypes[] = array('name' => 'source_ip', 'descr' => 'Source IP',
 				'mode' => '', 'syntax' => 'src');
 
+//$a_acltypes[] = array('name' => 'ssl_sni_matches',  'descr' => 'Server Name Indication TLS extension matches', 
+//				'mode' => 'https', 'syntax' => 'req_ssl_sni -i');
+
 function haproxy_custom_php_deinstall_command() {
 	exec("cd /var/db/pkg && pkg_delete `ls | grep haproxy`");
 	exec("rm /usr/local/pkg/haproxy.inc");
@@ -186,7 +189,7 @@ EOD;
 			/* link to frontend */
 			foreach ($a_backends as $id => $be) {
 				if ($a_backends[$id]['name'] == $oldserver['backend']) {
-					$a_backends[$id]['pool'] = $pool['name'];
+					$a_backends[$id]['backend_serverpool'] = $pool['name'];
 					$pool['monitor_uri'] = $be['monitor_uri'];
 					unset($a_backends[$id]['monitor_uri']);
 					break;
@@ -199,6 +202,29 @@ EOD;
 			$a_pools[] = $pool;
 		}
 		unset($config['installedpackages']['haproxy']['ha_servers']);
+		write_config();
+	}
+	
+	/* XML update to: pkg v1.3 and 'pool' changed to 'backend_serverpool' because 'pool' was added to listtags() in xmlparse.inc */
+	if (is_array($config['installedpackages']['haproxy']['ha_backends']['item'][0]['pool']))
+	{
+		foreach($config['installedpackages']['haproxy']['ha_backends']['item'] as &$frontend)
+		{
+			$backend_serverpool = $frontend['pool'][0];
+			$frontend['backend_serverpool'] = $backend_serverpool;
+			unset($frontend['pool']);
+		}
+		write_config();
+	}
+	//also move setting for existing 2.0 installations as only the new variable is used 
+	if (isset($config['installedpackages']['haproxy']['ha_backends']['item'][0]['pool']))
+	{
+		foreach($config['installedpackages']['haproxy']['ha_backends']['item'] as &$frontend)
+		{
+			$backend_serverpool = $frontend['pool'];
+			$frontend['backend_serverpool'] = $backend_serverpool;
+			unset($frontend['pool']);
+		}
 		write_config();
 	}
 
@@ -420,7 +446,7 @@ function haproxy_writeconf() {
 		foreach ($a_backends as $backend) {
 			if($backend['status'] != 'active')
 				continue;
-			if(!$backend['pool'])
+			if(!$backend['backend_serverpool'])
 				continue;
 
 			$bname = $backend['extaddr'] . ":" . $backend['port'];
@@ -519,7 +545,7 @@ function haproxy_writeconf() {
 				if(!is_array($a_acl)) 
 					$a_acl=array();
 			
-				$poolname = $bconfig['pool'] . "_" . strtolower($bconfig['type']);
+				$poolname = $bconfig['backend_serverpool'] . "_" . strtolower($bconfig['type']);
 
 				// Create different pools if the svrport is set
 				if ($bconfig['svrport'] > 0)
@@ -564,7 +590,7 @@ function haproxy_writeconf() {
 	if (is_array($a_pendingpl) && is_array($a_pools)) {
 		foreach ($a_pendingpl as $pending) {
 			foreach ($a_pools as $pool) {
-				if ($pending['frontend']['pool'] == $pool['name']) {
+				if ($pending['frontend']['backend_serverpool'] == $pool['name']) {
 					write_backend($fd, $pending['name'], $pool, $pending['frontend']);
 				}
 			}

--- a/config/haproxy/haproxy_listeners.php
+++ b/config/haproxy/haproxy_listeners.php
@@ -140,7 +140,7 @@ include("head.inc");
 					<?=$textss . $backend['type'] . $textse;?>
                   </td>
                   <td class="listlr" ondblclick="document.location='haproxy_listeners_edit.php?id=<?=$i;?>';">
-					<?=$textss . $backend['pool'] . $textse;?>
+					<?=$textss . $backend['backend_serverpool'] . $textse;?>
                   </td>
                   <td class="list" nowrap>
                     <table border="0" cellspacing="0" cellpadding="1">

--- a/config/haproxy/haproxy_listeners_edit.php
+++ b/config/haproxy/haproxy_listeners_edit.php
@@ -83,7 +83,7 @@ if (isset($id) && $a_backend[$id]) {
 	
 	$pconfig['type'] = $a_backend[$id]['type'];
 	$pconfig['extaddr'] = $a_backend[$id]['extaddr'];	
-	$pconfig['pool'] = $a_backend[$id]['pool'];	
+	$pconfig['backend_serverpool'] = $a_backend[$id]['backend_serverpool'];	
 	$pconfig['max_connections'] = $a_backend[$id]['max_connections'];	
 	$pconfig['client_timeout'] = $a_backend[$id]['client_timeout'];	
 	$pconfig['port'] = $a_backend[$id]['port'];	
@@ -218,7 +218,7 @@ if ($_POST) {
 		update_if_changed("port", $backend['port'], $_POST['port']);
 		update_if_changed("svrport", $backend['svrport'], $_POST['svrport']);
 		update_if_changed("extaddr", $backend['extaddr'], $_POST['extaddr']);
-		update_if_changed("pool", $backend['pool'], $_POST['pool']);
+		update_if_changed("backend_serverpool", $backend['backend_serverpool'], $_POST['backend_serverpool']);
 		update_if_changed("max_connections", $backend['max_connections'], $_POST['max_connections']);
 		update_if_changed("client_timeout", $backend['client_timeout'], $_POST['client_timeout']);
 		update_if_changed("advanced", $backend['advanced'], base64_encode($_POST['advanced']));
@@ -507,22 +507,19 @@ include("head.inc");
 			</td>
 		</tr>
 		<tr>
-			  <td width="22%" valign="top" class="vncellreq">Server pool</td>
+			  <td width="22%" valign="top" class="vncellreq">Backend server pool</td>
 			  <td width="78%" class="vtable">
-				<select name="pool" class="formfld">
+			  
+				<select id="backend_serverpool" name="backend_serverpool" class="formfld">
 				<?php
 					if (is_array($a_pools)) {
-						foreach ($a_pools as $p): 
-				?>
-					<option value="<?=$p['name'];?>" <?php if ($p['name'] == $pconfig['pool']) echo "selected"; ?>>
-						<?=htmlspecialchars("{$p['name']}");?>
-					</option>
-				<?php
-						endforeach;
+						foreach ($a_pools as $p) {
+							$selected = $p['name'] == $pconfig['backend_serverpool'] ? 'selected' : '';
+							$name = htmlspecialchars("{$p['name']}");
+							echo "<option value=\"{$p['name']}\" $selected>$name</option>";
+						}
 					} else { 	
-				?>
-					<option value="-">-</option>
-				<?php
+						echo "<option value=\"-\">-</option>";
 					}
 				?>
 				</select>

--- a/config/haproxy/haproxy_pool_edit.php
+++ b/config/haproxy/haproxy_pool_edit.php
@@ -133,8 +133,8 @@ if ($_POST) {
 			$a_backend = &$config['installedpackages']['haproxy']['ha_backends']['item'];
 
 			for ( $i = 0; $i < count($a_backend); $i++) {
-				if ($a_backend[$i]['pool'] == $pool['name'])
-					$a_backend[$i]['pool'] = $_POST['name'];
+				if ($a_backend[$i]['backend_serverpool'] == $pool['name'])
+					$a_backend[$i]['backend_serverpool'] = $_POST['name'];
 			}
 		}
 

--- a/config/haproxy/haproxy_pools.php
+++ b/config/haproxy/haproxy_pools.php
@@ -114,7 +114,7 @@ include("head.inc");
 		 $fe_list = "";
 		 $sep = "";
 		 foreach ($a_backends as $backend) {
-			 if($backend['pool'] == $pool['name']) {
+			 if($backend['backend_serverpool'] == $pool['name']) {
 				 $fe_list .= $sep . $backend['name'];
 				 $sep = ", ";
 			 }


### PR DESCRIPTION
updated HAProxy package to work with pfSense 2.1

'pool' changed to 'backend_serverpool' because 'pool' was added to listtags() in xmlparse.inc so it will work with pfSense 2.1
