### PR TITLE
Fix logic bug in preproc auto-rule-disable so it skips already disabled rules

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -1855,7 +1855,8 @@ function snort_filter_preproc_rules($snortcfg, &$active_rules) {
 	 ***************************************************/
 	foreach ($active_rules as $k1 => $rulem) {
 		foreach ($rulem as $k2 => $v) {
-			if ($v['disabled'] == 0)
+			/* If rule is already disabled, skip it. */
+			if ($v['disabled'] == 1)
 				continue;
 			foreach ($rule_opts_preprocs as $opt => $preproc) {
 				$pcre = "/\s*\b" . $opt . "/i";


### PR DESCRIPTION
# Change Log

Date:  03/22/2013
1.  Fix logic bug in function that auto-disables rules containing rule options 
   associated with disabled pre-processors.  The logic was supposed to skip 
   disabling already disabled rules, but instead was skipping enabled rules.
