### PR TITLE
siproxd: separate enable/disable of RTP proxy from rest of daemon

### DIFF
--- a/config/siproxd.inc
+++ b/config/siproxd.inc
@@ -162,7 +162,7 @@ function sync_package_siproxd() {
 	if($siproxd_conf['rtpenable'] != "") {
 		fwrite($fout, "rtp_proxy_enable = " . $siproxd_conf['rtpenable'] . "\n");
 	} else {
-		fwrite($fout, "rtp_proxy_enable = 0\n");
+		fwrite($fout, "rtp_proxy_enable = 1\n");
 	}
 
 	if(($siproxd_conf['rtplower'] != "") && ($siproxd_conf['rtpupper'] != "")) {

--- a/config/siproxd.xml
+++ b/config/siproxd.xml
@@ -120,7 +120,7 @@
 		<field>
 			<fielddescr>Enable RTP proxy</fielddescr>
 			<fieldname>rtpenable</fieldname>
-			<description>Enable or disable the RTP proxy. (default is disabled)</description>
+			<description>Enable or disable the RTP proxy. (default is enabled)</description>
 			<type>select</type>
 			<options>
 				<option>


### PR DESCRIPTION
I added a sipenable setting to siproxd that allows one to run siproxd without the RTP proxy feature enabled. This allows one to maintain a SIP registration proxy while allowing RTP packets to pass through the firewall unproxied. Not proxying RTP packets leads to less latency and jitter and simplifies traffic shaping.
