### PR TITLE
Fix Incorrect Directory Replacement

### DIFF
--- a/config/dansguardian/dansguardian.inc
+++ b/config/dansguardian/dansguardian.inc
@@ -321,7 +321,7 @@ function sync_package_dansguardian($via_rpc="no",$install_process=false) {
 	
 	#contentscanners preg_replace patterns
 	$match[0]="/(conf)/";
-	$match[1]="/(\/usr.local)/";
+	$match[1]="/\/usr.local|".str_replace("/","\\/",DANSGUARDIAN_DIR)."/";
 	$match[2]="/,/";
 	$replace[0]="$1'";
 	$replace[1]="contentscanner = '".DANSGUARDIAN_DIR;


### PR DESCRIPTION
On some installs, the directory ends up being /usr/pbi/dansguardian-xxx/...
This results in include lines not being written correctly and broken config files. DANSGUARDIAN_DIR should be present on every system.
