### PR TITLE
bandwidthd - specify explicitly the graph location index.html

### DIFF
--- a/config/bandwidthd/bandwidthd.xml
+++ b/config/bandwidthd/bandwidthd.xml
@@ -70,7 +70,7 @@
 		</tab>
 		<tab>
 			<text>Access BandwidthD</text>
-			<url>/bandwidthd" target="_blank</url>
+			<url>/bandwidthd/index.html" target="_blank</url>
 		</tab>
 	</tabs>
 	<configpath>installedpackages->package->bandwidthd</configpath>


### PR DESCRIPTION
This helps some people whose browser does not find index.html automagically, and does not harm anything for others. Not worth bumping the version just for this.
http://forum.pfsense.org/index.php/topic,49165.msg362705.html#msg362705
