### PR TITLE
Fix typo in snort package name.

### DIFF
--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -497,7 +497,7 @@
 		<configurationfile>vhosts.xml</configurationfile>
 	</package>
 	<package>
-		<name>Snort</name>
+		<name>snort</name>
 		<pkginfolink></pkginfolink>
 		<website>http://www.snort.org</website>
 		<descr>Snort is an open source network intrusion prevention and detection system (IDS/IPS). Combining the benefits of signature, protocol, and anomaly-based inspection.</descr>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -484,7 +484,7 @@
 		<configurationfile>vhosts.xml</configurationfile>
 	</package>
 	<package>
-		<name>Snort</name>
+		<name>snort</name>
 		<pkginfolink></pkginfolink>
 		<website>http://www.snort.org</website>
 		<descr>Snort is an open source network intrusion prevention and detection system (IDS/IPS). Combining the benefits of signature, protocol, and anomaly-based inspection.</descr>


### PR DESCRIPTION
Fix misspelling in snort package name.  Name must be "snort" instead of "Snort".
