### PR TITLE
IPv6 Addresses need to be enclosed in brackets

### DIFF
--- a/config/squid3/33/squid_reverse.inc
+++ b/config/squid3/33/squid_reverse.inc
@@ -89,6 +89,9 @@ function squid_resync_reverse() {
 	if(!empty($settings['reverse_ip'])) {
 		$reverse_ip = explode(";", ($settings['reverse_ip']));
 		foreach ($reverse_ip as $reip) {
+		      //IPv6 Addresses need to be enclosed in brackets
+		      if (strpos($reip, ':')) $reip = '[' . $reip . ']';
+		      
 		      //HTTP
 		      if (!empty($settings['reverse_http']))
 		      		$conf .= "http_port {$reip}:{$http_port} accel defaultsite={$http_defsite} vhost\n";


### PR DESCRIPTION
IPv6 Addresses need to be enclosed in brackets

This is a very lazy test for IPv6 instead of IPv4 addresses. The desired function, filter_var, does not appear to be available in the pfSense build I'm running.

http://php.net/manual/en/function.filter-var.php
