### PR TITLE
Fixed URL under ACL's tab. Was opening the default group rather than pre...

### DIFF
--- a/config/dansguardian/dansguardian_ips_header.template
+++ b/config/dansguardian/dansguardian_ips_header.template
@@ -64,7 +64,7 @@
 		</tab>
 		<tab>
 			<text>ACLs</text>
-			<url>/pkg_edit.php?xml=dansguardian_site_acl.xml&amp;id=0</url>
+			<url>/pkg.php?xml=dansguardian_site_acl.xml</url>
 		</tab>
 		<tab>
 			<text>LDAP</text>


### PR DESCRIPTION
...senting a list. I.E. - not consistent with how the ACL's tab functioned from any of the other pages
