### PR TITLE
haproxy-devel, added support for combining acl's,lb-agent-chk,multiple port's,openssl1.0.1

### DIFF
--- a/config/haproxy-devel/haproxy.inc
+++ b/config/haproxy-devel/haproxy.inc
@@ -39,30 +39,32 @@ $d_haproxyconfdirty_path = $g['varrun_path'] . "/haproxy.conf.dirty";
 
 $a_acltypes = array();
 $a_acltypes[] = array('name' => 'host_starts_with', 'descr' => 'Host starts with',
-				'mode' => 'http', 'syntax' => 'hdr_beg(host) -i');
+				'mode' => 'http', 'syntax' => 'hdr_beg(host) -i %1$s');
 $a_acltypes[] = array('name' => 'host_ends_with', 'descr' => 'Host ends with',
-				'mode' =>'http', 'syntax' => 'hdr_end(host) -i');
+				'mode' =>'http', 'syntax' => 'hdr_end(host) -i %1$s');
 $a_acltypes[] = array('name' => 'host_matches', 'descr' => 'Host matches',
-				'mode' =>'http', 'syntax' => 'hdr(host) -i');
+				'mode' =>'http', 'syntax' => 'hdr(host) -i %1$s');
 $a_acltypes[] = array('name' => 'host_regex', 'descr' => 'Host regex',
-				'mode' =>'http', 'syntax' => 'hdr_reg(host) -i');
+				'mode' =>'http', 'syntax' => 'hdr_reg(host) -i %1$s');
 $a_acltypes[] = array('name' => 'host_contains', 'descr' => 'Host contains',
-				'mode' => 'http', 'syntax' => 'hdr_dir(host) -i');
+				'mode' => 'http', 'syntax' => 'hdr_dir(host) -i %1$s');
 $a_acltypes[] = array('name' => 'path_starts_with', 'descr' => 'Path starts with',
-				'mode' => 'http', 'syntax' => 'path_beg -i');
+				'mode' => 'http', 'syntax' => 'path_beg -i %1$s');
 $a_acltypes[] = array('name' => 'path_ends_with', 'descr' => 'Path ends with',
-				'mode' => 'http', 'syntax' => 'path_end -i');
+				'mode' => 'http', 'syntax' => 'path_end -i %1$s');
 $a_acltypes[] = array('name' => 'path_matches', 'descr' => 'Path matches',
-				'mode' => 'http', 'syntax' => 'path -i');
+				'mode' => 'http', 'syntax' => 'path -i %1$s');
 $a_acltypes[] = array('name' => 'path_regex', 'descr' => 'Path regex',
-				'mode' => 'http', 'syntax' => 'path_reg -i');
+				'mode' => 'http', 'syntax' => 'path_reg -i %1$s');
 $a_acltypes[] = array('name' => 'path_contains', 'descr' => 'Path contains',
-				'mode' => 'http', 'syntax' => 'path_dir -i');
+				'mode' => 'http', 'syntax' => 'path_dir -i %1$s');
 $a_acltypes[] = array('name' => 'source_ip', 'descr' => 'Source IP',
-				'mode' => '', 'syntax' => 'src');
+				'mode' => '', 'syntax' => 'src %1$s');
+$a_acltypes[] = array('name' => 'backendservercount', 'descr' => 'Minimum count usable servers',
+				'mode' => '', 'syntax' => 'nbsrv(%2$s) ge %1$d', 'parameters' => 'value,backendname');
 if ($haproxy_sni_ssloffloading) {
 	$a_acltypes[] = array('name' => 'ssl_sni_matches',  'descr' => 'Server Name Indication TLS extension matches', 
-					'mode' => 'https', 'syntax' => 'req_ssl_sni -i', 'advancedoptions' => "tcp-request inspect-delay 5s\n\ttcp-request content accept if { req_ssl_hello_type 1 }");
+					'mode' => 'https', 'syntax' => 'req_ssl_sni -i %1$s', 'advancedoptions' => "tcp-request inspect-delay 5s\n\ttcp-request content accept if { req_ssl_hello_type 1 }");
 }
 
 $a_checktypes['none'] = array('name' => 'none', 'syntax' => '',
@@ -71,10 +73,9 @@ $a_checktypes['Basic'] = array('name' => 'Basic', 'syntax' => '',
 	'descr' => 'Basic socket connection check');
 $a_checktypes['HTTP'] = array('name' => 'HTTP', 'syntax' => 'httpchk',
 	'descr' => 'HTTP protocol to check on the servers health, can also be used for HTTPS servers(requirs checking the SSL box for the servers).', 'parameters' => "uri,method,version");
-/* seams this was added in HAProxy1.5dev18, haproxy-devel package is currently using 1.5dev17
+/* 'Agent' was added in HAProxy1.5dev18 */
 $a_checktypes['Agent'] = array('name' => 'Agent', 'syntax' => 'lb-agent-chk', 'usedifferenport' => 'yes', 
 	'descr' => 'Use a TCP connection to read an ASCII string of the form 100%,75%,drain,down (others in haproxy manual)');
-*/
 $a_checktypes['LDAP'] = array('name' => 'LDAP', 'syntax' => 'ldap-check',
 	'descr' => 'Use LDAPv3 health checks for server testing');
 $a_checktypes['MySQL'] = array('name' => 'MySQL', 'syntax' => 'mysql-check',
@@ -384,6 +385,7 @@ function write_backend($fd, $name, $pool, $frontend) {
 			
 	fwrite ($fd, "\tmode\t\t\t" . $backend_type . "\n");
 	
+	unset($checkport);
 	$check_type = $pool['check_type'];
 	if ($check_type != 'none')
 	{
@@ -392,12 +394,14 @@ function write_backend($fd, $name, $pool, $frontend) {
 			$optioncheck .= " user " . $pool['monitor_username'];
 		if ($check_type == "SMTP" || $check_type == "ESMTP")
 			$optioncheck .= " " . $pool['monitor_domain'];
-		if ($check_type == "HTTP")
-		{
+		if ($check_type == "HTTP") {
 			$uri = $pool['monitor_uri'];
 			if (!$uri)
 				$uri = "/";
 			$optioncheck .= " {$pool['httpcheck_method']} {$uri} {$pool['monitor_httpversion']}";
+		}
+		if ($check_type == "Agent") {
+			$checkport = " port " . $pool['monitor_agentport'];
 		}
 	} else {
 		$optioncheck = "httpchk";
@@ -451,7 +455,6 @@ function write_backend($fd, $name, $pool, $frontend) {
 	if ($pool['advanced_backend']) {
 		$adv_be	= explode("\n", base64_decode($pool['advanced_backend']));
 		foreach($adv_be as $adv_line) {
-			$adv_line = trim($adv_line);
 			if ($adv_line != "") {
 				fwrite($fd, "\t" . $adv_line . "\n");
 			}
@@ -495,7 +498,7 @@ function write_backend($fd, $name, $pool, $frontend) {
 			{
 				$ssl = $backend_type == "http" ? ' ssl' : ' check-ssl';
 			}
-			fwrite ($fd, "\tserver\t\t\t" . $be['name'] . " " . $be['address'].":" . $be['port'] . "$ssl $cookie $checkinter $isbackup weight " . $be['weight'] . "{$advanced_txt} {$be['advanced']}\n");
+			fwrite ($fd, "\tserver\t\t\t" . $be['name'] . " " . $be['address'].":" . $be['port'] . "$ssl $cookie $checkinter$checkport $isbackup weight " . $be['weight'] . "{$advanced_txt} {$be['advanced']}\n");
 		}
 	}
 	fwrite ($fd, "\n");
@@ -537,6 +540,7 @@ function haproxy_writeconf() {
 		fwrite ($fd, "\tmaxconn\t\t\t".$a_global['maxconn']."\n");
 		if($a_global['remotesyslog'])
 			fwrite ($fd, "\tlog\t\t\t{$a_global['remotesyslog']}\t{$a_global['logfacility']}\t{$a_global['loglevel']}\n");
+		fwrite ($fd, "\tstats socket /tmp/haproxy.socket level admin\n");
 		fwrite ($fd, "\tuid\t\t\t80\n");
 		fwrite ($fd, "\tgid\t\t\t80\n");
 		// Set numprocs if defined or use system default (#cores)
@@ -586,10 +590,11 @@ function haproxy_writeconf() {
 				unlink_if_exists("var/etc/{$backend['name']}.{$backend['port']}.crt");
 			}
 			
+			$bname = get_frontend_ipport($backend);
+
 			if ($backend['extaddr']=='localhost')
 				$backend['extaddr'] = "127.0.0.1";
-
-			$bname = $backend['extaddr'] . ":" . $backend['port'];
+			
 			if (!is_array($a_bind[$bname])) {
 				$a_bind[$bname] = array();
 				$a_bind[$bname]['config'] = array();
@@ -662,8 +667,12 @@ function haproxy_writeconf() {
 
 			// Advanced pass thru
 			if($bind['advanced']) {
-				$advanced = base64_decode($bind['advanced']);
-				fwrite($fd, "\t" . $advanced . "\n");
+				$advanced	= explode("\n", base64_decode($bind['advanced']));
+				foreach($advanced as $adv_line) {
+					if ($adv_line != "") {
+						fwrite($fd, "\t" . $adv_line . "\n");
+					}
+				}
 			}
 
 			// https is an alias for tcp for clarity purpouses
@@ -729,33 +738,38 @@ function haproxy_writeconf() {
 				if (strtolower($bind['type']) == "http" && $bconfig['ssloffload'] && $bconfig['ssloffloadacl']) {
 					$aclname = "SNI_" . $poolname;
 					$cert_cn = cert_get_cn($bconfig['ssloffloadcert'] ,true);
-					//$expr = "req_ssl_sni -i $cert_cn";
-					$expr = "hdr(host) -i $cert_cn";
-					fwrite ($fd, "\tacl\t\t\t" . $aclname . "\t" . $expr . "\n");
-					fwrite ($fd, "\tuse_backend\t\t" . $poolname . " if " . $aclname . "\n");
+					$a_acl[] = array('name' => $aclname,'expression' => 'host_matches', 'value' => $cert_cn);
 				}
 				
+				// combine acl's with same name to allow for 'combined checks' to check for example hostname and fileextension together..
+				$a_acl_combine = array();
 				foreach ($a_acl as $entry) {
-					$acl = haproxy_find_acl($entry['expression']);
-					if (!$acl)
-						continue;
+					$name = $entry['name'];
+					$a_acl_combine[$name][] = $entry;
+				}
+				
+				foreach ($a_acl_combine as $a_usebackend) {
+					$aclnames = "";
+					foreach ($a_usebackend as $entry) {
+						$acl = haproxy_find_acl($entry['expression']);
+						if (!$acl)
+							continue;
 
-					// Filter out acls for different modes
-					if ($acl['mode'] != '' && $acl['mode'] != strtolower($bind['type']))
-						continue;
+						// Filter out acls for different modes
+						if ($acl['mode'] != '' && $acl['mode'] != strtolower($bind['type']))
+							continue;
 
-					if ($acl['syntax'] != '')
-						$expr = $acl['syntax'] . " " . $entry['value'];
-					else
-						$expr = $entry['expression'] . " " . $entry['value'];
+						$expr = sprintf($acl['syntax'],$entry['value'],$poolname);
 
-					$aclname = $i . "_" . $entry['name'];
-					fwrite ($fd, "\tacl\t\t\t" . $aclname . "\t" . $expr . "\n");
-					fwrite ($fd, "\tuse_backend\t\t" . $poolname . " if " . $aclname . "\n");
-					
-					if ($acl['advancedoptions'] != '')
-						$advancedextra[$acl['syntax']] = $acl['advancedoptions']."\n";
-					$i++;
+						$aclname = $i . "_" . $entry['name'];
+						$aclnames .= $aclname." ";
+						fwrite ($fd, "\tacl\t\t\t" . $aclname . "\t" . $expr . "\n");
+						
+						if ($acl['advancedoptions'] != '')
+							$advancedextra[$acl['syntax']] = $acl['advancedoptions']."\n";
+						$i++;
+					}
+					fwrite ($fd, "\tuse_backend\t\t" . $poolname . " if " . $aclnames . "\n");
 				}
 			}
 			foreach($advancedextra as $extra)
@@ -971,7 +985,8 @@ function haproxy_do_xmlrpc_sync($sync_to_ip, $password) {
 }
 
 function get_frontend_id($name) {
-	global $a_backend;
+	global $config;
+	$a_backend = &$config['installedpackages']['haproxy']['ha_backends']['item'];
 	$i = 0;
 	foreach($a_backend as $backend)
 	{
@@ -983,7 +998,8 @@ function get_frontend_id($name) {
 }
 
 function get_frontend_ipport($fontend) {
-	global $a_backend;
+	global $config;
+	$a_backend = &$config['installedpackages']['haproxy']['ha_backends']['item'];
 	if ($fontend['secondary'] == 'yes')
 		$mainfontend = $a_backend[get_frontend_id($fontend['primary_frontend'])];
 	else
@@ -995,7 +1011,6 @@ function get_frontend_ipport($fontend) {
 	else 
 		$result = get_current_wan_address('wan');
 	return $result . ":" . $mainfontend['port'];
-	return 'abc';
 }
 
 function haproxy_check_config() {
@@ -1060,7 +1075,7 @@ function get_frontent_acls($frontend) {
 				continue;
 			
 			$acl_item = array();
-			$acl_item['descr'] = $acl['descr'] . " " . $entry['value'];
+			$acl_item['descr'] = $acl['descr'] . ": " . $entry['value'];
 			$acl_item['ref'] = $entry;
 			
 			$result[] = $acl_item;
@@ -1101,8 +1116,7 @@ function haproxy_escapestring($configurationsting) {
 	return str_replace('#', '\\#', $result);
 }
 
-function echo_html_select($name, $keyvaluelist, $selected, $listEmptyMessage="", $onchangeEvent="")
-{
+function echo_html_select($name, $keyvaluelist, $selected, $listEmptyMessage="", $onchangeEvent="") {
 	if (count($keyvaluelist)>0){
 		if ($onchangeEvent != "")
 			$onchangeEvent .= " onchange=$onchangeEvent";

--- a/config/haproxy-devel/haproxy_global.php
+++ b/config/haproxy-devel/haproxy_global.php
@@ -29,11 +29,9 @@
 	POSSIBILITY OF SUCH DAMAGE.
 */
 
-require("globals.inc");
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("haproxy.inc");
-
-$d_haproxyconfdirty_path = $g['varrun_path'] . "/haproxy.conf.dirty";
+require_once("globals.inc");
 
 if (!is_array($config['installedpackages']['haproxy'])) 
 	$config['installedpackages']['haproxy'] = array();

--- a/config/haproxy-devel/haproxy_listeners.php
+++ b/config/haproxy-devel/haproxy_listeners.php
@@ -30,9 +30,6 @@
 */
 
 require_once("guiconfig.inc");
-
-$d_haproxyconfdirty_path = $g['varrun_path'] . "/haproxy.conf.dirty";
-
 require_once("haproxy.inc");
 require_once("certs.inc");
 
@@ -137,7 +134,10 @@ include("head.inc");
 		}
 		usort($a_backend,'sort_backends');
 		
-		$certimg = "/themes/{$g['theme']}/images/icons/icon_frmfld_cert.png";
+		$img_cert = "/themes/{$g['theme']}/images/icons/icon_frmfld_cert.png";
+		$img_adv = "/themes/{$g['theme']}/images/icons/icon_advanced.gif";
+		$img_acl = "/themes/{$g['theme']}/images/icons/icon_ts_rule.gif";
+		
 		unset($ipport_previous);
 		foreach ($a_backend as $backend):
 			$backendname = $backend['name'];
@@ -154,18 +154,27 @@ include("head.inc");
 				<?=$backend['secondary']!='yes'?"yes":"no";?>
 			  </td>
 			  <td class="listlr" ondblclick="document.location='haproxy_listeners_edit.php?id=<?=$backendname;?>';">
-				<? if (strtolower($backend['type']) == "http" && $backend['ssloffload']):
-					$cert = lookup_cert($backend['ssloffloadcert']);?>
-					<img src="<?=$certimg;?>" alt="SSL offloading" title="SSL offloading cert: '<?=$cert['descr'];?>'" border="0" height="16" width="16" />
-				<? endif;?>
-				<?
-				$acls = get_frontent_acls($backend);
-				$isadvset = "";
-				foreach ($acls as $acl) {
-					$isadvset .= "&#10;" . $acl['descr'];
+				<? 
+				if (strtolower($backend['type']) == "http" && $backend['ssloffload'])
+				{
+					$cert = lookup_cert($backend['ssloffloadcert']);
+					echo '<img src="'.$img_cert.'" title="SSL offloading cert: '.$cert['descr'].'" alt="SSL offloading" border="0" height="16" width="16" />';
 				}
-				if ($isadvset) 
-					echo "<img src=\"./themes/{$g['theme']}/images/icons/icon_advanced.gif\" title=\"" . gettext("advanced settings set") . ": {$isadvset}\" border=\"0\">";
+				
+				$acls = get_frontent_acls($backend);
+				$isaclset = "";
+				foreach ($acls as $acl) {
+					$isaclset .= "&#10;" . $acl['descr'];
+				}
+				if ($isaclset) 
+					echo "<img src=\"$img_acl\" title=\"" . gettext("acl's used") . ": {$isaclset}\" border=\"0\">";
+					
+				$isadvset = "";
+				if ($backend['advanced_bind']) $isadvset .= "Advanced bind: {$backend['advanced_bind']}\r\n";
+				if ($backend['advanced']) $isadvset .= "advanced settings used\r\n";
+				if ($isadvset)
+					echo "<img src=\"$img_adv\" title=\"" . gettext("advanced settings set") . ": {$isadvset}\" border=\"0\">";				
+				
 				?>
 			  </td>
 			  <td class="listlr" ondblclick="document.location='haproxy_listeners_edit.php?id=<?=$backendname;?>';">

--- a/config/haproxy-devel/haproxy_listeners_edit.php
+++ b/config/haproxy-devel/haproxy_listeners_edit.php
@@ -191,11 +191,6 @@ if ($_POST) {
 		$acl_value=$_POST['acl_value'.$x];
 
 		if ($acl_name) {
-			// check for duplicates
-			if (in_array($acl_name, $acl_names)) {
-				$input_errors[] = "The name '$acl_name' is duplicate.";
-			}
-
 			$acl_names[]=$acl_name;
 
 			$acl=array();
@@ -207,7 +202,7 @@ if ($_POST) {
 			if (preg_match("/[^a-zA-Z0-9\.\-_]/", $acl_name))
 				$input_errors[] = "The field 'Name' contains invalid characters.";
 
-			if (!preg_match("/.{2,}/", $acl_value))
+			if (!preg_match("/.{1,}/", $acl_value))
 				$input_errors[] = "The field 'Value' is required.";
 
 			if (!preg_match("/.{2,}/", $acl_name))
@@ -602,55 +597,56 @@ include("head.inc");
 			<td width="22%" valign="top" class="vncell">Access Control lists</td>
 			<td width="78%" class="vtable" colspan="2" valign="top">
 			<table class="" width="100%" cellpadding="0" cellspacing="0" id='acltable'>
-	                <tr>
-	                  <td width="35%" class="">Name</td>
-	                  <td width="40%" class="">Expression</td>
-	                  <td width="20%" class="">Value</td>
-	                  <td width="5%" class=""></td>
-			</tr>
-			<?php 
-			$a_acl=$pconfig['a_acl'];
+				<tr>
+				  <td width="35%" class="">Name</td>
+				  <td width="40%" class="">Expression</td>
+				  <td width="20%" class="">Value</td>
+				  <td width="5%" class=""></td>
+				</tr>
+				<?php 
+				$a_acl=$pconfig['a_acl'];
 
-			if (!is_array($a_acl)) {
-				$a_acl=array();
-			}
+				if (!is_array($a_acl)) {
+					$a_acl=array();
+				}
 
-			$counter=0;
-			foreach ($a_acl as $acl) {
-				$t = haproxy_find_acl($acl['expression']);
-				$display = '';
-				if (!$t || ($t['mode'] != '' && $t['mode'] != strtolower($pconfig['type'])))
-					$display = 'style="display: none;"';
-			?>
-			<tr id="aclrow<?=$counter;?>" <?=$display;?>>
-				<td><input name="acl_name<?=$counter;?>" id="acl_name<?=$counter;?>" type="text" value="<?=$acl['name']; ?>" size="20"/></td>
-				<td>
-				<select name="acl_expression<?=$counter;?>" id="acl_expression<?=$counter;?>">
+				$counter=0;
+				foreach ($a_acl as $acl) {
+					$t = haproxy_find_acl($acl['expression']);
+					$display = '';
+					if (!$t || ($t['mode'] != '' && $t['mode'] != strtolower($pconfig['type'])))
+						$display = 'style="display: none;"';
+				?>
+				<tr id="aclrow<?=$counter;?>" <?=$display;?>>
+					<td><input name="acl_name<?=$counter;?>" id="acl_name<?=$counter;?>" type="text" value="<?=$acl['name']; ?>" size="20"/></td>
+					<td>
+					<select name="acl_expression<?=$counter;?>" id="acl_expression<?=$counter;?>">
+					<?php
+					foreach ($a_acltypes as $expr) { ?>
+						<option value="<?=$expr['name'];?>"<?php if($acl['expression'] == $expr['name']) echo " SELECTED"; ?>><?=$expr['descr'];?>:</option>
+					<?php } ?>
+					</select>
+					</td>
+					<td><input name="acl_value<?=$counter;?>" id="acl_value<?=$counter;?>" type="text" value="<?=$acl['value']; ?>" size="35"/></td>
+					<td class="list">
+						 <table border="0" cellspacing="0" cellpadding="1"><tr>
+						 <td valign="middle">
+					  <img src="/themes/<?= $g['theme']; ?>/images/icons/icon_x.gif" title="delete entry" width="17" height="17" border="0" onclick="removeRow(this); return false;">
+						 </td>
+						 <td valign="middle">
+					 <img src="/themes/<?= $g['theme']; ?>/images/icons/icon_plus.gif" title="duplicate entry" width="17" height="17" border="0" onclick="dupRow(<?=$counter;?>, 'acltable'); return false;">
+						 </td></tr></table>
+					</td>
+				</tr>
 				<?php
-				foreach ($a_acltypes as $expr) { ?>
-					<option value="<?=$expr['name'];?>"<?php if($acl['expression'] == $expr['name']) echo " SELECTED"; ?>><?=$expr['descr'];?>:</option>
-				<?php } ?>
-				</select>
-				</td>
-				<td><input name="acl_value<?=$counter;?>" id="acl_value<?=$counter;?>" type="text" value="<?=$acl['value']; ?>" size="35"/></td>
-			  	<td class="list">
-			         <table border="0" cellspacing="0" cellpadding="1"><tr>
-			         <td valign="middle">
-				  <img src="/themes/<?= $g['theme']; ?>/images/icons/icon_x.gif" title="delete entry" width="17" height="17" border="0" onclick="removeRow(this); return false;">
-			         </td>
-			         <td valign="middle">
-				 <img src="/themes/<?= $g['theme']; ?>/images/icons/icon_plus.gif" title="duplicate entry" width="17" height="17" border="0" onclick="dupRow(<?=$counter;?>, 'acltable'); return false;">
-			         </td></tr></table>
-				</td>
-			</tr>
-			<?php
-			$counter++;
-			}
-			?>
+				$counter++;
+				}
+				?>
 			</table>
 			<a onclick="javascript:addRowTo('acltable'); return false;" href="#">
 			<img border="0" src="/themes/<?= $g['theme']; ?>/images/icons/icon_plus.gif" alt="" title="add another entry" />
 			</a><br/>
+			acl's with the same name wil be 'combined', acl's with different names will be evaluated seperately.<br/>
 			For more information about ACL's please see <a href='http://haproxy.1wt.eu/download/1.5/doc/configuration.txt' target='_new'>HAProxy Documentation</a> Section 7 - Using ACL's
 			</td>
 		</tr>

--- a/config/haproxy-devel/haproxy_pool_edit.php
+++ b/config/haproxy-devel/haproxy_pool_edit.php
@@ -51,7 +51,7 @@ if (isset($_GET['dup']))
 global $simplefields;
 $simplefields = array(
 "name","cookie","balance",
-"check_type","checkinter","httpcheck_method","monitor_uri","monitor_httpversion","monitor_username","monitor_domain",
+"check_type","checkinter","httpcheck_method","monitor_uri","monitor_httpversion","monitor_username","monitor_domain","monitor_agentport",
 "connection_timeout","server_timeout","retries",
 "stats_enabled","stats_username","stats_password","stats_uri","stats_realm","stats_admin","stats_node_enabled","stats_node","stats_desc","stats_refresh");
 
@@ -269,10 +269,15 @@ foreach($simplefields as $field){
 		setCSSdisplay(".haproxy_check_http", check_type == 'HTTP');
 		setCSSdisplay(".haproxy_check_username", check_type == 'MySQL' ||  check_type == 'PostgreSQL');
 		setCSSdisplay(".haproxy_check_smtp", check_type == 'SMTP' ||  check_type == 'ESMTP');
+		setCSSdisplay(".haproxy_check_agent", check_type == 'Agent');
 
 		monitor_username = d.getElementById("monitor_username");
 		sqlcheckusername = d.getElementById("sqlcheckusername");
-		sqlcheckusername.innerHTML=monitor_username.value;
+		if(!browser_InnerText_support){
+			sqlcheckusername.textContent = monitor_username.value;
+		} else{
+			sqlcheckusername.innerText = monitor_username.value;
+		}
 	}
 
 
@@ -567,6 +572,14 @@ FLUSH PRIVILEGES;</pre>
 				<input name="monitor_domain" type="text" <?if(isset($pconfig['monitor_domain'])) echo "value=\"{$pconfig['monitor_domain']}\"";?>size="64">
 			</td>
 		</tr>
+		<tr align="left" class="haproxy_check_agent">
+			<td width="22%" valign="top" class="vncell">Agentport</td>
+			<td width="78%" class="vtable" colspan="2">
+				<input name="monitor_agentport" type="text" <?if(isset($pconfig['monitor_agentport'])) echo "value=\"{$pconfig['monitor_agentport']}\"";?>size="64">
+				<br/>
+				Fill in the TCP portnumber the healtcheck should be performed on.
+			</td>
+		</tr>
 	</table>
 	<br/>
 	<table width="100%" border="0" cellpadding="6" cellspacing="0">
@@ -696,6 +709,7 @@ set by the 'retries' parameter.</div>
 <?
 	phparray_to_javascriptarray($a_checktypes,"checktypes",Array('/*','/*/name','/*/descr'));
 ?>
+	browser_InnerText_support = (document.getElementsByTagName("body")[0].innerText != undefined) ? true : false;
 
 	field_counter_js = 7;
 	rows = 1;

--- a/config/haproxy-devel/haproxy_pools.php
+++ b/config/haproxy-devel/haproxy_pools.php
@@ -32,7 +32,6 @@
 require_once("guiconfig.inc");
 require_once("haproxy.inc");
 
-$d_haproxyconfdirty_path = $g['varrun_path'] . "/haproxy.conf.dirty";
 
 if (!is_array($config['installedpackages']['haproxy']['ha_pools']['item'])) {
 	$config['installedpackages']['haproxy']['ha_pools']['item'] = array();

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -183,21 +183,21 @@
 				This package implements TCP, HTTP and HTTPS balance features from Haproxy.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5-dev17 pkg v 0.1</version>
+		<version>1.5-dev18 pkg v 0.2</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>http://www.pfsense.com/packages/config/haproxy-devel/haproxy.xml</config_file>
 		<configurationfile>haproxy.xml</configurationfile>
 		<depends_on_package_base_url>http://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
 		<depends_on_package>haproxy-1.4.21.tbz</depends_on_package>
-		<depends_on_package_pbi>haproxy-devel-1.5-dev17-i386.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>haproxy-devel-1.5-dev18-i386.pbi</depends_on_package_pbi>
 		<build_port_path>/usr/ports/net/haproxy-devel</build_port_path>
 		<build_pbi>
 			<ports_before>security/openssl/</ports_before>
 			<custom_name>haproxy-devel</custom_name>
 			<port>/usr/ports/net/haproxy-devel</port>
 		</build_pbi>
-		<build_options>WITH_PORTS_OPENSSL=yes;OPTIONS_UNSET=PCRE DPCRE;OPTIONS_SET=OPENSSL SPCRE</build_options>
+		<build_options>WITH_OPENSSL_PORT=yes;OPTIONS_UNSET=PCRE DPCRE;OPTIONS_SET=OPENSSL SPCRE</build_options>
 	</package>
 	<package>
 		<name>Apache with mod_security-dev</name>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -170,21 +170,21 @@
 				This package implements TCP, HTTP and HTTPS balance features from Haproxy.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5-dev17 pkg v 0.1</version>
+		<version>1.5-dev18 pkg v 0.2</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>http://www.pfsense.com/packages/config/haproxy-devel/haproxy.xml</config_file>
 		<configurationfile>haproxy.xml</configurationfile>
 		<depends_on_package_base_url>http://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
 		<depends_on_package>haproxy-1.4.21.tbz</depends_on_package>
-		<depends_on_package_pbi>haproxy-devel-1.5-dev17-amd64.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>haproxy-devel-1.5-dev18-amd64.pbi</depends_on_package_pbi>
 		<build_port_path>/usr/ports/net/haproxy-devel</build_port_path>
 		<build_pbi>
 			<ports_before>security/openssl/</ports_before>
 			<custom_name>haproxy-devel</custom_name>
 			<port>/usr/ports/net/haproxy-devel</port>
 		</build_pbi>
-		<build_options>WITH_PORTS_OPENSSL=yes;OPTIONS_UNSET=PCRE DPCRE;OPTIONS_SET=OPENSSL SPCRE</build_options>
+		<build_options>WITH_OPENSSL_PORT=yes;OPTIONS_UNSET=PCRE DPCRE;OPTIONS_SET=OPENSSL SPCRE</build_options>
 	</package>
 	<package>
 		<name>Apache with mod_security-dev</name>


### PR DESCRIPTION
haproxy-devel, added support for combining acl's
-Agent check (lb-agent-chk)
-binding multiple port's
-new try at including OpenSSL 1.0.1
-fix combining frontends

(please note that changed compile options may trigger OpenSSL 1.0.1 to be 'installed' on the build machine if it is not there already.)
