### PR TITLE
squid proxy server listening on virtual IP

### DIFF
--- a/config/squid/squid.inc
+++ b/config/squid/squid.inc
@@ -629,6 +629,14 @@ function squid_resync_general() {
 		if($real_ifaces[$i][0]) {
 			$conf .= "http_port {$real_ifaces[$i][0]}:$port\n";
 		}
+                // XXX: bind on Virtual IP too.
+                if($config['virtualip']['vip']) {
+                        foreach($config['virtualip']['vip'] as $vip) {
+                                if($vip['interface'] == $iface) {
+                                        $conf .= "http_port {$vip['subnet']}:$port\n";
+                                }
+                        }
+                }
 	}
 	if (($settings['transparent_proxy'] == 'on')) {
 		$conf .= "http_port 127.0.0.1:" . $settings['proxy_port'] . " transparent\n";


### PR DESCRIPTION
Here a small patch I made to make squid listen on a virtual IP on a pfsense cluster.

There should be an option to bind the proxy server either or interface address or a virtual IP.   Until that option will be added, selecting an interface the proxy will bind on interface address   AND any virtual IP configurated on it.
