### PR TITLE
pfBlocker allow list ranges that are not exact subnets

### DIFF
--- a/config/pf-blocker/pfblocker.inc
+++ b/config/pf-blocker/pfblocker.inc
@@ -52,29 +52,6 @@ function cb_get_real_interface_address($iface) {
 	return array($ip, long2ip(hexdec($netmask)));
 }
 
-function pfblocker_Range2CIDR($ip_min, $ip_max) {
-	#function called without any args
-	if ($ip_min == "" || $ip_max == "")
-		return "";
-	#function called with same ip in min and max
-	if ($ip_min == $ip_max)
-		return $ip_min. "/32";
-	#convert ip to decimal numbers
-	$ip_min_long=ip2long($ip_min);
-	$ip_max_long=ip2long($ip_max);
-	#check long results
-	if ($ip_min_long == -1 || $ip_max_long  == -1)
-		return "";
-	#identify bits mask
-	$bits=(32 -strlen(decbin($ip_max_long - $ip_min_long)));
-	if ($bits < 0)
-		return "";
-	#identify first ip on range network
-	$network=long2ip( $ip_min_long & ((1<<32)-(1<<(32-$bits))-1) );
-	#print decbin($ip_min_long)."\n".$network."\n";
-	return $network . "/". $bits;
-}
-
 function sync_package_pfblocker($cron="") {
 	global $g,$config;
 	
@@ -290,10 +267,12 @@ function sync_package_pfblocker($cron="") {
 										foreach ($url_list as $line){
 											# Network range 192.168.0.0-192.168.0.254
 											if (preg_match("/(\d+\.\d+\.\d+\.\d+)-(\d+\.\d+\.\d+\.\d+)/",$line,$matches)){
-												$cidr= pfblocker_Range2CIDR($matches[1],$matches[2]);
-												if ($cidr != ""){
-													${$alias}.= $cidr."\n";
-													$new_file.= $cidr."\n";
+												$a_cidr = ip_range_to_subnet_array($matches[1],$matches[2]);
+												if (is_array($a_cidr)) {
+													foreach ($a_cidr as $cidr) {
+														${$alias}.= $cidr."\n";
+														$new_file.= $cidr."\n";
+													}
 												}
 											}
 											# CIDR format 192.168.0.0/16


### PR DESCRIPTION
Fixes #2892
I made a "nasty" list as follows:
192.168.100.0-192.168.101.255
192.168.103.8-192.168.103.23
192.168.104.1-192.168.104.254
192.168.105.22-192.168.106.66
192.168.107.3-192.168.107.33
And this code turns it into:
192.168.100.0/23
192.168.103.8/29
192.168.103.16/29
192.168.104.1/32
192.168.104.2/31
192.168.104.4/30
192.168.104.8/29
192.168.104.16/28
192.168.104.32/27
192.168.104.64/26
192.168.104.128/26
192.168.104.192/27
192.168.104.224/28
192.168.104.240/29
192.168.104.248/30
192.168.104.252/31
192.168.104.254/32
192.168.105.22/31
192.168.105.24/29
192.168.105.32/27
192.168.105.64/26
192.168.105.128/25
192.168.106.0/26
192.168.106.64/31
192.168.106.66/32
192.168.107.3/32
192.168.107.4/30
192.168.107.8/29
192.168.107.16/28
192.168.107.32/31
Which is the correct group of CIDRs to represent the given ranges.
