### PR TITLE
haproxy-devel updated to version 1.5dev19, including support for 'transparent proxy'

### DIFF
--- a/config/haproxy-devel/haproxy.inc
+++ b/config/haproxy-devel/haproxy.inc
@@ -934,6 +934,8 @@ function haproxy_check_run($reload) {
 
 	if(use_transparent_clientip_proxying())
 		load_ipfw_rules();
+	else
+		mwexec("/usr/local/sbin/ipfw_context -d haproxy", true);
 	
 	if(isset($a_global['enable'])) {
 		if (isset($a_global['carpdev'])) {

--- a/config/haproxy-devel/haproxy_pool_edit.php
+++ b/config/haproxy-devel/haproxy_pool_edit.php
@@ -491,7 +491,7 @@ foreach($simplefields as $field){
 				</table>
 			</td>
 		</tr>
-		<tr align="left" style="display:none;">
+		<tr align="left">
 			<td width="22%" valign="top" class="vncell">Transparent ClientIP</td>
 			<td width="78%" class="vtable" colspan="2">
 				<input id="transparent_clientip" name="transparent_clientip" type="checkbox" value="yes" <?php if ($pconfig['transparent_clientip']=='yes') echo "checked"; ?> onclick='updatevisibility();'>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -183,14 +183,14 @@
 				This package implements TCP, HTTP and HTTPS balance features from Haproxy.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5-dev18 pkg v 0.2</version>
+		<version>1.5-dev19 pkg v 0.3</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>http://www.pfsense.com/packages/config/haproxy-devel/haproxy.xml</config_file>
 		<configurationfile>haproxy.xml</configurationfile>
 		<depends_on_package_base_url>http://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
 		<depends_on_package>haproxy-1.4.21.tbz</depends_on_package>
-		<depends_on_package_pbi>haproxy-devel-1.5-dev18-i386.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>haproxy-devel-1.5-dev19-i386.pbi</depends_on_package_pbi>
 		<build_port_path>/usr/ports/net/haproxy-devel</build_port_path>
 		<build_pbi>
 			<ports_before>security/openssl/</ports_before>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -170,14 +170,14 @@
 				This package implements TCP, HTTP and HTTPS balance features from Haproxy.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5-dev18 pkg v 0.2</version>
+		<version>1.5-dev19 pkg v 0.3</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>http://www.pfsense.com/packages/config/haproxy-devel/haproxy.xml</config_file>
 		<configurationfile>haproxy.xml</configurationfile>
 		<depends_on_package_base_url>http://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
 		<depends_on_package>haproxy-1.4.21.tbz</depends_on_package>
-		<depends_on_package_pbi>haproxy-devel-1.5-dev18-amd64.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>haproxy-devel-1.5-dev19-amd64.pbi</depends_on_package_pbi>
 		<build_port_path>/usr/ports/net/haproxy-devel</build_port_path>
 		<build_pbi>
 			<ports_before>security/openssl/</ports_before>


### PR DESCRIPTION
haproxy-devel updated to version 1.5dev19, including support for 'transparent proxy'
