### PR TITLE
nut: Adding cyberpower MIB as a selectable value

### DIFF
--- a/config/nut/nut.xml
+++ b/config/nut/nut.xml
@@ -599,6 +599,10 @@
 					<name>pw</name>
 					<value>pw</value>
 				</option>
+				<option>
+					<name>cyberpower</name>
+					<value>cyberpower</value>
+				</option>
 			</options>
 		</field>
 		<field>


### PR DESCRIPTION
Enable the 'cyberpower' MIB to be able to use the snmp-ups driver together with pfsense's nut package.
