### PR TITLE
Fix bad include reference in Snort Widget -- caused pkg start crash with Snort

### DIFF
--- a/config/widget-snort/widget-snort.inc
+++ b/config/widget-snort/widget-snort.inc
@@ -1,8 +1,5 @@
 <?php
-
-require_once("guiconfig.inc");
 require_once("config.inc");
-
 function widget_snort_uninstall() {
 
 	global $config;
@@ -19,10 +16,9 @@ function widget_snort_uninstall() {
 		write_config();
 	}
 
-	/* Remove our associated file */
+	/* Remove our associated files */
 	unlink("/usr/local/www/widgets/include/widget-snort.inc");
 	unlink("/usr/local/www/widgets/widgets/snort_alerts.widget.php");
 	unlink("/usr/local/www/widgets/javascript/snort_alerts.js");
 }
-
 ?>

--- a/config/widget-snort/widget-snort.xml
+++ b/config/widget-snort/widget-snort.xml
@@ -46,9 +46,15 @@
 	<requirements>Dashboard package and Snort</requirements>
 	<faq>Currently there are no FAQ	items provided.</faq>
 	<name>widget-snort</name>
-	<version>0.3.3</version>
+	<version>0.3.4</version>
 	<title>Widget - Snort</title>
 	<include_file>/usr/local/www/widgets/include/widget-snort.inc</include_file>
+	<menu>
+	</menu>
+	<service>
+	</service>
+	<tabs>
+	</tabs>
 	<additional_files_needed>
 		<prefix>/usr/local/www/widgets/javascript/</prefix>
 		<chmod>0644</chmod>
@@ -64,6 +70,14 @@
 		<chmod>0644</chmod>
 		<item>http://www.pfsense.com/packages/config/widget-snort/widget-snort.inc</item>
 	</additional_files_needed>
+	<fields>
+	</fields>
+	<custom_add_php_command>
+	</custom_add_php_command>
+	<custom_php_resync_config_command>
+	</custom_php_resync_config_command>
+	<custom_php_install_command>
+	</custom_php_install_command>
 	<custom_php_deinstall_command>
 		widget_snort_uninstall();
 	</custom_php_deinstall_command>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1481,7 +1481,7 @@
 		<descr>Dashboard widget for Snort.</descr>
 		<category>System</category>
 		<config_file>http://www.pfsense.com/packages/config/widget-snort/widget-snort.xml</config_file>
-		<version>0.3.3</version>
+		<version>0.3.4</version>
 		<status>BETA</status>
 		<required_version>1.2</required_version>
 		<configurationfile>widget-snort.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1468,7 +1468,7 @@
 		<descr>Dashboard widget for Snort.</descr>
 		<category>System</category>
 		<config_file>http://www.pfsense.com/packages/config/widget-snort/widget-snort.xml</config_file>
-		<version>0.3.3</version>
+		<version>0.3.4</version>
 		<status>BETA</status>
 		<required_version>1.2</required_version>
 		<configurationfile>widget-snort.xml</configurationfile>


### PR DESCRIPTION
# Snort Dashboard Widget  ver 0.3.4
# CHANGE LOG
1.  Remove incorrect "include" file from new "widget-snort.inc" file.  The bad reference was for "guiconfig.inc" and "config.inc", but it should have been just "config.inc".  The extraneous inclusion of "guiconfig.inc" was causing a failure to start for the Snort package upon a firewall reboot.  Could also impact other packages as the bad include seemed to crash the "start all packages" code.
2.  Bump the version to 0.3.4 to reflect this critical update.
