### PR TITLE
systempatches, allow patches with a different folder structure to be committed (useful for packages) v2

### DIFF
--- a/config/systempatches/patches.inc
+++ b/config/systempatches/patches.inc
@@ -34,6 +34,7 @@ $git_root_url = "http://github.com/pfsense/pfsense/commit/";
 $patch_suffix = ".patch";
 $patch_dir = "/var/patches";
 $patch_cmd = "/usr/bin/patch";
+$patches_config = &$config['installedpackages']['patches'];
 
 function patch_package_install() {
 	patch_add_shellcmd();
@@ -97,6 +98,17 @@ function patch_fetch(& $patch) {
 	}
 }
 
+function rewrite_patch_paths(&$patch) {
+	global $patches_config;
+	$pathrewrites = base64_decode($patches_config['pathrewrites']);
+	$filepathrewrites = explode("\n", $pathrewrites);
+	foreach($filepathrewrites as $changeitem){
+		$oldnew = explode("|",$changeitem);
+		$patch = str_replace("--- a/".$oldnew[0],"--- a/".$oldnew[1],$patch);
+		$patch = str_replace("+++ b/".$oldnew[0],"+++ b/".$oldnew[1],$patch);
+	}
+}
+
 /* Write a patch file out to $patch_dir */
 function patch_write($patch) {
 	global $patch_dir, $patch_suffix;
@@ -107,6 +119,8 @@ function patch_write($patch) {
 		return false;
 	} else {
 		$text = base64_decode($patch['patch']);
+		if (isset($patch['rewritepaths']))
+			rewrite_patch_paths($text);
 		$filename = $patch_dir . '/' . $patch['uniqid'] . $patch_suffix;
 		return (file_put_contents($filename, $text) > 0);
 	}

--- a/config/systempatches/patches.inc
+++ b/config/systempatches/patches.inc
@@ -34,7 +34,9 @@ $git_root_url = "http://github.com/pfsense/pfsense/commit/";
 $patch_suffix = ".patch";
 $patch_dir = "/var/patches";
 $patch_cmd = "/usr/bin/patch";
-$patches_config = &$config['installedpackages']['patches'];
+
+if (isset($config['installedpackages']['patches']))
+	$patches_config = &$config['installedpackages']['patches'];
 
 function patch_package_install() {
 	patch_add_shellcmd();
@@ -102,10 +104,15 @@ function rewrite_patch_paths(&$patch) {
 	global $patches_config;
 	$pathrewrites = base64_decode($patches_config['pathrewrites']);
 	$filepathrewrites = explode("\n", $pathrewrites);
-	foreach($filepathrewrites as $changeitem){
+	foreach($filepathrewrites as $changeitem) {
 		$oldnew = explode("|",$changeitem);
-		$patch = str_replace("--- a/".$oldnew[0],"--- a/".$oldnew[1],$patch);
-		$patch = str_replace("+++ b/".$oldnew[0],"+++ b/".$oldnew[1],$patch);
+
+		$search = preg_quote($oldnew[0],"/");
+		$replace = $oldnew[1];
+		
+		$search = "/^((---)|(\+\+\+)) ((a\/)|(b\/))?$search/m";
+		$replace = "$1 $4$replace";
+		$patch = preg_replace($search, $replace, $patch);
 	}
 }
 

--- a/config/systempatches/system_patches.php
+++ b/config/systempatches/system_patches.php
@@ -162,6 +162,17 @@ include("head.inc");
 <script type="text/javascript" language="javascript" src="/javascript/row_toggle.js"></script>
 <?php if ($savemsg) print_info_box($savemsg); ?>
 <table width="100%" border="0" cellpadding="0" cellspacing="0" summary="system patches">
+	<tr>
+		<td class="tabnavtbl">
+		<?php
+		/* active tabs */
+		$tab_array = array();
+		$tab_array[] = array("Patches", true, "system_patches.php");
+		$tab_array[] = array("Path rewrites", false, "system_patches_pathrewrites.php");
+		display_top_tabs($tab_array);
+		?>
+		</td>
+	</tr>
 <tr><td><div id="mainarea">
 <table class="tabcont" width="100%" border="0" cellpadding="0" cellspacing="0" summary="main area">
 <tr><td colspan="8" align="center">

--- a/config/systempatches/system_patches.php
+++ b/config/systempatches/system_patches.php
@@ -48,7 +48,7 @@ $a_patches = &$config['installedpackages']['patches']['item'];
 
 /* if a custom message has been passed along, lets process it */
 if ($_GET['savemsg'])
-	$savemsg = $_GET['savemsg'];
+	$savemsg = htmlspecialchars($_GET['savemsg']);
 
 if ($_POST) {
 	$pconfig = $_POST;

--- a/config/systempatches/system_patches_edit.php
+++ b/config/systempatches/system_patches_edit.php
@@ -217,7 +217,7 @@ include("head.inc");
 	<td width="78%" class="vtable">
 		<input name="rewritepaths" type="checkbox" id="rewritepaths" value="yes" <?php if ($pconfig['rewritepaths']) echo "checked=\"checked\""; ?> />
 		<strong><?=gettext("Rewrite file paths"); ?></strong><br />
-		<span class="vexpl"><?=gettext("Set this option for patches that need to apply to a different folder structure then they have on git."); ?></span>
+		<span class="vexpl"><?=gettext("Set this option for patches that need to apply to a different folder structure than they have on git."); ?></span>
 	</td>
 </tr>
 <tr>

--- a/config/systempatches/system_patches_edit.php
+++ b/config/systempatches/system_patches_edit.php
@@ -62,6 +62,7 @@ if (isset($id) && $a_patches[$id]) {
 	$pconfig['basedir'] = $a_patches[$id]['basedir'];
 	$pconfig['ignorewhitespace'] = isset($a_patches[$id]['ignorewhitespace']);
 	$pconfig['autoapply'] = isset($a_patches[$id]['autoapply']);
+	$pconfig['rewritepaths'] = isset($a_patches[$id]['rewritepaths']);
 	$pconfig['uniqid'] = $a_patches[$id]['uniqid'];
 } else {
 	$pconfig['pathstrip'] = 1;
@@ -118,6 +119,7 @@ if ($_POST) {
 		$thispatch['basedir'] = empty($_POST['basedir']) ? "/" : $_POST['basedir'];
 		$thispatch['ignorewhitespace'] = isset($_POST['ignorewhitespace']);
 		$thispatch['autoapply'] = isset($_POST['autoapply']);
+		$thispatch['rewritepaths'] = isset($_POST['rewritepaths']);
 		if (empty($_POST['uniqid'])) {
 			$thispatch['uniqid'] = uniqid();
 		} else {
@@ -147,8 +149,8 @@ $pgtitle = array(gettext("System"),gettext("Patches"), gettext("Edit"));
 include("head.inc");
 
 ?>
-<link type="text/css" rel="stylesheet" href="/pfCenter/javascript/chosen/chosen.css" />
-<script src="/pfCenter/javascript/chosen/chosen.proto.js" type="text/javascript"></script>
+<link type="text/css" rel="stylesheet" href="/javascript/chosen/chosen.css" />
+<script src="/javascript/chosen/chosen.proto.js" type="text/javascript"></script>
 </head>
 
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
@@ -208,6 +210,14 @@ include("head.inc");
 		<input name="autoapply" type="checkbox" id="autoapply" value="yes" <?php if ($pconfig['autoapply']) echo "checked=\"checked\""; ?> />
 		<strong><?=gettext("Auto-Apply Patch"); ?></strong><br />
 		<span class="vexpl"><?=gettext("Set this option to apply the patch automatically when possible, useful for patches to survive after firmware updates."); ?></span>
+	</td>
+</tr>
+<tr>
+	<td width="22%" valign="top" class="vncell"><?=gettext("Rewrite file paths"); ?></td>
+	<td width="78%" class="vtable">
+		<input name="rewritepaths" type="checkbox" id="rewritepaths" value="yes" <?php if ($pconfig['rewritepaths']) echo "checked=\"checked\""; ?> />
+		<strong><?=gettext("Rewrite file paths"); ?></strong><br />
+		<span class="vexpl"><?=gettext("Set this option for patches that need to apply to a different folder structure then they have on git."); ?></span>
 	</td>
 </tr>
 <tr>

--- a/config/systempatches/system_patches_pathrewrites.php
+++ b/config/systempatches/system_patches_pathrewrites.php
@@ -91,12 +91,11 @@ include("head.inc");
 		<table class="tabcont" width="100%" border="0" cellpadding="0" cellspacing="0" summary="main area">
 		<tr><td colspan="8">
 			<?php 
-			echo gettext("This page allows you to set 'path rewrites' for files inside patches, set the 'rewrite path' checkbox in the and fill this memobox with the proper patchpath|realpath values seperated by pipes. Each file should be on a seperate line. If no realpath is set, that file will be skipped.");
+			echo gettext("This page allows you to set 'path rewrites' for files inside patches, set the 'rewrite path' checkbox in the patch and fill this memobox with the proper patchpath|realpath values seperated by pipes. Each file should be on a seperate line.");
 			echo gettext("<br/><br/>Example:");
 			?>
 			<br/>
-			<b>config/haproxy-devel/haproxy.xml|<br/>
-			config/haproxy-devel/haproxy.inc|usr/local/pkg/haproxy.inc<br/>
+			<b>config/haproxy-devel/haproxy.inc|usr/local/pkg/haproxy.inc<br/>
 			config/haproxy-devel/haproxy_global.php|usr/local/www/haproxy_global.php</b><br/>
 			<br/><br/>
 			</td>

--- a/config/systempatches/system_patches_pathrewrites.php
+++ b/config/systempatches/system_patches_pathrewrites.php
@@ -1,0 +1,122 @@
+<?php
+/*
+	system_patches.php
+	Copyright (C) 2012 Jim Pingle
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/*
+	pfSense_MODULE:	system
+*/
+
+##|+PRIV
+##|*IDENT=page-system-patches
+##|*NAME=System: Patches
+##|*DESCR=Allow access to the 'System: Patches' page.
+##|*MATCH=system_patches.php*
+##|-PRIV
+
+require("guiconfig.inc");
+require_once("functions.inc");
+require_once("itemid.inc");
+require_once("patches.inc");
+
+if (!is_array($config['installedpackages']['patches']['item']))
+	$config['installedpackages']['patches']['item'] = array();
+
+$patches_config = &$config['installedpackages']['patches'];
+
+/* if a custom message has been passed along, lets process it */
+if ($_GET['savemsg'])
+	$savemsg = $_GET['savemsg'];
+
+if ($_POST) {
+	$pconfig = $_POST;
+	if (!empty($_POST['pathrewrites'])) {
+		/* Strip DOS style carriage returns from textarea input */
+		$patches_config['pathrewrites'] = base64_encode(str_replace("\r", "", $pconfig['pathrewrites']));
+	}
+	write_config("Patches path rewrite files saved");
+}
+
+$closehead = false;
+$pgtitle = array(gettext("System"),gettext("Patches"),gettext("Path rewrites"));
+include("head.inc");
+
+?>
+<script type="text/javascript" src="/javascript/domTT/domLib.js"></script>
+<script type="text/javascript" src="/javascript/domTT/domTT.js"></script>
+<script type="text/javascript" src="/javascript/domTT/behaviour.js"></script>
+<script type="text/javascript" src="/javascript/domTT/fadomatic.js"></script>
+
+<link type="text/css" rel="stylesheet" href="/javascript/chosen/chosen.css" />
+</head>
+<body link="#000000" vlink="#000000" alink="#000000">
+<?php include("fbegin.inc"); ?>
+<form action="system_patches_pathrewrites.php" method="post" name="iform">
+<script type="text/javascript" language="javascript" src="/javascript/row_toggle.js"></script>
+<?php if ($savemsg) print_info_box($savemsg); ?>
+	<table width="100%" border="0" cellpadding="0" cellspacing="0" summary="system patches">
+	<tr><td class="tabnavtbl">
+		<?php
+		/* active tabs */
+		$tab_array = array();
+		$tab_array[] = array("Patches", false, "system_patches.php");
+		$tab_array[] = array("Path rewrites", true, "system_patches_pathrewrites.php");
+		display_top_tabs($tab_array);
+		?>
+		</td>
+	</tr>
+	<tr><td><div id="mainarea">
+		<table class="tabcont" width="100%" border="0" cellpadding="0" cellspacing="0" summary="main area">
+		<tr><td colspan="8">
+			<?php 
+			echo gettext("This page allows you to set 'path rewrites' for files inside patches, set the 'rewrite path' checkbox in the and fill this memobox with the proper patchpath|realpath values seperated by pipes. Each file should be on a seperate line. If no realpath is set, that file will be skipped.");
+			echo gettext("<br/><br/>Example:");
+			?>
+			<br/>
+			<b>config/haproxy-devel/haproxy.xml|<br/>
+			config/haproxy-devel/haproxy.inc|usr/local/pkg/haproxy.inc<br/>
+			config/haproxy-devel/haproxy_global.php|usr/local/www/haproxy_global.php</b><br/>
+			<br/><br/>
+			</td>
+		</tr>
+		<tr>
+			<td>
+				<?=gettext("Path rewrites:"); ?><br/>
+				<textarea name="pathrewrites" class="" id="pathrewrites" rows="15" cols="90" wrap="off"><?=htmlspecialchars(base64_decode($patches_config['pathrewrites']));?></textarea>
+			</td>
+		</tr>
+		<tr>
+			<td align="center">
+				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
+			</td>
+		</tr>
+		</table>
+		</div></td>
+	</tr>
+	</table>
+</form>
+<?php include("fend.inc"); ?>
+</body>
+</html>

--- a/config/systempatches/system_patches_pathrewrites.php
+++ b/config/systempatches/system_patches_pathrewrites.php
@@ -1,7 +1,7 @@
 <?php
 /*
 	system_patches.php
-	Copyright (C) 2012 Jim Pingle
+	Copyright (C) 2013 PiBa-NL
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,7 @@ $patches_config = &$config['installedpackages']['patches'];
 
 /* if a custom message has been passed along, lets process it */
 if ($_GET['savemsg'])
-	$savemsg = $_GET['savemsg'];
+	$savemsg = htmlspecialchars($_GET['savemsg']);
 
 if ($_POST) {
 	$pconfig = $_POST;

--- a/config/systempatches/systempatches.xml
+++ b/config/systempatches/systempatches.xml
@@ -57,6 +57,11 @@
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
 		<chmod>644</chmod>
+		<item>https://packages.pfsense.org/packages/config/systempatches/system_patches_pathrewrites.php</item>
+	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/usr/local/www/</prefix>
+		<chmod>644</chmod>
 		<item>https://packages.pfsense.org/packages/config/systempatches/system_patches_edit.php</item>
 	</additional_files_needed>
 	<additional_files_needed>


### PR DESCRIPTION
systempatches, allow patches with a different folder structure to be committed (useful for packages) v2

Same purpose as for https://github.com/pfsense/pfsense-packages/pull/555 but now improved like this:
-no unnecessary whitespace changes
-'simplified' the solution for the parsing/modification of the patch paths.

The intention of the patch is that when you 'fetch' a change from github even if the paths are different its still possible to apply the patch. So when both config/systempatches/patches.inc and config/systempatches/system_patches.php  are affected it is possible to apply the patch. To /usr/local/www/system_patches.php and /usr/local/pkg/patches.inc without the need to manually split up the patch.

Like it was before, the 'modification routine' is optional and must be chosen with a checkbox for a patch to be affected. So their is no possibility for negative affects on current existing and working patches.

@jim-p, i hope this one is ok, as creating 'proper' patches and then using gist to distribute them seams troublesome to me when using git for sourcecontrol but needing to move files around before creating the patch file.. (or needing to manually modify the patches each time). I use the patches package a lot during development&testing and also to easily get the latest changes into my production machine with an easy way to revert any issues that might sometimes arise. I found that creating separate patches for each affected file, (as i cant select 2 out of 3 changed files to create a patch for), then saving them all in the patches package then applying them all is a rather error prone procedure..

Or perhaps should each package represent the directory tree or part thereof it uses? So i should for haproxy move some files to /config/haproxy-devel/www/ and /config/haproxy-devel/pkg/ instead of having them all in 1 directory?