### PR TITLE
Add Uninstall Function to Snort Dashboard Widget

### DIFF
--- a/config/widget-snort/snort_alerts.widget.php
+++ b/config/widget-snort/snort_alerts.widget.php
@@ -90,7 +90,6 @@ if (file_exists("/usr/local/pkg/snort/snort.inc")) {
 
 					$snort_alerts[$counter]['instanceid'] = $a_instance[$instanceid]['interface'];
 					$snort_alerts[$counter]['timestamp'] = $fields[0];
-					/* Look for the dash separating date and time so we can handle entries with year in them */
 					$snort_alerts[$counter]['timeonly'] = substr($fields[0], strpos($fields[0], '-')+1, -8);
 					$snort_alerts[$counter]['dateonly'] = substr($fields[0], 0, strpos($fields[0], '-'));
 					$snort_alerts[$counter]['src'] = $fields[6];

--- a/config/widget-snort/widget-snort.inc
+++ b/config/widget-snort/widget-snort.inc
@@ -1,0 +1,28 @@
+<?php
+
+require_once("guiconfig.inc");
+require_once("config.inc");
+
+function widget_snort_uninstall() {
+
+	global $config;
+
+	/* Remove the Snort widget from the Dashboard display list */
+	$widgets = $config['widgets']['sequence'];
+	if (!empty($widgets)) {
+		$widgetlist = explode(",", $widgets);
+		foreach ($widgetlist as $key => $widget) {
+			if (strstr($widget, "snort_alerts-container"))
+				unset($widgetlist[$key]);
+		}
+		$config['widgets']['sequence'] = implode(",", $widgetlist);
+		write_config();
+	}
+
+	/* Remove our associated file */
+	unlink("/usr/local/www/widgets/include/widget-snort.inc");
+	unlink("/usr/local/www/widgets/widgets/snort_alerts.widget.php");
+	unlink("/usr/local/www/widgets/javascript/snort_alerts.js");
+}
+
+?>

--- a/config/widget-snort/widget-snort.xml
+++ b/config/widget-snort/widget-snort.xml
@@ -46,8 +46,9 @@
 	<requirements>Dashboard package and Snort</requirements>
 	<faq>Currently there are no FAQ	items provided.</faq>
 	<name>widget-snort</name>
-	<version>1.0</version>
+	<version>0.3.3</version>
 	<title>Widget - Snort</title>
+	<include_file>/usr/local/www/widgets/include/widget-snort.inc</include_file>
 	<additional_files_needed>
 		<prefix>/usr/local/www/widgets/javascript/</prefix>
 		<chmod>0644</chmod>
@@ -58,4 +59,12 @@
 		<chmod>0644</chmod>
 		<item>http://www.pfsense.com/packages/config/widget-snort/snort_alerts.widget.php</item>
 	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/usr/local/www/widgets/include/</prefix>
+		<chmod>0644</chmod>
+		<item>http://www.pfsense.com/packages/config/widget-snort/widget-snort.inc</item>
+	</additional_files_needed>
+	<custom_php_deinstall_command>
+		widget_snort_uninstall();
+	</custom_php_deinstall_command>
 </packagegui>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1481,7 +1481,7 @@
 		<descr>Dashboard widget for Snort.</descr>
 		<category>System</category>
 		<config_file>http://www.pfsense.com/packages/config/widget-snort/widget-snort.xml</config_file>
-		<version>0.3.2</version>
+		<version>0.3.3</version>
 		<status>BETA</status>
 		<required_version>1.2</required_version>
 		<configurationfile>widget-snort.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1468,7 +1468,7 @@
 		<descr>Dashboard widget for Snort.</descr>
 		<category>System</category>
 		<config_file>http://www.pfsense.com/packages/config/widget-snort/widget-snort.xml</config_file>
-		<version>0.3.2</version>
+		<version>0.3.3</version>
 		<status>BETA</status>
 		<required_version>1.2</required_version>
 		<configurationfile>widget-snort.xml</configurationfile>


### PR DESCRIPTION
# Widget-Snort Alerts
# CHANGE LOG
1.  Added an uninstall function to the Snort Alerts dashboard widget so that it can be gracefully uninstalled without leaving an error on Dashboard GUI page.  Typical package deletion was not cleaning up the 'sequences' variable in the 'widgets' portion of the config.xml file, and the Dashboard would continue to attempt display of the Snort widget even with the package removed.  Browser refresh attempts did not help.  The new uninstall function present in the new include file locates the "snort_alerts-container" entry in the 'sequences' variable and removes it.  It also deletes all associated Snort Widget files.  This allows a clean and complete removal of the Snort dashboard widget.
2.  Corrected the widget version in the package's XML file back to 0.3.3 to accurately reflect a minor revision bump from 0.3.2.
3.  Bumped the Snort Alerts widget version number to 0.3.3 in the pkg_config.8.xml and pkg_config.8.xml.amd64 files.
4.  Added an additional "widget-snort.inc" include file to the package.  This file contains the uninstall function.  The file was added to the widget-snort.xml manifest, and a reference to the include file and custom de-install function were also included in the package manifest.
