### PR TITLE
haproxy-devel, removed cert filtering, server options, fixed saving global advanced setting.

### DIFF
--- a/config/haproxy-devel/haproxy.inc
+++ b/config/haproxy-devel/haproxy.inc
@@ -32,7 +32,6 @@ require_once("functions.inc");
 require_once("pkg-utils.inc");
 require_once("notices.inc");
 
-
 global $haproxy_sni_ssloffloading;
 $haproxy_sni_ssloffloading=true;// can only be used with recent 1.5-dev17 builds.
 
@@ -439,7 +438,7 @@ function write_backend($fd, $name, $pool, $frontend) {
 				$isbackup = "";
 			}
 			$ssl = ($backend_type == "http" && $be['ssl'] == 'yes') ? ' ssl' : "";
-			fwrite ($fd, "\tserver\t\t\t" . $be['name'] . " " . $be['address'].":" . $be['port'] . "$ssl $cookie $checkinter $isbackup weight " . $be['weight'] . "{$advanced_txt}\n");
+			fwrite ($fd, "\tserver\t\t\t" . $be['name'] . " " . $be['address'].":" . $be['port'] . "$ssl $cookie $checkinter $isbackup weight " . $be['weight'] . "{$advanced_txt} {$be['advanced']}\n");
 		}
 	}
 	fwrite ($fd, "\n");
@@ -451,12 +450,20 @@ function haproxy_configure() {
 	return haproxy_check_run(1);
 }
 
-function haproxy_check_writtenconfig_error() {
-	$configcheckoutput = shell_exec("haproxy -c -V -f /var/etc/haproxy.cfg 2>&1");
-	if (!strstr($configcheckoutput, "Configuration file is valid"))
-		return str_replace("\n","<br/>\n", $configcheckoutput);
-	else
-		return false;
+function haproxy_check_writtenconfig_error(&$messages) {
+	$retval = exec("haproxy -c -V -f /var/etc/haproxy.cfg 2>&1", $output, $err);
+	$messages = "";
+	if ($err > 1)
+		$messages = "<h2><strong>FATAL ERROR CODE: $err while starting haproxy</strong></h2>";
+	elseif ($err == 1)
+		$messages = "Errors found while starting haproxy";
+		
+	if ((count($output) > 1) && $output[0] != "Configuration file is valid")
+	{
+		foreach($output as $line)
+			$messages .= "<br/>" . htmlspecialchars($line) . "\n";
+	}
+	return (strstr($retval, "Configuration file is valid"));
 }
 
 function haproxy_writeconf() {
@@ -540,6 +547,7 @@ function haproxy_writeconf() {
 				$b['max_connections'] = $backend['max_connections'];
 				$b['client_timeout'] = $backend['client_timeout'];
 				$b['advanced'] = $backend['advanced'];
+				$b['ssloffload'] = $backend['ssloffload'];
 			}
 			
 			if ($ssl_crt != "") {
@@ -594,7 +602,7 @@ function haproxy_writeconf() {
 			}
 
 			// https is an alias for tcp for clarity purpouses
-			if(strtolower($bind['type']) == "https") {
+			if($bind['type'] == "https") {
 				$backend_type = "tcp";
 			} else {
 				$backend_type = $bind['type'];
@@ -604,12 +612,18 @@ function haproxy_writeconf() {
 			fwrite ($fd, "\tlog\t\t\tglobal\n");
 			fwrite ($fd, "\toption\t\t\tdontlognull\n");
 
-			if($bind['httpclose']) 
-				fwrite ($fd, "\toption\t\t\thttpclose\n");
+			if ($backend_type == 'http')
+			{
+				if($bind['httpclose']) 
+					fwrite ($fd, "\toption\t\t\thttpclose\n");
 
-			if($bind['forwardfor']) {
-				fwrite ($fd, "\toption\t\t\tforwardfor\n");
-				fwrite ($fd, "\treqadd X-Forwarded-Proto:\ https\tif { ssl_fc }\n");
+				if($bind['forwardfor']) {
+					fwrite ($fd, "\toption\t\t\tforwardfor\n");
+					if($bind['ssloffload'] == "yes")
+						fwrite ($fd, "\treqadd X-Forwarded-Proto:\ https\n");
+					else
+						fwrite ($fd, "\treqadd X-Forwarded-Proto:\ http\n");
+				}
 			}
 
 			if($bind['max_connections'])
@@ -678,7 +692,6 @@ function haproxy_writeconf() {
 						$advancedextra[$acl['syntax']] = $acl['advancedoptions']."\n";
 					$i++;
 				}
-
 			}
 			foreach($advancedextra as $extra)
 				fwrite ($fd, "\t".$extra."\n");
@@ -717,7 +730,10 @@ function haproxy_writeconf() {
 	fclose($fd);
 
 	if ($input_errors)
+	{
+		require_once("guiconfig.inc");
 		print_input_errors($input_errors);
+	}
 	
 	if (isset($a_global['carpdev']))
 		haproxy_install_cron(true);
@@ -961,6 +977,30 @@ function get_haproxy_frontends($excludeitem="") {
 		$result[$frontend['name']]['ref'] = &$frontend;
 	}
 	asort($result, SORT_STRING);
+	return $result;
+}
+
+function get_frontent_acls($frontend) {
+	$result = array();
+	$a_acl = &$frontend['ha_acls']['item'];
+	if (is_array($a_acl))
+	{
+		foreach ($a_acl as $entry) {
+			$acl = haproxy_find_acl($entry['expression']);
+			if (!$acl)
+				continue;
+
+			// Filter out acls for different modes
+			if ($acl['mode'] != '' && $acl['mode'] != strtolower($frontend['type']))
+				continue;
+			
+			$acl_item = array();
+			$acl_item['descr'] = $acl['descr'] . " " . $entry['value'];
+			$acl_item['ref'] = $entry;
+			
+			$result[] = $acl_item;
+		}
+	}
 	return $result;
 }
 

--- a/config/haproxy-devel/haproxy_global.php
+++ b/config/haproxy-devel/haproxy_global.php
@@ -49,13 +49,10 @@ if ($_POST) {
 		$retval = haproxy_configure();
 		config_unlock();
 
-		$result = haproxy_check_writtenconfig_error();
+		$result = haproxy_check_writtenconfig_error($messages);
+		$savemsg = $messages;
 		if ($result)
-			$savemsg = gettext($result);
-		else {
-			$savemsg = get_std_save_message($retval);
 			unlink_if_exists($d_haproxyconfdirty_path);
-		}
 	} else {
 		if ($_POST['enable']) {
 			$reqdfields = explode(" ", "maxconn");
@@ -89,7 +86,7 @@ if ($_POST) {
 			$config['installedpackages']['haproxy']['loglevel'] = $_POST['loglevel'] ? $_POST['loglevel'] : false;
 			$config['installedpackages']['haproxy']['carpdev'] = $_POST['carpdev'] ? $_POST['carpdev'] : false;
 			$config['installedpackages']['haproxy']['syncpassword'] = $_POST['syncpassword'] ? $_POST['syncpassword'] : false;
-			$config['installedpackages']['haproxy']['advanced'] = base64_encode($_POST['advanced']) ? $_POST['advanced'] : false;
+			$config['installedpackages']['haproxy']['advanced'] = $_POST['advanced'] ? base64_encode($_POST['advanced']) : false;
 			$config['installedpackages']['haproxy']['nbproc'] = $_POST['nbproc'] ? $_POST['nbproc'] : false;			
 			touch($d_haproxyconfdirty_path);
 			write_config();
@@ -146,7 +143,7 @@ function enable_change(enable_change) {
 <?php if ($input_errors) print_input_errors($input_errors); ?>
 <?php if ($savemsg) print_info_box($savemsg); ?>
 <?php if (file_exists($d_haproxyconfdirty_path)): ?><p>
-<?php print_info_box_np("The load balancer configuration has been changed.<br>You must apply the changes in order for them to take effect.");?><br>
+<?php print_info_box_np("The haproxy configuration has been changed.<br>You must apply the changes in order for them to take effect.");?><br>
 <?php endif; ?>
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 	<tr><td class="tabnavtbl">
@@ -344,7 +341,7 @@ function enable_change(enable_change) {
 			<tr>
 				<td width="22%" valign="top" class="vncell">Synchronization password</td>
 				<td width="78%" class="vtable">
-					<input name="syncpassword" type="password" value="<?=$pconfig['syncpassword'];?>">
+					<input name="syncpassword" type="password" autocomplete="off" value="<?=$pconfig['syncpassword'];?>">
 					<br/>
 					<strong>Enter the password that will be used during configuration synchronization.  This is generally the remote webConfigurator password.</strong>
 				</td>

--- a/config/haproxy-devel/haproxy_listeners.php
+++ b/config/haproxy-devel/haproxy_listeners.php
@@ -50,13 +50,10 @@ if ($_POST) {
 		$retval = haproxy_configure();
 		config_unlock();
 
-		$result = haproxy_check_writtenconfig_error();
+		$result = haproxy_check_writtenconfig_error($messages);
+		$savemsg = $messages;
 		if ($result)
-			$savemsg = gettext($result);
-		else {
-			$savemsg = get_std_save_message($retval);
 			unlink_if_exists($d_haproxyconfdirty_path);
-		}
 	}
 } else {
 	$result = haproxy_check_config($retval);
@@ -96,7 +93,7 @@ include("head.inc");
 <?php if ($input_errors) print_input_errors($input_errors); ?>
 <?php if ($savemsg) print_info_box($savemsg); ?>
 <?php if (file_exists($d_haproxyconfdirty_path)): ?><p>
-<?php print_info_box_np("The virtual server configuration has been changed.<br>You must apply the changes in order for them to take effect.");?><br>
+<?php print_info_box_np("The haproxy configuration has been changed.<br>You must apply the changes in order for them to take effect.");?><br>
 <?php endif; ?>
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr><td class="tabnavtbl">
@@ -161,6 +158,15 @@ include("head.inc");
 					$cert = lookup_cert($backend['ssloffloadcert']);?>
 					<img src="<?=$certimg;?>" alt="SSL offloading" title="SSL offloading cert: '<?=$cert['descr'];?>'" border="0" height="16" width="16" />
 				<? endif;?>
+				<?
+				$acls = get_frontent_acls($backend);
+				$isadvset = "";
+				foreach ($acls as $acl) {
+					$isadvset .= "&#10;" . $acl['descr'];
+				}
+				if ($isadvset) 
+					echo "<img src=\"./themes/{$g['theme']}/images/icons/icon_advanced.gif\" title=\"" . gettext("advanced settings set") . ": {$isadvset}\" border=\"0\">";
+				?>
 			  </td>
 			  <td class="listlr" ondblclick="document.location='haproxy_listeners_edit.php?id=<?=$backendname;?>';">
 				<?=$backend['name'];?>

--- a/config/haproxy-devel/haproxy_listeners_edit.php
+++ b/config/haproxy-devel/haproxy_listeners_edit.php
@@ -76,8 +76,8 @@ function get_certificates_server($get_includeWebCert=false) {
 			continue;
 
 		$purpose = cert_get_purpose($cert['crt']);
-		if ($purpose['server'] != 'Yes')
-			continue;
+		//$certserverpurpose = $purpose['server'] == 'Yes' ? " [Server certificate]" : "";
+		$certserverpurpose = "";
 
 		$selected = "";
 		$caname = "";
@@ -101,7 +101,7 @@ function get_certificates_server($get_includeWebCert=false) {
 		if ($usagestr != "")
 			$usagestr = " (".trim($usagestr).")";
 		
-		$certificates[$cert['refid']]['name'] = $cert['descr'] . $caname . $inuse . $revoked . $usagestr;
+		$certificates[$cert['refid']]['name'] = $cert['descr'] . $caname . $certserverpurpose . $inuse . $revoked . $usagestr;
 	}
 	return $certificates;
 }
@@ -607,7 +607,11 @@ include("head.inc");
 					<option value="https"<?php if($pconfig['type'] == "https") echo " SELECTED"; ?>>HTTPS</option>
 					<option value="tcp"<?php if($pconfig['type'] == "tcp") echo " SELECTED"; ?>>TCP</option>
 					<option value="health"<?php if($pconfig['type'] == "health") echo " SELECTED"; ?>>Health</option>
-				</select>
+				</select><br/>
+				<span class="vexpl">
+					This defines the processing type of HAProxy, and will determine the availabe options for acl checks and also several other options.<br/>
+					Please note that for https encryption/decryption on HAProxy with a certificate the processing type needs to be set to 'http'.
+				</span>
 			</td>
 		</tr>
 		<tr>
@@ -679,7 +683,7 @@ include("head.inc");
 				<div>the time (in milliseconds) we accept to wait for data from the client, or for the client to accept data (default 30000).</div>
 			</td>
 		</tr>
-		<tr align="left">
+		<tr align="left" class="haproxy_mode_http">
 			<td width="22%" valign="top" class="vncell">Use 'forwardfor' option</td>
 			<td width="78%" class="vtable" colspan="2">
 				<input id="forwardfor" name="forwardfor" type="checkbox" value="yes" <?php if ($pconfig['forwardfor']=='yes') echo "checked"; ?>>
@@ -693,7 +697,7 @@ include("head.inc");
 				it is important to ensure that option httpclose is set when using this option.
 			</td>
 		</tr>
-		<tr align="left">
+		<tr align="left" class="haproxy_mode_http">
 			<td width="22%" valign="top" class="vncell">Use 'httpclose' option</td>
 			<td width="78%" class="vtable" colspan="2">
 				<input id="httpclose" name="httpclose" type="checkbox" value="yes" <?php if ($pconfig['httpclose']=='yes') echo "checked"; ?>>

--- a/config/haproxy-devel/haproxy_pool_edit.php
+++ b/config/haproxy-devel/haproxy_pool_edit.php
@@ -110,23 +110,24 @@ if ($_POST) {
 
 	$a_servers=array();			
 	for($x=0; $x<99; $x++) {
-		$server_name=$_POST['server_name'.$x];
-		$server_address=$_POST['server_address'.$x];
-		$server_port=$_POST['server_port'.$x];
-		$server_ssl=$_POST['server_ssl'.$x];
-		$server_weight=$_POST['server_weight'.$x];
-		$server_status=$_POST['server_status'.$x];
+		$server_name     = $_POST['server_name'.$x];
+		$server_address  = $_POST['server_address'.$x];
+		$server_port     = $_POST['server_port'.$x];
+		$server_ssl      = $_POST['server_ssl'.$x];
+		$server_weight   = $_POST['server_weight'.$x];
+		$server_status   = $_POST['server_status'.$x];
+		$server_advanced = $_POST['server_advanced'.$x];
 
 		if ($server_address) {
-
-			$server=array();
-			$server['name']=$server_name;
-			$server['address']=$server_address;
-			$server['port']=$server_port;
-			$server['ssl']=$server_ssl;
-			$server['weight']=$server_weight;
-			$server['status']=$server_status;
-			$a_servers[]=$server;
+			$server = array();
+			$server['name']     = $server_name;
+			$server['address']  = $server_address;
+			$server['port']     = $server_port;
+			$server['ssl']      = $server_ssl;
+			$server['weight']   = $server_weight;
+			$server['status']   = $server_status;
+			$server['advanced'] = $server_advanced;
+			$a_servers[] = $server;
 
 			if (preg_match("/[^a-zA-Z0-9\.\-_]/", $server_name))
 				$input_errors[] = "The field 'Name' contains invalid characters.";
@@ -134,10 +135,10 @@ if ($_POST) {
 				$input_errors[] = "The field 'Address' contains invalid characters.";
 
 			if (!preg_match("/.{2,}/", $server_name))
-				$input_errors[] = "The field 'Name' is required.";
+				$input_errors[] = "The field 'Name' is required (and must be at least 2 characters).";
 
 			if (!preg_match("/.{2,}/", $server_address))
-				$input_errors[] = "The field 'Address' is required.";
+				$input_errors[] = "The field 'Address' is required (and must be at least 2 characters).";
 
 
 			if (!is_numeric($server_weight))
@@ -167,7 +168,7 @@ if ($_POST) {
 		}
 
 		if($pool['name'] != "")
-			$changedesc .= " modified '{$pool['name']}' pool:";
+			$changedesc .= " modified pool: '{$pool['name']}'";
 
 		$pool['ha_servers']['item']=$a_servers;
 
@@ -304,12 +305,13 @@ row_helper();
 			
 			<table class="" width="100%" cellpadding="0" cellspacing="0" id='servertable'>
 	                <tr>
-	                  <td width="30%" class="listhdrr">Name</td>
-	                  <td width="30%" class="listhdrr">Address</td>
-	                  <td width="18%" class="listhdrr">Port</td>
+	                  <td width="20%" class="listhdrr">Name</td>
+	                  <td width="10%" class="listhdrr">Address</td>
+	                  <td width="5%" class="listhdrr">Port</td>
 	                  <td width="5%" class="listhdrr">SSL</td>
 	                  <td width="8%" class="listhdrr">Weight</td>
 	                  <td width="5%" class="listhdr">Backup</td>
+	                  <td width="15%" class="listhdr">Advanced</td>
 	                  <td width="4%" class=""></td>
 			</tr>
 			<?php 
@@ -322,13 +324,14 @@ row_helper();
 			$counter=0;
 			foreach ($a_servers as $server) {
 			?>
-			<tr id="tr_view_<?=$counter;?>" name="tr_view_<?=$counter;?>">
+			<tr id="tr_view_<?=$counter;?>" name="tr_view_<?=$counter;?>" ondblclick="editRow(<?=$counter;?>); return false;" >
 			<td class="vtable listlr"><?=$server['name']; ?></td>
 			<td class="vtable listr"><?=$server['address']; ?></td>
 			<td class="vtable listr"><?=$server['port']; ?></td>
 			<td class="vtable listr"><?=$server['ssl']=='yes'?'yes':'no'; ?></td>
 			<td class="vtable listr"><?=$server['weight']; ?></td>
 			<td class="vtable listr"><?=$server['status']; ?></td>
+			<td class="vtable listr"><?=htmlspecialchars($server['advanced']); ?></td>
 			<td class="list">
 			  <table border="0" cellspacing="0" cellpadding="1"><tr>
 			  <td valign="middle">
@@ -346,7 +349,7 @@ row_helper();
 				<td class="vtable">
 				  <input name="server_name<?=$counter;?>" id="server_name<?=$counter;?>" type="text" value="<?=$server['name']; ?>" size="30"/></td>
 				<td class="vtable">
-				  <input name="server_address<?=$counter;?>" id="server_address<?=$counter;?>" type="text" value="<?=$server['address']; ?>" size="30"/></td>
+				  <input name="server_address<?=$counter;?>" id="server_address<?=$counter;?>" type="text" value="<?=$server['address']; ?>" size="20"/></td>
 				<td class="vtable">
 				  <input name="server_port<?=$counter;?>" id="server_port<?=$counter;?>" type="text" value="<?=$server['port']; ?>" size="5"/></td>
 				<td class="vtable">
@@ -355,12 +358,14 @@ row_helper();
 				  <input name="server_weight<?=$counter;?>" id="server_weight<?=$counter;?>" type="text" value="<?=$server['weight']; ?>" size="5"/></td>
 				<td class="vtable">
 				<select name="server_status<?=$counter;?>" id="server_status<?=$counter;?>">
-				  <option value="active"  <?php if($server['status']=='active') echo "SELECTED";?>>active</option>
+				  <option value="active" <?php if($server['status']=='active') echo "SELECTED";?>>active</option>
 				  <option value="backup" <?php  if($server['status']=='backup') echo "SELECTED";?>>backup</option>
 				  <option value="disabled" <?php  if($server['status']=='disabled') echo "SELECTED";?>>disabled</option>
 				  <option value="inactive" <?php  if($server['status']=='inactive') echo "SELECTED";?>>inactive</option>
 				</select>
 				</td>
+				<td class="vtable">
+				  <input name="server_advanced<?=$counter;?>" id="server_advanced<?=$counter;?>" type="text" value="<?=htmlspecialchars($server['advanced']); ?>" size="20"/></td>
 				<td class="list">
 			         <table border="0" cellspacing="0" cellpadding="1"><tr>
 			         <td valign="middle">

--- a/config/haproxy-devel/haproxy_pools.php
+++ b/config/haproxy-devel/haproxy_pools.php
@@ -53,13 +53,10 @@ if ($_POST) {
 		$retval = haproxy_configure();
 		config_unlock();
 
-		$result = haproxy_check_writtenconfig_error();
+		$result = haproxy_check_writtenconfig_error($messages);
+		$savemsg = $messages;
 		if ($result)
-			$savemsg = gettext($result);
-		else {
-			$savemsg = get_std_save_message($retval);
 			unlink_if_exists($d_haproxyconfdirty_path);
-		}
 	}
 }
 
@@ -90,7 +87,7 @@ include("head.inc");
 <?php if ($input_errors) print_input_errors($input_errors); ?>
 <?php if ($savemsg) print_info_box($savemsg); ?>
 <?php if (file_exists($d_haproxyconfdirty_path)): ?><p>
-<?php print_info_box_np("The virtual pool configuration has been changed.<br>You must apply the changes in order for them to take effect.");?><br>
+<?php print_info_box_np("The haproxy configuration has been changed.<br>You must apply the changes in order for them to take effect.");?><br>
 <?php endif; ?>
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr><td class="tabnavtbl">


### PR DESCRIPTION
haproxy-devel
-allow advanced configuration like a cookie per backend-server
-show if ACLs have been used in the overview
-fixed global advanced option saving
-show all certificates, as filtering server certs didn't work properly.
