### PR TITLE
adding generic USB UPS support via blazer_usb module that is supported a...

### DIFF
--- a/config/nut/nut.xml
+++ b/config/nut/nut.xml
@@ -299,6 +299,10 @@
 					<value>upscode204</value>
 				</option>
 				<option>
+					<name>Generic USB UPS (Blazer)</name>
+					<value>blazer_usb01</value>
+				</option>
+				<option>
 					<name>Inform GUARD Line Interactive</name>
 					<value>powercom00</value>
 				</option>


### PR DESCRIPTION
This Pull request adds a menu item for Generic UPS support support via the blazer_usb driver

This is confirmed working with ProLink model UPS and likely many others

it might be better to generate this list automatically from the supported drivers list in some way as likely many other UPS' could be supported very very easily but simply aren't because the menu doesnt cater for them
