### PR TITLE
Fixing presentation, typos and location selector

### DIFF
--- a/config/apache_mod_security-dev/apache_balancer.xml
+++ b/config/apache_mod_security-dev/apache_balancer.xml
@@ -112,20 +112,20 @@
 	</adddeleteeditpagefields>
 	<fields>
 		<field>
-			<name>apache Reverse Peer Mappings</name>
+			<name>Apache Reverse Peer Mappings</name>
 			<type>listtopic</type>
 		</field>
 			<field>
 			<fielddescr>Enable</fielddescr>
 			<fieldname>enable</fieldname>
-			<description>If this field is checked, then this server poll will be available for virtual hosts config.</description>
+			<description>If this field is checked, then this server pool will be available for Virtual Hosts configuration.</description>
 			<type>checkbox</type>
 		</field>
 		<field>
 			<fielddescr>Balancer name</fielddescr>
 			<fieldname>name</fieldname>
-			<description><![CDATA[Name to identify this peer on apache conf<br>
-						example: www_site1]]></description>
+			<description><![CDATA[Name to identify this peer in Apache configuration<br>
+						Example: www_site1]]></description>
 			<type>input</type>
 			<size>20</size>
 		</field>
@@ -139,7 +139,7 @@
 		<field>
 			<fielddescr>Protocol</fielddescr>
 			<fieldname>proto</fieldname>
-			<description><![CDATA[Protocol listening on this internal server(s) port.]]></description>
+			<description><![CDATA[Protocol used on the internal server(s).]]></description>
 			<type>select</type>
 			<options>
 				<option> <name>HTTP</name> <value>http</value> </option>
@@ -161,40 +161,40 @@
 				<rowhelperfield>
 					<fielddescr>FQDN or IP Address</fielddescr>
 					<fieldname>host</fieldname>
-					<description>Internal site IP or Hostnamesite</description>
+					<description>Internal site IP or site hostname</description>
 					<type>input</type>
 					<size>27</size>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>port</fielddescr>
+					<fielddescr>Port</fielddescr>
 					<fieldname>port</fieldname>
 					<description>Internal site port</description>
 					<type>input</type>
 					<size>5</size>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>routeid</fielddescr>
+					<fielddescr>Route ID</fielddescr>
 					<fieldname>routeid</fieldname>
 					<description>ID to define sticky connections</description>
 					<type>input</type>
 					<size>6</size>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>weight</fielddescr>
+					<fielddescr>Weight</fielddescr>
 					<fieldname>loadfactor</fieldname>
 					<description>Server weight</description>
 					<type>input</type>
 					<size>4</size>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>ping</fielddescr>
+					<fielddescr>Ping</fielddescr>
 					<fieldname>ping</fieldname>
 					<description>Server ping test interval</description>
 					<type>input</type>
 					<size>6</size>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>ttl</fielddescr>
+					<fielddescr>TTL</fielddescr>
 					<fieldname>ttl</fieldname>
 					<description>Server ping TTL</description>
 					<type>input</type>

--- a/config/apache_mod_security-dev/apache_location.xml
+++ b/config/apache_mod_security-dev/apache_location.xml
@@ -104,7 +104,7 @@
 			<fieldname>balancer</fieldname>
 		</columnitem>
 		<columnitem>
-			<fielddescr>lbmethod</fielddescr>
+			<fielddescr>LB Method</fielddescr>
 			<fieldname>lbmethod</fieldname>
 		</columnitem>
 		<columnitem>

--- a/config/apache_mod_security-dev/apache_mod_security.inc
+++ b/config/apache_mod_security-dev/apache_mod_security.inc
@@ -582,6 +582,7 @@ EOF;
 				foreach ($virtualhost['row'] as $be){
 					if ($be['location'] != "none"){
 						$backend=$apache_location[$be['location']];
+						$vh_config.="# {$backend['name']}\n";
 						$vh_config.=" <Location ".($backend['sitepath'] ? $backend['sitepath'] : "/").">\n";
 						$vh_config.="  ProxyPass        balancer://{$backend['balancer']}{$backend['backendpath']}\n";
 						$vh_config.="  ProxyPassReverse balancer://{$backend['balancer']}{$backend['backendpath']}\n";

--- a/config/apache_mod_security-dev/apache_virtualhost.xml
+++ b/config/apache_mod_security-dev/apache_virtualhost.xml
@@ -267,7 +267,7 @@
 			<show_disable_value>none</show_disable_value>
 		</field>
 		<field>
-			<fielddescr>intermediate CA certificate(optional)</fielddescr>
+			<fielddescr>Intermediate CA certificate (optional)</fielddescr>
 			<fieldname>reverse_int_ca</fieldname>
 			<description>Select intermediate CA assigned to certificate. Not all certificates require this.</description>
 			<type>select_source</type>
@@ -285,8 +285,8 @@
 			<rowhelper>
 				<rowhelperfield>
 					<fielddescr><![CDATA[Location]]></fielddescr>
-					<fieldname>Location</fieldname>
-					<description>Server locatino</description>
+					<fieldname>location</fieldname>
+					<description>Server Location</description>
 					<source><![CDATA[$config['installedpackages']['apachelocation']['config']]]></source>
 					<source_name>name</source_name>
 					<source_value>name</source_value>


### PR DESCRIPTION
- Fixed presentation (capitalization mostly)
- Fixed a few typos
- Fixed fieldname in apache_virtualhost.xml for location referencing (otherwise, reloading the VirtualHost screen makes the setting return to 'none')
- Add a comment to virtualhost config to identify locations in generated Apache config file
