### PR TITLE
bandwidthd on nanobsd - put legend and logo files in place

### DIFF
--- a/config/bandwidthd/bandwidthd.inc
+++ b/config/bandwidthd/bandwidthd.inc
@@ -252,7 +252,12 @@ if [ ! -L "{$bandwidthd_nano_dir}/etc" ] ; then
 	fi
 	/bin/ln -s {$bandwidthd_config_dir} {$bandwidthd_nano_dir}/etc
 fi
-
+if [ ! -f "{$bandwidthd_htdocs_dir}/legend.gif" ] ; then
+	/bin/cp {$bandwidthd_base_dir}/htdocs/legend.gif {$bandwidthd_htdocs_dir}
+fi
+if [ ! -f "{$bandwidthd_htdocs_dir}/logo.gif" ] ; then
+	/bin/cp {$bandwidthd_base_dir}/htdocs/logo.gif {$bandwidthd_htdocs_dir}
+fi
 cd {$bandwidthd_nano_dir}
 {$bandwidthd_nano_dir}/bandwidthd
 cd -


### PR DESCRIPTION
legend.gif and logo.gif were missing from the report/graph page. They need to be put in /var/bandwidthd/htdocs
