### PR TITLE
Fix VRT rules tarball filename so 2.9.4.1 rules download instead of 2.9.4.0

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -41,7 +41,7 @@ require_once("filter.inc");
 $snort_version = "2.9.4.1";
 $pfSense_snort_version = "2.5.4";
 $snort_package_version = "Snort {$snort_version} pkg v. {$pfSense_snort_version}";
-$snort_rules_file = "snortrules-snapshot-2940.tar.gz";
+$snort_rules_file = "snortrules-snapshot-2941.tar.gz";
 $emerging_threats_version = "2.9.0";
 $flowbit_rules_file = "flowbit-required.rules";
 $snort_enforcing_rules_file = "snort.rules";


### PR DESCRIPTION
# CHANGE LOG

Correct typo for Snort VRT rules tarball filename so it correctly references the tarball 
for Snort version 2.9.4.1.  The Shared Object pre-compiled rules changed slightly 
in 2.9.4.1 and the pre-compiled objects in the 2.9.4.0 tarball will not work with Snort 
2.9.4.1.
