### PR TITLE
Open the Access Bandwidthd UI in a new tab

### DIFF
--- a/config/bandwidthd/bandwidthd.xml
+++ b/config/bandwidthd/bandwidthd.xml
@@ -46,7 +46,7 @@
     <requirements>Describe your package requirements here</requirements>
     <faq>Currently there are no FAQ items provided.</faq>
 	<name>bandwidthd</name>
-	<version>1.0</version>
+	<version>2.0.1.4</version>
 	<title>Bandwidthd</title>
 	<aftersaveredirect>/pkg_edit.php?xml=bandwidthd.xml&amp;id=0</aftersaveredirect>
 	<include_file>/usr/local/pkg/bandwidthd.inc</include_file>
@@ -69,7 +69,7 @@
 		</tab>
 		<tab>
 			<text>Access BandwidthD</text>
-			<url>/bandwidthd</url>
+			<url>/bandwidthd" target="_blank</url>
 		</tab>
 	</tabs>
 	<configpath>installedpackages->package->bandwidthd</configpath>


### PR DESCRIPTION
The Access Bandwidthd tab takes the user completely out of the pfSense WebGUI interface when clicked. This behaviour is not user-friendly. IMHO it is better to open the Bandwidthd UI in a new tab.
Note: the syntax of the double-quotes looks a bit odd - but the underlying package processing functions put double-quotes around the whole thing and it works out!
