### PR TITLE
Update asterisk.xml

### DIFF
--- a/config/asterisk/asterisk.xml
+++ b/config/asterisk/asterisk.xml
@@ -98,6 +98,6 @@
 	<custom_delete_php_command>
 	</custom_delete_php_command>	
 	<custom_php_resync_config_command>
-		sync_package_asterisk();
+/*		sync_package_asterisk(); */
 	</custom_php_resync_config_command>
 </packagegui>


### PR DESCRIPTION
Function sync_package_asterisk(); is called twice when installing  (also from asterisk_install();) this makes several edits in the startup and config files twice. Commented it out for now here.
