### PR TITLE
There should only be one instance of unbound monitor running

### DIFF
--- a/config/unbound/unbound_monitor.sh
+++ b/config/unbound/unbound_monitor.sh
@@ -43,7 +43,7 @@ fi
 
 PROCS=`/bin/pgrep -f unbound_monitor.sh | wc -l | awk '{print $1}'`
 
-if [ ${PROCS} -gt 2 ]; then
+if [ ${PROCS} -gt 1 ]; then
 	echo "There are another unbound monitor proccess running"
 	exit 0
 fi


### PR DESCRIPTION
Script checks the number of running instances of itself and exits if
more than two. Since there should only be one instance running (itself)
it should check for more than one.
