### PR TITLE
Snort Packge Update to ver 2.5.7 - Bug fixes and new features

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -33,6 +33,7 @@
 require_once("pfsense-utils.inc");
 require_once("config.inc");
 require_once("functions.inc");
+require_once("service-utils.inc");
 
 // Needed on 2.0 because of filter_get_vpns_list()
 require_once("filter.inc");
@@ -44,13 +45,16 @@ global $snort_community_rules_filename, $snort_community_rules_url, $emergingthr
 
 /* package version */
 $snort_version = "2.9.4.1";
-$pfSense_snort_version = "2.5.6";
+$pfSense_snort_version = "2.5.7";
 $snort_package_version = "Snort {$snort_version} pkg v. {$pfSense_snort_version}";
 
 // Define SNORTDIR and SNORTLIBDIR constants according to FreeBSD version (PBI support or no PBI)
 if (floatval(php_uname("r")) >= 8.3) {
 	exec("/usr/local/sbin/pbi_info | grep 'snort-{$snort_version}' | xargs /usr/local/sbin/pbi_info | awk '/Prefix/ {print $2}'",$pbidirarray);
 	$snort_pbidir = "{$pbidirarray[0]}";
+	/* In case this is an initial Snort install and pbi_info() above returned null, set a sane default value */
+	if (empty($snort_pbidir))
+		$snort_pbidir = "/usr/pbi/snort-" . php_uname("m");
 	define("SNORTDIR", "{$snort_pbidir}/etc/snort");
 	define("SNORTLIBDIR", "{$snort_pbidir}/lib/snort");
 }
@@ -325,7 +329,6 @@ function snort_barnyard_stop($snortcfg, $if_real) {
 	$snort_uuid = $snortcfg['uuid'];
 	if (file_exists("{$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid") && isvalidpid("{$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid")) {
 		killbypid("{$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid");
-		@unlink("{$g['varrun_path']}/barnyard2_{$if_real}{$snort_uuid}.pid");
 	}
 }
 
@@ -335,12 +338,11 @@ function snort_stop($snortcfg, $if_real) {
 	$snort_uuid = $snortcfg['uuid'];
 	if (file_exists("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid") && isvalidpid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid")) {
 		killbypid("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid");
-		exec("/bin/rm {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid");
 	}
 
 	snort_barnyard_stop($snortcfg, $if_real);
 
-	log_error("Interface Rule STOP for {$snortcfg['descr']}({$if_real})...");
+	log_error("Snort STOP for {$snortcfg['descr']}({$if_real})...");
 }
 
 function snort_barnyard_start($snortcfg, $if_real) {
@@ -368,7 +370,7 @@ function snort_start($snortcfg, $if_real) {
 
 	snort_barnyard_start($snortcfg, $if_real);
 
-	log_error("Interface Rule START for {$snortcfg['descr']}({$if_real})...");
+	log_error("Snort START for {$snortcfg['descr']}({$if_real})...");
 }
 
 function snort_get_friendly_interface($interface) {
@@ -461,6 +463,7 @@ function snort_postinstall() {
 
 	$snortdir = SNORTDIR;
 	$snortlibdir = SNORTLIBDIR;
+	$rcdir = RCFILEPREFIX;
 
 	/* Set flag for post-install in progress */
 	$is_postinstall = true;
@@ -484,8 +487,8 @@ function snort_postinstall() {
 
 	/* Remove any previously installed scripts since we rebuild them */
 	@unlink("{$snortdir}/sid");
-	@unlink("/usr/local/etc/rc.d/snort");
-	@unlink("/usr/local/etc/rc.d/barnyard2");
+	@unlink("{$rcdir}/snort.sh");
+	@unlink("{$rcdir}/barnyard2");
 
 	/* remove example library files */
 	$files = glob("{$snortlibdir}/dynamicrules/*_example*");
@@ -497,18 +500,25 @@ function snort_postinstall() {
 
 	/* remake saved settings */
 	if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
+		log_error(gettext("[Snort] Saved settings detected... rebuilding installation with saved settings..."));
 		update_status(gettext("Saved settings detected..."));
 		update_output_window(gettext("Please wait... rebuilding installation with saved settings..."));
+		log_error(gettext("[Snort] Downloading and updating configured rule types..."));
 		@include_once("/usr/local/pkg/snort/snort_check_for_rule_updates.php");
 		update_status(gettext("Generating snort.conf configuration file from saved settings..."));
 		$rebuild_rules = "on";
 		sync_snort_package_config();
 		$rebuild_rules = "off";
 		update_output_window(gettext("Finished rebuilding files..."));
+		log_error(gettext("[Snort] Finished rebuilding installation from saved settings..."));
+		update_status(gettext("Starting Snort using rebuilt configuration..."));
+		log_error(gettext("[Snort] Starting Snort using rebuilt configuration..."));
+		start_service("snort");
 	}
 
 	/* Done with post-install, so clear flag */
 	$is_postinstall = false;
+	log_error(gettext("[Snort] Package post-installation tasks completed..."));
 }
 
 function snort_Getdirsize($node) {
@@ -642,17 +652,20 @@ function snort_rm_blocked_install_cron($should_install) {
 	}
 	switch($should_install) {
 	case true:
-		if(!$is_installed) {
-			$cron_item = array();
-			$cron_item['minute'] = "$snort_rm_blocked_min";
-			$cron_item['hour'] = "$snort_rm_blocked_hr";
-			$cron_item['mday'] = "$snort_rm_blocked_mday";
-			$cron_item['month'] = "$snort_rm_blocked_month";
-			$cron_item['wday'] = "$snort_rm_blocked_wday";
-			$cron_item['who'] = "root";
-			$cron_item['command'] = "/usr/bin/nice -n20 /usr/local/sbin/expiretable -t $snort_rm_blocked_expire snort2c";
+		$cron_item = array();
+		$cron_item['minute'] = "$snort_rm_blocked_min";
+		$cron_item['hour'] = "$snort_rm_blocked_hr";
+		$cron_item['mday'] = "$snort_rm_blocked_mday";
+		$cron_item['month'] = "$snort_rm_blocked_month";
+		$cron_item['wday'] = "$snort_rm_blocked_wday";
+		$cron_item['who'] = "root";
+		$cron_item['command'] = "/usr/bin/nice -n20 /usr/local/sbin/expiretable -t $snort_rm_blocked_expire snort2c";
+
+		/* Add cron job if not already installed, else just update the existing one */
+		if (!$is_installed) 
 			$config['cron']['item'][] = $cron_item;
-		}
+		elseif ($is_installed)
+			$config['cron']['item'][$x] = $cron_item;
 		break;
 	case false:
 		if ($is_installed == true)
@@ -722,17 +735,20 @@ function snort_rules_up_install_cron($should_install) {
 	}
 	switch($should_install) {
 	case true:
-		if(!$is_installed) {
-			$cron_item = array();
-			$cron_item['minute'] = "$snort_rules_up_min";
-			$cron_item['hour'] = "$snort_rules_up_hr";
-			$cron_item['mday'] = "$snort_rules_up_mday";
-			$cron_item['month'] = "$snort_rules_up_month";
-			$cron_item['wday'] = "$snort_rules_up_wday";
-			$cron_item['who'] = "root";
-			$cron_item['command'] = "/usr/bin/nice -n20 /usr/local/bin/php -f /usr/local/pkg/snort/snort_check_for_rule_updates.php >> /tmp/snort_update.log";
+		$cron_item = array();
+		$cron_item['minute'] = "$snort_rules_up_min";
+		$cron_item['hour'] = "$snort_rules_up_hr";
+		$cron_item['mday'] = "$snort_rules_up_mday";
+		$cron_item['month'] = "$snort_rules_up_month";
+		$cron_item['wday'] = "$snort_rules_up_wday";
+		$cron_item['who'] = "root";
+		$cron_item['command'] = "/usr/bin/nice -n20 /usr/local/bin/php -f /usr/local/pkg/snort/snort_check_for_rule_updates.php >> /tmp/snort_update.log";
+
+		/* Add cron job if not already installed, else just update the existing one */
+		if (!$is_installed) 
 			$config['cron']['item'][] = $cron_item;
-		}
+		elseif ($is_installed)
+			$config['cron']['item'][$x] = $cron_item;
 		break;
 	case false:
 		if($is_installed == true)
@@ -1553,6 +1569,7 @@ function snort_create_rc() {
 	global $config, $g;
 
 	$snortdir = SNORTDIR;
+	$rcdir = RCFILEPREFIX;	
 
 	if (!is_array($config['installedpackages']['snortglobal']['rule']))
 		return;
@@ -1621,11 +1638,18 @@ EOE;
 
 ###### For Each Iface
 	# Start snort and barnyard2
-	if [ -f {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid ]; then
-		/bin/rm {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid
+	if [ ! -f {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid ]; then
+		pid=`/bin/pgrep -xf '/usr/local/bin/snort -R {$snort_uuid} -D -q -l /var/log/snort/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$if_real}'`
+	else
+		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid`
 	fi
-	/usr/local/bin/snort -R {$snort_uuid} -D -q -l /var/log/snort/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$if_real}
-	/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort START For {$value['descr']}({$snort_uuid}_{$if_real})..."
+	if [ $? = 0 ]; then
+		/bin/pkill -HUP \$pid
+		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort SOFT RESTART for {$value['descr']}({$snort_uuid}_{$if_real})..."
+	else
+		/usr/local/bin/snort -R {$snort_uuid} -D -q -l /var/log/snort/snort_{$if_real}{$snort_uuid} --pid-path {$g['varrun_path']} --nolock-pidfile -G {$snort_uuid} -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -i {$if_real}
+		/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort START for {$value['descr']}({$snort_uuid}_{$if_real})..."
+	fi
 
 	sleep 2
 	{$start_barnyard2}
@@ -1634,7 +1658,7 @@ EOE;
 
 		$start_snort_iface_stop[] = <<<EOE
 
-	/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort STOP For {$value['descr']}({$snort_uuid}_{$if_real})..."
+	/usr/bin/logger -p daemon.info -i -t SnortStartup "Snort STOP for {$value['descr']}({$snort_uuid}_{$if_real})..."
 	if [ -f {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid ]; then
 		pid=`/bin/pgrep -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid`
 		/bin/pkill -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid -a
@@ -1703,11 +1727,11 @@ esac
 EOD;
 
 	/* write out snort.sh */
-	if (!@file_put_contents("/usr/local/etc/rc.d/snort.sh", $snort_sh_text)) {
-		log_error("Could not open /usr/local/etc/rc.d/snort.sh for writing.");
+	if (!@file_put_contents("{$rcdir}/snort.sh", $snort_sh_text)) {
+		log_error("Could not open {$rcdir}/snort.sh for writing.");
 		return;
 	}
-	@chmod("/usr/local/etc/rc.d/snort.sh", 0755);
+	@chmod("{$rcdir}/snort.sh", 0755);
 }
 
 /* open barnyard2.conf for writing */
@@ -1791,6 +1815,8 @@ function snort_deinstall() {
 
 	$snortdir = SNORTDIR;
 	$snortlibdir = SNORTLIBDIR;
+	$snortlogdir = SNORTLOGDIR;
+	$rcdir = RCFILEPREFIX;
 
 	/* Make sure all active Snort processes are terminated */
 	mwexec('/usr/bin/killall snort', true);
@@ -1845,14 +1871,22 @@ function snort_deinstall() {
 	/*      future versions of pfSense.                       */
 	/**********************************************************/
 	if (file_exists("/tmp/pkg_libs.tgz") || file_exists("/tmp/pkg_bins.tgz")) {
+		log_error(gettext("[Snort] Package deletion requested... removing all files..."));
 		mwexec("/bin/rm -rf {$snortdir}");
 		mwexec("/bin/rm -rf {$snortlibdir}/dynamicrules");
+		mwexec("/bin/rm -f {$rcdir}/snort.sh");
+		mwexec("/bin/rm -rf /usr/local/pkg/snort");
+		mwexec("/bin/rm -rf /usr/local/www/snort");
+		mwexec("/bin/rm -rf /usr/local/etc/snort");
 	}
 
 	/* Keep this as a last step */
 	if ($config['installedpackages']['snortglobal']['forcekeepsettings'] != 'on') {
+		log_error(gettext("Not saving settings... all Snort configuration info and logs deleted..."));
 		unset($config['installedpackages']['snortglobal']);
 		@unlink("{$snort_rules_upd_log}");
+		mwexec("/bin/rm -rf {$snortlogdir}");
+		log_error(gettext("[Snort] The package has been removed from this system..."));
 	}
 }
 
@@ -1861,18 +1895,20 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 	global $snort_enforcing_rules_file, $flowbit_rules_file, $rebuild_rules;
 
 	$snortdir = SNORTDIR;
+	$no_rules_defined = true;
 
 	/* If there is no reason to rebuild the rules, exit to save time. */
 	if ($rebuild_rules == "off")
 		return;
 
 	/* Log a message for rules rebuild in progress */
-	log_error(gettext("Updating rules configuration for: " . snort_get_friendly_interface($snortcfg['interface']) . " ..."));
+	log_error(gettext("[Snort] Updating rules configuration for: " . snort_get_friendly_interface($snortcfg['interface']) . " ..."));
 
 	/* Only rebuild rules if some are selected or an IPS Policy is enabled  */
 	if (!empty($snortcfg['rulesets']) || $snortcfg['ips_policy_enable'] == 'on') {
 		$enabled_rules = array();
 		$enabled_files = array();
+		$no_rules_defined = false;
 
 		/* Create an array with the full path filenames of the enabled  */
 		/* rule category files if we have any.                          */
@@ -1911,7 +1947,7 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 		/* Check for and disable any rules dependent upon disabled preprocessors if  */
 		/* this option is enabled for the interface.                                 */
 		if ($snortcfg['preproc_auto_rule_disable'] == "on") {
-			log_error('Auto-disabling rules dependent on disabled preprocessors for ' . snort_get_friendly_interface($snortcfg['interface']) . '...');
+			log_error('[Snort] Checking for rules dependent on disabled preprocessors for: ' . snort_get_friendly_interface($snortcfg['interface']) . '...');
 			snort_filter_preproc_rules($snortcfg, $enabled_rules);
 		}
 
@@ -1921,14 +1957,14 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 
 		/* If auto-flowbit resolution is enabled, generate the dependent flowbits rules file. */
 		if ($snortcfg['autoflowbitrules'] == 'on') {
-			log_error('Resolving and auto-enabling any flowbit-required rules for ' . snort_get_friendly_interface($snortcfg['interface']) . '...');
+			log_error('[Snort] Enabling any flowbit-required rules for: ' . snort_get_friendly_interface($snortcfg['interface']) . '...');
 			$enabled_files[] = "{$snortcfgdir}/rules/{$snort_enforcing_rules_file}";
 			$fbits = snort_resolve_flowbits($enabled_files);
 
 			/* Check for and disable any flowbit-required rules dependent upon     */
 			/* disabled preprocessors if this option is enabled for the interface. */
 			if ($snortcfg['preproc_auto_rule_disable'] == "on") {
-				log_error('Auto-disabling flowbit-required rules dependent on disabled preprocessors for ' . snort_get_friendly_interface($snortcfg['interface']) . '...');
+				log_error('[Snort] Checking flowbit rules dependent on disabled preprocessors for: ' . snort_get_friendly_interface($snortcfg['interface']) . '...');
 				snort_filter_preproc_rules($snortcfg, $fbits, true);
 			}
 			snort_filter_preproc_rules($snortcfg, $fbits, true);
@@ -1944,14 +1980,20 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 		snort_write_flowbit_rules_file(array(), "{$snortcfgdir}/rules/{$flowbit_rules_file}");
 	}
 
-	if (!empty($snortcfg['customrules']))
+	if (!empty($snortcfg['customrules'])) {
 		@file_put_contents("{$snortcfgdir}/rules/custom.rules", base64_decode($snortcfg['customrules']));
+		$no_rules_defined = false;
+	}
 	else
 		@file_put_contents("{$snortcfgdir}/rules/custom.rules", "");
 
+	/* Log a warning if the interface has no rules defined or enabled */
+	if ($no_rules_defined)
+		log_error(gettext("[Snort] Warning - no text rules selected for: " . snort_get_friendly_interface($snortcfg['interface']) . " ..."));
+
 	/* Build a new sid-msg.map file from the enabled */
 	/* rules and copy it to the interface directory. */
-	log_error(gettext("Building new sig-msg.map file for " . snort_get_friendly_interface($snortcfg['interface']) . "..."));
+	log_error(gettext("[Snort] Building new sig-msg.map file for " . snort_get_friendly_interface($snortcfg['interface']) . "..."));
 	snort_build_sid_msg_map("{$snortcfgdir}/rules/", "{$snortcfgdir}/sid-msg.map");
 }
 
@@ -2049,8 +2091,8 @@ function snort_filter_preproc_rules($snortcfg, &$active_rules, $persist_log = fa
 					$disabled_count++;
 
 					/* Accumulate auto-disabled rules for logging */
-					$tmp = $active_rules[$k1][$k2]['category'] . "  ";
-					$tmp .= "{$k1}:{$k2}  Preproc: {$preproc}  Param: {$opt}";
+					$tmp = $active_rules[$k1][$k2]['category'] . ",";
+					$tmp .= "{$k1}:{$k2},{$preproc},{$opt}";
 					$log_msg[] = $tmp;
 					break;
 				}
@@ -2080,7 +2122,7 @@ function snort_filter_preproc_rules($snortcfg, &$active_rules, $persist_log = fa
 	/* than optimal with the preprocessors disabled.   */
 	/***************************************************/
 	if ($disabled_count > 0) {
-		log_error(gettext("Warning:  auto-disabled {$disabled_count} rules due to disabled preprocessor dependencies."));
+		log_error(gettext("[Snort] Warning: auto-disabled {$disabled_count} rules due to disabled preprocessor dependencies."));
 		natcasesort($log_msg);
 		if ($fp) {
 			/* Only write the header when not persisting the log */
@@ -2093,14 +2135,19 @@ function snort_filter_preproc_rules($snortcfg, &$active_rules, $persist_log = fa
 				@fwrite($fp, "# automatically disabled.  This behavior is controlled by the Auto-Rule Disable\n");
 				@fwrite($fp, "# feature on the Preprocessors tab.\n#\n");
 				@fwrite($fp, "# WARNING: Using the auto-disable rule feature is not recommended because it can\n");
-				@fwrite($fp, "# significantly reduce the threat detection capabilities of Snort!\n#\n");
-				@fwrite($fp, "# Log Format is: RULE CATEGORY    GID:SID   PREPROC   METADATA/CONTENT PARAMETER\n#\n");
+				@fwrite($fp, "# significantly reduce the threat detection capabilities of Snort!\n#");
+				@fwrite($fp, "\n# In the list below, the PREPROCESSOR column is the disabled preprocessor that\n");
+				@fwrite($fp, "# triggered the auto-disable of the rule represented by GID:SID.  The RULE OPTION\n");
+				@fwrite($fp, "# column shows the specific rule option or content modifier contained within\n");
+				@fwrite($fp, "# the rule text that requires the preprocessor be enabled in order to execute.\n#");
+				@fwrite($fp, "\n# RULE CATEGORY                 GID:SID     PREPROCESSOR          RULE OPTION\n");
 			}
 			foreach ($log_msg as $m) {
-				@fwrite($fp, $m . "\n");
+				$tmp = explode(",", $m);
+				@fwrite($fp, sprintf("%-30s  %-10s  %-20s  %s", $tmp[0], $tmp[1], $tmp[2], $tmp[3]) . "\n");
 			}
 		}
-		log_error(gettext("See '{$file}' for list of auto-disabled rules."));
+		log_error(gettext("[Snort] See '{$file}' for list of auto-disabled rules."));
 		unset($log_msg);
 	}
 	if ($fp)
@@ -2603,11 +2650,11 @@ EOD;
 		}
 		else {
 			$snort_misc_include_rules .= "config autogenerate_preprocessor_decoder_rules\n";
-			log_error("Seems preprocessor/decoder rules are missing, enabling autogeneration of them");
+			log_error("[Snort] Seems preprocessor/decoder rules are missing, enabling autogeneration of them");
 		}
 	} else {
 		$snort_misc_include_rules .= "config autogenerate_preprocessor_decoder_rules\n";
-		log_error("Seems preprocessor/decoder rules are missing, enabling autogeneration of them");
+		log_error("[Snort] Seems preprocessor/decoder rules are missing, enabling autogeneration of them");
 	}
 
 	/* generate rule sections to load */
@@ -2615,6 +2662,8 @@ EOD;
 	$selected_rules_sections = "include \$RULE_PATH/{$snort_enforcing_rules_file}\n";
 	$selected_rules_sections .= "include \$RULE_PATH/{$flowbit_rules_file}\n";
 	$selected_rules_sections  .= "include \$RULE_PATH/custom.rules\n";
+
+	/* Create the actual rules file and save in the interface directory */
 	snort_prepare_rule_files($snortcfg, $snortcfgdir);
 
 	$cksumcheck = "all";

--- a/config/snort/snort.xml
+++ b/config/snort/snort.xml
@@ -47,7 +47,7 @@
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>Snort</name>
 	<version>2.9.4.1</version>
-	<title>Services:2.9.4.1 pkg v. 2.5.6</title>
+	<title>Services:2.9.4.1 pkg v. 2.5.7</title>
 	<include_file>/usr/local/pkg/snort/snort.inc</include_file>
 	<menu>
 		<name>Snort</name>

--- a/config/snort/snort_alerts.php
+++ b/config/snort/snort_alerts.php
@@ -219,7 +219,7 @@ if ($pconfig['arefresh'] == 'on')
 				<td width="78%" class="vtable">
 					<input name="download" type="submit" class="formbtn" value="Download"> <?php echo gettext('All ' .
 						'log files will be saved.'); ?> <a href="/snort/snort_alerts.php?action=clear&instance=<?=$instanceid;?>">
-					<input name="delete" type="button" class="formbtn" value="Clear"
+					<input name="delete" type="submit" class="formbtn" value="Clear"
 					onclick="return confirm('Do you really want to remove all instance logs?')"></a>
 					<span class="red"><strong><?php echo gettext('Warning:'); ?></strong></span> <?php echo ' ' . gettext('all log files will be deleted.'); ?>
 				</td>

--- a/config/snort/snort_barnyard.php
+++ b/config/snort/snort_barnyard.php
@@ -32,7 +32,7 @@
 require_once("guiconfig.inc");
 require_once("/usr/local/pkg/snort/snort.inc");
 
-global $g;
+global $g, $rebuild_rules;
 
 $id = $_GET['id'];
 if (isset($_POST['id']))
@@ -87,6 +87,9 @@ if ($_POST) {
 		}
 
 		write_config();
+
+		/* No need to rebuild rules if just toggling Barnyard2 on or off */
+		$rebuild_rules = "off";
 		sync_snort_package_config();
 
 		/* after click go to this page */

--- a/config/snort/snort_blocked.php
+++ b/config/snort/snort_blocked.php
@@ -135,21 +135,23 @@ if ($pconfig['brefresh'] == 'on')
 <?php if ($savemsg) print_info_box($savemsg); ?>
 <form action="/snort/snort_blocked.php" method="post">
 <table width="99%" border="0" cellpadding="0" cellspacing="0">
-<tr><td>
-<?php
-	$tab_array = array();
-	$tab_array[0] = array(gettext("Snort Interfaces"), false, "/snort/snort_interfaces.php");
-	$tab_array[1] = array(gettext("Global Settings"), false, "/snort/snort_interfaces_global.php");
-	$tab_array[2] = array(gettext("Updates"), false, "/snort/snort_download_updates.php");
-	$tab_array[3] = array(gettext("Alerts"), false, "/snort/snort_alerts.php");
-	$tab_array[4] = array(gettext("Blocked"), true, "/snort/snort_blocked.php");
-	$tab_array[5] = array(gettext("Whitelists"), false, "/snort/snort_interfaces_whitelist.php");
-	$tab_array[6] = array(gettext("Suppress"), false, "/snort/snort_interfaces_suppress.php");
-	display_top_tabs($tab_array);
-?>
-</td></tr>
-	<tr>
-		<td>
+<tr>
+	<td>
+		<?php
+		$tab_array = array();
+		$tab_array[0] = array(gettext("Snort Interfaces"), false, "/snort/snort_interfaces.php");
+		$tab_array[1] = array(gettext("Global Settings"), false, "/snort/snort_interfaces_global.php");
+		$tab_array[2] = array(gettext("Updates"), false, "/snort/snort_download_updates.php");
+		$tab_array[3] = array(gettext("Alerts"), false, "/snort/snort_alerts.php");
+		$tab_array[4] = array(gettext("Blocked"), true, "/snort/snort_blocked.php");
+		$tab_array[5] = array(gettext("Whitelists"), false, "/snort/snort_interfaces_whitelist.php");
+		$tab_array[6] = array(gettext("Suppress"), false, "/snort/snort_interfaces_suppress.php");
+		display_top_tabs($tab_array);
+		?>
+	</td>
+</tr>
+<tr>
+	<td>
 		<table id="maintable" class="tabcont" width="100%" border="0"
 			cellpadding="0" cellspacing="0">
 			<tr>
@@ -164,7 +166,7 @@ if ($pconfig['brefresh'] == 'on')
 					<input name="download" type="submit" class="formbtn" value="Download"> <?php echo gettext("All " .
 				"blocked hosts will be saved."); ?> <input name="remove" type="submit"
 					class="formbtn" value="Clear"> <span class="red"><strong><?php echo gettext("Warning:"); ?></strong></span>
-				<?php echo gettext("all hosts will be removed."); ?></form>
+				<?php echo gettext("all hosts will be removed."); ?>
 				</td>
 			</tr>
 			<tr>
@@ -179,17 +181,16 @@ if ($pconfig['brefresh'] == 'on')
 				"number of blocked entries to view. %sDefault%s is %s500%s."), '<strong>', '</strong>', '<strong>', '</strong>'); ?>
 				</td>
 			</tr>
-	<tr>
-		<td colspan="2">
-			<table id="sortabletable1" class="sortable" width="100%" border="0"
-				cellpadding="0" cellspacing="0">
-				<tr id="frheader">
-					<td width="5%" class="listhdrr">#</td>
-					<td width="15%" class="listhdrr"><?php echo gettext("IP"); ?></td>
-					<td width="70%" class="listhdrr"><?php echo gettext("Alert Description"); ?></td>
-					<td width="5%" class="listhdrr"><?php echo gettext("Remove"); ?></td>
-				</tr>
-		<?php
+			<tr>
+				<td colspan="2">
+				<table id="sortabletable1" class="sortable" width="100%" border="0" cellpadding="0" cellspacing="0">
+					<tr id="frheader">
+						<td width="5%" class="listhdrr">#</td>
+						<td width="15%" class="listhdrr"><?php echo gettext("IP"); ?></td>
+						<td width="70%" class="listhdrr"><?php echo gettext("Alert Description"); ?></td>
+						<td width="5%" class="listhdrr"><?php echo gettext("Remove"); ?></td>
+					</tr>
+			<?php
 			/* set the arrays */
 			$blocked_ips_array = array();
 			if (is_array($blocked_ips)) {
@@ -242,27 +243,25 @@ if ($pconfig['brefresh'] == 'on')
 					$counter++;
 
 				/* use one echo to do the magic*/
-				echo "<tr>
-			<td width='5%' >&nbsp;{$counter}</td>
-			<td width='15%' >&nbsp;{$blocked_ip}</td>
-			<td width='70%' >&nbsp;{$blocked_desc}</td>
-			<td width='5%' align=\"center\" valign=\"top\"'><a href='snort_blocked.php?todelete=" . trim(urlencode($blocked_ip)) . "'>
-			<img title=\"" . gettext("Delete") . "\" border=\"0\" name='todelete' id='todelete' alt=\"Delete\" src=\"../themes/{$g['theme']}/images/icons/icon_x.gif\"></a></td>
-			</tr>\n";
-
+					echo "<tr>
+						<td width='5%' >&nbsp;{$counter}</td>
+						<td width='15%' >&nbsp;{$blocked_ip}</td>
+						<td width='70%' >&nbsp;{$blocked_desc}</td>
+						<td width='5%' align=\"center\" valign=\"top\"'><a href='snort_blocked.php?todelete=" . trim(urlencode($blocked_ip)) . "'>
+						<img title=\"" . gettext("Delete") . "\" border=\"0\" name='todelete' id='todelete' alt=\"Delete\" src=\"../themes/{$g['theme']}/images/icons/icon_x.gif\"></a></td>
+					</tr>\n";
 			}
 
-			echo "\n<tr><td colspan='3' align=\"center\" valign=\"top\">{$counter} items listed.</td></tr>";
-		} else
-			echo "\n<tr><td colspan='3' align=\"center\" valign=\"top\"><br><strong>There are currently no items being blocked by snort.</strong></td></tr>";
-
-		?>
+				echo "\n<tr><td colspan='4' align=\"center\" valign=\"top\">{$counter} items listed.</td></tr>";
+			} else
+				echo "\n<tr><td colspan='4' align=\"center\" valign=\"top\"><br><strong>There are currently no items being blocked by snort.</strong></td></tr>";
+			?>
+				</table>
+			</td>
+		</tr>
 		</table>
-		</td>
-	</tr>
-</table>
-		</td>
-	</tr>
+	</td>
+</tr>
 </table>
 </form>
 <?php

--- a/config/snort/snort_define_servers.php
+++ b/config/snort/snort_define_servers.php
@@ -33,7 +33,7 @@
 require_once("guiconfig.inc");
 require_once("/usr/local/pkg/snort/snort.inc");
 
-global $g;
+global $g, $rebuild_rules;
 
 $id = $_GET['id'];
 if (isset($_POST['id']))

--- a/config/snort/snort_download_updates.php
+++ b/config/snort/snort_download_updates.php
@@ -99,6 +99,22 @@ function popup(url)
  if (window.focus) {newwin.focus()}
  return false;
 }
+
+function wopen(url, name, w, h)
+{
+// Fudge factors for window decoration space.
+// In my tests these work well on all platforms & browsers.
+w += 32;
+h += 96;
+ var win = window.open(url,
+  name, 
+  'width=' + w + ', height=' + h + ', ' +
+  'location=no, menubar=no, ' +
+  'status=no, toolbar=no, scrollbars=yes, resizable=yes');
+ win.resizeTo(w, h);
+ win.focus();
+}
+
 </script>
 
 <form action="snort_download_updates.php" method="post" name="iform" id="iform">
@@ -161,7 +177,8 @@ function popup(url)
 							echo '
 			<button disabled="disabled"><span class="download">' . gettext("Update Rules") . '</span></button><br/>
 			<p style="text-align:left; margin-left:150px;">
-			<font color="#fc3608" size="2px"><b>' . gettext("WARNING:") . '</b></font><font size="1px" color="#000000">&nbsp;&nbsp;' . gettext('No rule types have been selected for download. "Global Settings Tab"') . '</font><br>';
+			<font color="#fc3608" size="2px"><b>' . gettext("WARNING:") . '</b></font><font size="1px" color="#000000">&nbsp;&nbsp;' . gettext('No rule types have been selected for download. ') .
+			gettext('Visit the ') . '<a href="snort_interfaces_global.php">Global Settings Tab</a>' . gettext(' to select rule types.') . '</font><br>';
 
 							echo '</p>' . "\n";
 						} else {
@@ -191,7 +208,7 @@ function popup(url)
 
 						if ($snort_rules_upd_logfile_chk == 'yes') {
 							echo "
-				<button class=\"formbtn\" onclick=\"popup('snort_log_view.php?logfile={$log}')\"><span class='pwhitetxt'>" . gettext("View Log") . "</span></button>";
+				<button class=\"formbtn\" onclick=\"wopen('snort_log_view.php?logfile={$log}', 'LogViewer', 800, 600)\"><span class='pwhitetxt'>" . gettext("View Log") . "</span></button>";
 				echo "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type=\"submit\" value=\"Clear Log\" name=\"clear\" id=\"Submit\" class=\"formbtn\" />\n";
 						}else{
 							echo "

--- a/config/snort/snort_interfaces_edit.php
+++ b/config/snort/snort_interfaces_edit.php
@@ -122,9 +122,11 @@ if ($_POST["Submit"]) {
 		/* Save configuration changes */
 		write_config();
 
-		/* Update snort.conf file for this interface */
+		/* Most changes don't require a rules rebuild, so default to "off" */
 		$rebuild_rules = "off";
-		snort_generate_conf($a_rule[$id]);
+
+		/* Update snort.conf and snort.sh files for this interface */
+		sync_snort_package_config();
 
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );

--- a/config/snort/snort_interfaces_global.php
+++ b/config/snort/snort_interfaces_global.php
@@ -52,6 +52,8 @@ $pconfig['autorulesupdate7'] = $config['installedpackages']['snortglobal']['auto
 $pconfig['forcekeepsettings'] = $config['installedpackages']['snortglobal']['forcekeepsettings'];
 $pconfig['snortcommunityrules'] = $config['installedpackages']['snortglobal']['snortcommunityrules'];
 
+if (empty($pconfig['snortloglimit']))
+	$pconfig['snortloglimit'] = 'on';
 
 /* if no errors move foward */
 if (!$input_errors) {

--- a/config/snort/snort_log_view.php
+++ b/config/snort/snort_log_view.php
@@ -54,13 +54,16 @@ $pgtitle = array(gettext("Snort"), gettext("Log File Viewer"));
 
 <body link="#000000" vlink="#000000" alink="#000000">
 <?php if ($savemsg) print_info_box($savemsg); ?>
-<?php include("fbegin.inc");?>
+<?php // include("fbegin.inc");?>
 
 <form action="snort_log_view.php" method="post">
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <tr>
 	<td class="tabcont">
 		<table width="100%" cellpadding="0" cellspacing="6" bgcolor="#eeeeee">
+		<tr>
+			<td class="pgtitle" colspan="2">Snort: Log File Viewer</td>
+		</tr>
 		<tr>
 			<td align="left" width="20%">
 				<input type="button" class="formbtn" value="Return" onclick="window.close()">
@@ -71,8 +74,8 @@ $pgtitle = array(gettext("Snort"), gettext("Log File Viewer"));
 		</tr>
 		<tr>
 			<td colspan="2" valign="top" class="label">
-			<div style="background: #eeeeee;" id="textareaitem"><!-- NOTE: The opening *and* the closing textarea tag must be on the same line. -->
-			<textarea readonly wrap="off" rows="33" cols="90" name="code2"><?=$contents;?></textarea>
+			<div style="background: #eeeeee; width:100%; height:100%;" id="textareaitem"><!-- NOTE: The opening *and* the closing textarea tag must be on the same line. -->
+			<textarea style="width:100%; height:100%;" readonly wrap="off" rows="33" cols="80" name="code2"><?=$contents;?></textarea>
 			</div>
 			</td>
 		</tr>
@@ -81,6 +84,6 @@ $pgtitle = array(gettext("Snort"), gettext("Log File Viewer"));
 </tr>
 </table>
 </form>
-<?php include("fend.inc");?>
+<?php // include("fend.inc");?>
 </body>
 </html>

--- a/config/snort/snort_rules.php
+++ b/config/snort/snort_rules.php
@@ -212,10 +212,22 @@ if ($_GET['act'] == "resetall" && !empty($rules_map)) {
 	exit;
 }
 
+if ($_POST['clear']) {
+	unset($a_rule[$id]['customrules']);
+	write_config();
+	$rebuild_rules = "on";
+	snort_generate_conf($a_rule[$id]);
+	$rebuild_rules = "off";
+	header("Location: /snort/snort_rules.php?id={$id}&openruleset={$currentruleset}");
+	exit;
+}
+
 if ($_POST['customrules']) {
 	$a_rule[$id]['customrules'] = base64_encode($_POST['customrules']);
 	write_config();
-	sync_snort_package_config();
+	$rebuild_rules = "on";
+	snort_generate_conf($a_rule[$id]);
+	$rebuild_rules = "off";
 	$output = "";
 	$retcode = "";
 	exec("snort -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf -T 2>&1", $output, $retcode);
@@ -299,6 +311,22 @@ function popup(url)
  if (window.focus) {newwin.focus()}
  return false;
 }
+
+function wopen(url, name, w, h)
+{
+// Fudge factors for window decoration space.
+// In my tests these work well on all platforms & browsers.
+w += 32;
+h += 96;
+ var win = window.open(url,
+  name, 
+  'width=' + w + ', height=' + h + ', ' +
+  'location=no, menubar=no, ' +
+  'status=no, toolbar=no, scrollbars=yes, resizable=yes');
+ win.resizeTo(w, h);
+ win.focus();
+}
+
 </script>
 
 <form action="/snort/snort_rules.php" method="post" name="iform" id="iform">
@@ -376,10 +404,14 @@ function popup(url)
 		<td width="3%" class="list">&nbsp;</td>
 	</tr>
 	<tr>
+		<td colspan="9">&nbsp;</td>
+	</tr>
+	<tr>
 		<td width="3%" class="list">&nbsp;</td>
-		<td colspan="7" class="vtable">
-			<input name="Submit" type="submit" class="formbtn" value="Save">
-			<input type="button" class="formbtn" value="Cancel" onclick="history.back()">
+		<td colspan="7">
+			<input name="Submit" type="submit" class="formbtn" value=" Save ">&nbsp;&nbsp;
+			<input type="button" class="formbtn" value="Cancel" onclick="history.back()">&nbsp;&nbsp;
+			<input name="clear" type="submit" class="formbtn" id="clear" value="Clear" onclick="return confirm('Do you really want to erase all custom rules?')">
 		</td>
 		<td width="3%" class="list">&nbsp;</td>
 	</tr>
@@ -390,7 +422,7 @@ function popup(url)
 			&nbsp;&nbsp;&nbsp;<?php echo gettext("Click to rebuild the rules with your changes.  Snort must be restarted to use the new rules."); ?>
 			<input type='hidden' name='id' value='<?=$id;?>'></td>
 		<td width="3%" align="center" valign="middle" class="listt"><a href="javascript: void(0)"
-				onclick="popup('snort_rules_edit.php?id=<?=$id;?>&openruleset=<?=$currentruleset;?>')">
+				onclick="wopen('snort_rules_edit.php?id=<?=$id;?>&openruleset=<?=$currentruleset;?>','FileViewer',800,600)">
 				<img src="../themes/<?= $g['theme']; ?>/images/icons/icon_service_restart.gif" <?php
 				echo "onmouseover='this.src=\"../themes/{$g['theme']}/images/icons/icon_services_restart_mo.gif\"' 
 				onmouseout='this.src=\"../themes/{$g['theme']}/images/icons/icon_service_restart.gif\"' ";?>				
@@ -475,7 +507,7 @@ function popup(url)
 	?>
 			<td width="3%" align="center" valign="middle" nowrap class="listt">
 				<a href="javascript: void(0)"
-				onclick="popup('snort_rules_edit.php?id=<?=$id;?>&openruleset=<?=$currentruleset;?>&ids=<?=$sid;?>&gid=<?=$gid;?>')"><img
+				onclick="wopen('snort_rules_edit.php?id=<?=$id;?>&openruleset=<?=$currentruleset;?>&ids=<?=$sid;?>&gid=<?=$gid;?>','FileViewer',800,600)"><img
 				src="../themes/<?= $g['theme']; ?>/images/icons/icon_right.gif" 
 				title="<?php echo gettext("Click to view rule"); ?>" width="17" height="17" border="0"></a>
 				<!-- Codes by Quackit.com -->

--- a/config/snort/snort_rules_edit.php
+++ b/config/snort/snort_rules_edit.php
@@ -113,7 +113,7 @@ $pgtitle = array(gettext("Snort"), gettext("File Viewer"));
 
 <body link="#000000" vlink="#000000" alink="#000000">
 <?php if ($savemsg) print_info_box($savemsg); ?>
-<?php include("fbegin.inc");?>
+<?php // include("fbegin.inc");?>
 
 <form action="snort_rules_edit.php" method="post">
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
@@ -121,14 +121,20 @@ $pgtitle = array(gettext("Snort"), gettext("File Viewer"));
 	<td class="tabcont">
 		<table width="100%" cellpadding="0" cellspacing="6" bgcolor="#eeeeee">
 		<tr>
-			<td>
+			<td class="pgtitle" colspan="2">Snort: Rules Viewer</td>
+		</tr>
+		<tr>
+			<td width="20%">
 				<input type="button" class="formbtn" value="Return" onclick="window.close()">
+			</td>
+			<td align="right">
+				<b><?php echo gettext("Rules File: ") . '</b>&nbsp;' . $file; ?>&nbsp;&nbsp;&nbsp;&nbsp;
 			</td>
 		</tr>
 		<tr>
-			<td valign="top" class="label">
-			<div style="background: #eeeeee;" id="textareaitem"><!-- NOTE: The opening *and* the closing textarea tag must be on the same line. -->
-			<textarea wrap="<?=$wrap_flag?>" rows="33" cols="90" name="code2"><?=$contents;?></textarea>
+			<td valign="top" class="label" colspan="2">
+			<div style="background: #eeeeee; width:100%; height:100%;" id="textareaitem"><!-- NOTE: The opening *and* the closing textarea tag must be on the same line. -->
+			<textarea style="width:100%; height:100%;" wrap="<?=$wrap_flag?>" rows="33" cols="80" name="code2"><?=$contents;?></textarea>
 			</div>
 			</td>
 		</tr>
@@ -137,6 +143,6 @@ $pgtitle = array(gettext("Snort"), gettext("File Viewer"));
 </tr>
 </table>
 </form>
-<?php include("fend.inc");?>
+<?php // include("fend.inc");?>
 </body>
 </html>

--- a/config/snort/snort_rulesets.php
+++ b/config/snort/snort_rulesets.php
@@ -82,8 +82,10 @@ if (($snortdownload == 'off') || ($a_nat[$id]['ips_policy_enable'] != 'on'))
 	$policy_select_disable = "disabled";
 
 if ($a_nat[$id]['autoflowbitrules'] == 'on') {
-	if (file_exists("{$snortdir}/snort_{$snort_uuid}_{$if_real}/rules/{$flowbit_rules_file}"))
+	if (file_exists("{$snortdir}/snort_{$snort_uuid}_{$if_real}/rules/{$flowbit_rules_file}") &&
+	    filesize("{$snortdir}/snort_{$snort_uuid}_{$if_real}/rules/{$flowbit_rules_file}") > 0) {
 		$btn_view_flowb_rules = "";
+	}
 	else
 		$btn_view_flowb_rules = " disabled";
 }
@@ -220,6 +222,22 @@ function popup(url)
  if (window.focus) {newwin.focus()}
  return false;
 }
+
+function wopen(url, name, w, h)
+{
+// Fudge factors for window decoration space.
+// In my tests these work well on all platforms & browsers.
+w += 32;
+h += 96;
+ var win = window.open(url,
+  name, 
+  'width=' + w + ', height=' + h + ', ' +
+  'location=no, menubar=no, ' +
+  'status=no, toolbar=no, scrollbars=yes, resizable=yes');
+ win.resizeTo(w, h);
+ win.focus();
+}
+
 function enable_change()
 {
  var endis = !(document.iform.ips_policy_enable.checked);
@@ -265,7 +283,10 @@ function enable_change()
 		<tr>
 			<td class="vexpl"><br/>
 		<?php printf(gettext("# The rules directory is empty:  %s%s/rules%s"), '<strong>',$snortdir,'</strong>'); ?> <br/><br/>
-		<?php printf(gettext("Please go to the %sUpdates%s tab to download the rules configured on the %sGlobal%s tab."),'<strong>' ,'</strong>', '<strong>' ,'</strong>'); ?>
+		<?php echo gettext("Please go to the ") . '<a href="snort_download_updates.php"><strong>' . gettext("Updates") . 
+			'</strong></a>' . gettext(" tab to download the rules configured on the ") . 
+			'<a href="snort_interfaces_global.php"><strong>' . gettext("Global") . 
+			'</strong></a>' . gettext(" tab."); ?>
 			</td>
 		</tr>
 <?php else: 
@@ -302,7 +323,7 @@ function enable_change()
 					   </tr>
 					   <tr>
 						<td width="15%" class="listn"><?php echo gettext("Auto Flowbit Rules"); ?></td>
-						<td width="85%"><input type="button" class="formbtn" value="View" onclick="popup('snort_rules_edit.php?id=<?=$id;?>&openruleset=<?=$flowbit_rules_file;?>')" <?php echo $btn_view_flowb_rules; ?>/>
+						<td width="85%"><input type="button" class="formbtn" value="View" onclick="wopen('snort_rules_edit.php?id=<?=$id;?>&openruleset=<?=$flowbit_rules_file;?>','FileViewer',800,600)" <?php echo $btn_view_flowb_rules; ?>/>
 						&nbsp;&nbsp;<span class="vexpl"><?php echo gettext("Click to view auto-enabled rules required to satisfy flowbit dependencies"); ?></span></td>
 					   </tr>
 					   <tr>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -512,7 +512,7 @@
 		<!-- Use both styles for now, since our snort port isn't yet optionsng, but barnyard2 and others are. -->
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL;snort_UNSET=TARGETBASED PERFPROFILE REACT;snort_SET=DECODERPRE FLEXRESP3 GRE IPV6 MPLS NORMALIZER ZLIB;perl_SET=THREADS;WITH_THREADS=yes;WITH_IPV6=true;WITH_MPLS=true;WITH_GRE=true;WITHOUT_TARGETBASED=true;WITH_DECODERPRE=true;WITH_ZLIB=true;WITH_NORMALIZER=true;WITHOUT_REACT=true;WITH_FLEXRESP3=true;WITHOUT_ODBC=true;WITHOUT_POSTGRESQL=true;WITHOUT_PRELUDE=true;NOPORTDOCS=true</build_options>
 		<config_file>http://www.pfsense.com/packages/config/snort/snort.xml</config_file>
-		<version>2.9.4.1 pkg v. 2.5.6</version>
+		<version>2.9.4.1 pkg v. 2.5.7</version>
 		<required_version>2.0</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -499,7 +499,7 @@
 		<!-- Use both styles for now, since our snort port isn't yet optionsng, but barnyard2 and others are. -->
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL;snort_UNSET=TARGETBASED PERFPROFILE REACT;snort_SET=DECODERPRE FLEXRESP3 GRE IPV6 MPLS NORMALIZER ZLIB;perl_SET=THREADS;WITH_THREADS=yes;WITH_IPV6=true;WITH_MPLS=true;WITH_GRE=true;WITHOUT_TARGETBASED=true;WITH_DECODERPRE=true;WITH_ZLIB=true;WITH_NORMALIZER=true;WITHOUT_REACT=true;WITH_FLEXRESP3=true;WITHOUT_ODBC=true;WITHOUT_POSTGRESQL=true;WITHOUT_PRELUDE=true;NOPORTDOCS=true</build_options>
 		<config_file>http://www.pfsense.com/packages/config/snort/snort.xml</config_file>
-		<version>2.9.4.1 pkg v. 2.5.6</version>
+		<version>2.9.4.1 pkg v. 2.5.7</version>
 		<required_version>2.0</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>


### PR DESCRIPTION
# Snort 2.9.4.1 - Package Version 2.5.7
# CHANGE LOG  -- 04/25/2013

This update for the Snort package includes several bug fixes, process and UI enhancements and new features.  This updates the package to version 2.5.7.  This is a GUI code update only.  The underlying Snort binary package is still 2.9.4.1.
# Bug Fixes
1.  Fixed longstanding bug preventing edits to the intervals for the  "Rules Update" and "Remove Blocked Offenders" cron jobs.  Changes made in the GLOBAL SETTINGS tab altering the initial settings are now saved and actually implemented in /etc/crontab.
2.  Made additional enhancements to the ".../etc/rc.d/snort.sh" script to further improve the startup reliability of Snort and Barnyard2.  Found it necessary to add back the code in the "rc_start()" function that prevents double-starting of Snort on reboots following firmware updates or reboots.  These changes also corrected problems with Snort not auto-starting following 2.1-BETA snapshot updates and the associated package reinstallation.
3.  Corrected a perceived bug in how the Snort reinstall process worked when reinstalling using previously saved settings.  Now, if previously saved Snort settings are detected, Snort is auto-started at the end of the post-install process.  Several users requested this new behavior.
4.  Corrected a number of typos in the Automatic Rules Update module where string variables used as arguments within quotes were not properly delimited with braces {}.  For example, "$my_variable" instead of "{$my_variable}".  This could certainly have caused some random mischief!
5.  Found several more HTML formatting errors scattered around in various modules.  Fixing these corrected some weird table formatting issues with stuff not lining up correctly.  One example was on the ALERTS tab where on Internet Explorer the layout was scrunched up all on the right-hand side when the alerts table was empty.
6.  On the ALERTS tab, the CLEAR button was set to "type=button" instead of the required "type=submit".  This caused the CLEAR button to be ineffective in Internet Explorer because it was not hooked to the page form object, and consequently alerts could not be cleared when using Internet Explorer 9 or higher.
7.  On the SNORT INTERFACES tab, added code to insure the ".../etc/rc.d/snort.sh" shell script was correctly generated each time an interface was added, removed or had the Barnyard2 settings modified.  Previously, some actions could result in the required lines not being added to the shell script.
8.  Fixed some spelling errors in assorted log messages and in a few code comments.  These had no impact on functionality, but they just looked bad.
9.  Fixed a bug in the new PBI-aware install code where during certain stages of package reinstalling on 2.1 systems the PBI path was null.  Now, when the PBI path for Snort shows as null, a sane default value is used instead.  This bug was also partly responsible for Snort reinstall failures on 2.1 systems during snapshot updates.
# Enhanced or New Features
1.  Added a check on the SNORT INTERFACES tab for an empty set of rules on an interface.  If a configured and enabled interface has no selected rules, a warning icon is now printed next to the offending interface.  Additionally, a warning message is also printed in the system log when the interface is started.  Lack of selected rules will not prevent Snort from starting on the interface, but now the user is notified of the condition.
2.  Changed the pop-up window for viewing the Flowbit-Required Rules and the Rule Updates Log to be a more conventional style custom pop-up that is not full-screen and does not contain the menu UI of pfSense.  This will hopefully prevent some user confusion caused by the old UI where the pop-up window was full-screen and contained the menu.  However, this old pop-up window did not have all the necessary state information from the old window; so some menu functions within Snort would get confused.
3.  Added an automatic VIEW button to the PREPROCESSORS tab that appears whenever the automatic disabling of preprocessor-dependent rules is enabled and it has resulted in some rules actually being disabled.  The user can now directly view these auto-disabled rules using the VIEW button on the PREPROCESSORS tab.  Note that this new button only appears if rules have actually been disabled.  If no rules were auto-disabled, then the new VIEW button is hidden.
4.  Changed several of the system log messages from Snort to be more descriptive.  Also added a few additional messages from the Snort package deletion and reinstallation routines to give a better record of the process in the event something goes wrong.
5.  Continuing in the vein of making Snort easier for novices to use right out-of-the-box without inadvertently shooting themselves in the foot, the Snort package now default enables the most commonly-needed preprocessors.  These are clearly marked now on the PREPROCESSORS tab.  The new default values are used only when the user has never selected a value.  If you have an existing Snort installation and saved the values "unchecked", then they will remain that way until you change them.
6.  Added a new CLEAR button on the Custom Rules view of the RULES tab.  When the Custom Rules are selected in the dropdown, and the text area is available for editing custom rules, you now have a CLEAR button that will delete all custom rules in the text area and erase them from the configuration file.  The new button has a confirmation dialog where you must answer OK before it actually clears the custom rules.
7.  Improved the security and integrity of the Rules Update process (both manual and automated) by incorporating verification of the MD5 hash of downloaded rules update files before unpacking and installing them.  Previously the code simply tested that the downloaded file size was greater than an arbitrary number.  If yes, the download was assumed good.  In the new scheme, the MD5 hash of the downloaded file is calculated and then compared to the MD5 hash obtained from the rules origin web site.  Only if they match does the updating of the rules proceed.  If the hashes do not match, appropriate error messages are sent to the system log and the Rules Update Log.
