### PR TITLE
Fix logrotate lines max

### DIFF
--- a/config/squidGuard/squidguard_configurator.inc
+++ b/config/squidGuard/squidguard_configurator.inc
@@ -205,6 +205,7 @@ define('SQUIDGUARD_GUILOG_LEVEL',           SQUIDGUARD_INFO);     # log level
 define('SQUIDGUARD_GUILOG_MAXCOUNT',        500);                 # log max lines
 define('SQUIDGUARD_GUILOG_ENABLE',          true);                # on/off gui log - option override GUI settings
 define('SQUIDGUARD_LOG_ENABLE',             true);                # on/off SG  log - option override GUI settings
+define('SQUIDGUARD_LOGROTATE_MAXCOUNT',             1000);                # logrotate max lines
 
 #
 define('FLT_DEFAULT_ALL', 'all');
@@ -1920,7 +1921,8 @@ function acl_remove_blacklist_items($items)
 # -----------------------------------------------------------------------------
 function sg_script_logrotate()
 {
-
+	$lines = SQUIDGUARD_LOGROTATE_MAXCOUNT;
+	
 	global $squidguard_config;
 
 	$sglogname = $squidguard_config[F_LOGDIR] . "/" . SQUIDGUARD_LOGFILE;


### PR DESCRIPTION
$lines variable is not defined in "sg_script_logrotate" function.
tail: -: No such file or directory
