### PR TITLE
haproxy-devel, compile against the newer version of OpenSSL 1.0.1

### DIFF
--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -193,10 +193,11 @@
 		<depends_on_package_pbi>haproxy-devel-1.5-dev17-i386.pbi</depends_on_package_pbi>
 		<build_port_path>/usr/ports/net/haproxy-devel</build_port_path>
 		<build_pbi>
+			<ports_before>security/openssl/</ports_before>
 			<custom_name>haproxy-devel</custom_name>
 			<port>/usr/ports/net/haproxy-devel</port>
 		</build_pbi>
-		<build_options>OPTIONS_UNSET=PCRE DPCRE;OPTIONS_SET=OPENSSL SPCRE</build_options>
+		<build_options>WITH_PORTS_OPENSSL=yes;OPTIONS_UNSET=PCRE DPCRE;OPTIONS_SET=OPENSSL SPCRE</build_options>
 	</package>
 	<package>
 		<name>Apache with mod_security-dev</name>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -180,10 +180,11 @@
 		<depends_on_package_pbi>haproxy-devel-1.5-dev17-amd64.pbi</depends_on_package_pbi>
 		<build_port_path>/usr/ports/net/haproxy-devel</build_port_path>
 		<build_pbi>
+			<ports_before>security/openssl/</ports_before>
 			<custom_name>haproxy-devel</custom_name>
 			<port>/usr/ports/net/haproxy-devel</port>
 		</build_pbi>
-		<build_options>OPTIONS_UNSET=PCRE DPCRE;OPTIONS_SET=OPENSSL SPCRE</build_options>
+		<build_options>WITH_PORTS_OPENSSL=yes;OPTIONS_UNSET=PCRE DPCRE;OPTIONS_SET=OPENSSL SPCRE</build_options>
 	</package>
 	<package>
 		<name>Apache with mod_security-dev</name>


### PR DESCRIPTION
haproxy-devel, compile against the newer version of OpenSSL 1.0.1
