### PR TITLE
Fix display of Year and prevent Dashboard crash if Snort not installed

### DIFF
--- a/config/widget-snort/widget-snort.xml
+++ b/config/widget-snort/widget-snort.xml
@@ -46,7 +46,7 @@
 	<requirements>Dashboard package and Snort</requirements>
 	<faq>Currently there are no FAQ	items provided.</faq>
 	<name>widget-snort</name>
-	<version>0.5</version>
+	<version>1.0</version>
 	<title>Widget - Snort</title>
 	<additional_files_needed>
 		<prefix>/usr/local/www/widgets/javascript/</prefix>


### PR DESCRIPTION
# Snort Dashboard Widget
# Change Log
1.  Change parsing of the CSV data from the Alert log to properly pull out the date and time values when the Alert log contains entries with the YEAR in the date.  The updated code looks for the dash "-" that separates the DATE from the TIME, and uses that to parse the date and time values.  This was necessitated by the recent update to Snort and Barnyard2 that configures them to log the year in timestamps.  The new logic correctly handles both types of Alert data (with year and without year in the timestamps).
2.  Added a test for the existence of the "snort.inc" file prior to including it in the Dashboard widget's code.  This file is only present when Snort is actually installed, and including it when it is not present results in a Dashboard crash as reported on the pfSense Packages Forum.  If the "snort.inc" file does not exist, the code now gracefully exits and prints a message in the Snort Widget Dashboard table that "Snort is not installed'.  This condition happened when a user removed the Snort package but not the Snort Dashboard Widget package.
3.  Bump the version of the Snort Dashboard Widget to 1.0 from 0.5 to reflect the changes noted above.
