### PR TITLE
Incorporate Ermal's comments -- use conf_mount_rw() only where needed.

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -2520,6 +2520,8 @@ function snort_generate_conf($snortcfg) {
 	if (!is_array($config['installedpackages']['snortglobal']['rule']))
 		return;
 
+	conf_mount_rw();
+
 	/* See if we should protect and not modify the preprocessor rules files */
 	if (!empty($snortcfg['protect_preproc_rules'])) 	
 		$protect_preproc_rules = $snortcfg['protect_preproc_rules'];
@@ -3767,10 +3769,12 @@ EOD;
 	$conf = fopen("{$snortcfgdir}/snort.conf", "w");
 	if(!$conf) {
 		log_error("Could not open {$snortcfgdir}/snort.conf for writing.");
+		conf_mount_ro();
 		return -1;
 	}
 	fwrite($conf, $snort_conf_text);
 	fclose($conf);
+	conf_mount_ro();
 	unset($snort_conf_text, $selected_rules_sections, $suppress_file_name, $snort_misc_include_rules, $spoink_type, $snortunifiedlog_type, $alertsystemlog_type);
 	unset($home_net, $external_net, $ipvardef, $portvardef);
 }

--- a/config/snort/snort_alerts.php
+++ b/config/snort/snort_alerts.php
@@ -216,7 +216,6 @@ if (($_GET['act'] == "addsuppress_srcip" || $_GET['act'] == "addsuppress_dstip")
 }
 
 if ($_GET['action'] == "clear" || $_POST['delete']) {
-	conf_mount_rw();
 	snort_post_delete_logs($snort_uuid);
 	$fd = @fopen("/var/log/snort/snort_{$if_real}{$snort_uuid}/alert", "w+");
 	if ($fd)
@@ -225,13 +224,11 @@ if ($_GET['action'] == "clear" || $_POST['delete']) {
 	mwexec('/bin/chmod 660 /var/log/snort/*', true);
 	if (file_exists("{$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid"))
 		mwexec("/bin/pkill -HUP -F {$g['varrun_path']}/snort_{$if_real}{$snort_uuid}.pid -a");
-	conf_mount_ro();
 	header("Location: /snort/snort_alerts.php?instance={$instanceid}");
 	exit;
 }
 
 if ($_POST['download']) {
-	conf_mount_rw();
 	$save_date = exec('/bin/date "+%Y-%m-%d-%H-%M-%S"');
 	$file_name = "snort_logs_{$save_date}_{$if_real}.tar.gz";
 	exec("cd /var/log/snort/snort_{$if_real}{$snort_uuid} && /usr/bin/tar -czf /tmp/{$file_name} *");
@@ -256,8 +253,6 @@ if ($_POST['download']) {
 	}
 	else
 		$savemsg = gettext("An error occurred while creating archive");
-
-	conf_mount_ro();
 }
 
 /* Load up an array with the current Suppression List GID,SID values */

--- a/config/snort/snort_blocked.php
+++ b/config/snort/snort_blocked.php
@@ -63,7 +63,6 @@ if ($_POST['remove']) {
 /* TODO: build a file with block ip and disc */
 if ($_POST['download'])
 {
-	conf_mount_rw();
 	$blocked_ips_array_save = "";
 	exec('/sbin/pfctl -t snort2c -T show', $blocked_ips_array_save);
 	/* build the list */
@@ -105,8 +104,6 @@ if ($_POST['download'])
 			$savemsg = gettext("An error occurred while creating archive");
 	} else
 		$savemsg = gettext("No content on snort block list");
-
-	conf_mount_ro();
 }
 
 if ($_POST['save'])

--- a/config/snort/snort_check_for_rule_updates.php
+++ b/config/snort/snort_check_for_rule_updates.php
@@ -104,6 +104,9 @@ $snort_filename = "snortrules-snapshot-{$snortver[0]}.tar.gz";
 $snort_filename_md5 = "{$snort_filename}.md5";
 $snort_rule_url = VRT_DNLD_URL;
 
+/* Mount the Snort conf directories R/W so we can modify files there */
+conf_mount_rw();
+
 /* Set up Emerging Threats rules filenames and URL */
 if ($etpro == "on") {
 	$emergingthreats_filename = ETPRO_DNLD_FILENAME;
@@ -364,8 +367,9 @@ function snort_fetch_new_rules($file_url, $file_dst, $file_md5, $desc = "") {
 
 }
 
+/**********************/
 /* Start of main code */
-conf_mount_rw();
+/**********************/
 
 /*  remove old $tmpfname files */
 if (is_dir("{$tmpfname}"))

--- a/config/snort/snort_define_servers.php
+++ b/config/snort/snort_define_servers.php
@@ -131,13 +131,14 @@ if ($_POST) {
 
 		$a_nat[$id] = $natent;
 
-		conf_mount_rw();
 		write_config();
 
 		/* Update the snort conf file for this interface. */
 		$rebuild_rules = false;
 		snort_generate_conf($a_nat[$id]);
-		conf_mount_ro();
+
+		/* Soft-restart Snort to live-load new variables. */
+		snort_reload_config($a_nat[$id]);
 
 		/* after click go to this page */
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );

--- a/config/snort/snort_download_updates.php
+++ b/config/snort/snort_download_updates.php
@@ -87,10 +87,8 @@ if (file_exists("{$snortdir}/{$snort_community_rules_filename}.md5"))
 
 /* Check for postback to see if we should clear the update log file. */
 if (isset($_POST['clear'])) {
-	conf_mount_rw();
 	if (file_exists("{$snort_rules_upd_log}"))
 		mwexec("/bin/rm -f {$snort_rules_upd_log}");
-	conf_mount_ro();
 }
 
 if (isset($_POST['update'])) {

--- a/config/snort/snort_edit_hat_data.php
+++ b/config/snort/snort_edit_hat_data.php
@@ -61,23 +61,19 @@ else
 	$pconfig['host_attribute_data'] = "";
 
 if ($_POST['clear']) {
-	conf_mount_rw();
 	unset($a_nat[$id]['host_attribute_data']);
 	write_config();
 	$rebuild_rules = false;
 	snort_generate_conf($a_nat[$id]);
-	conf_mount_ro();
 	header("Location: /snort/snort_edit_hat_data.php?id={$id}");
 	exit;
 }
 
 if ($_POST['host_attribute_data']) {
-	conf_mount_rw();
 	$a_nat[$id]['host_attribute_data'] = base64_encode($_POST['host_attribute_data']);
 	write_config();
 	$rebuild_rules = false;
 	snort_generate_conf($a_nat[$id]);
-	conf_mount_ro();
 	header("Location: /snort/snort_preprocessors.php?id={$id}");
 	exit;
 }

--- a/config/snort/snort_interfaces_edit.php
+++ b/config/snort/snort_interfaces_edit.php
@@ -150,8 +150,8 @@ if ($_POST["Submit"]) {
 			if ($natent['interface'] != $a_rule[$id]['interface']) {
 				$oif_real = snort_get_real_interface($a_rule[$id]['interface']);
 				snort_stop($a_rule[$id], $oif_real);
-				conf_mount_rw();
 				exec("rm -r /var/log/snort_{$oif_real}" . $a_rule[$id]['uuid']);
+				conf_mount_rw();
 				exec("mv -f {$snortdir}/snort_" . $a_rule[$id]['uuid'] . "_{$oif_real} {$snortdir}/snort_" . $a_rule[$id]['uuid'] . "_{$if_real}");
 				conf_mount_ro();
 			}

--- a/config/snort/snort_post_install.php
+++ b/config/snort/snort_post_install.php
@@ -1354,7 +1354,6 @@ EOD;
 /*****************************************************************************/
 /* This starts the actual post-install code                                  */
 /*****************************************************************************/
-conf_mount_rw();
 
 /* Hard kill any running Snort processes that may have been started by any   */
 /* of the pfSense scripts such as check_reload_status() or rc.start_packages */
@@ -1455,7 +1454,6 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 /* Update Snort package version in configuration */
 $config['installedpackages']['snortglobal']['snort_config_ver'] = "3.0.2";
 write_config();
-conf_mount_ro();
 
 /* Done with post-install, so clear flag */
 unset($g['snort_postinstall']);

--- a/config/snort/snort_preprocessors.php
+++ b/config/snort/snort_preprocessors.php
@@ -514,8 +514,6 @@ elseif ($_POST['Submit']) {
 			write_config();
 		}
 
-		conf_mount_rw();
-
 		/*************************************************/
 		/* Update the snort.conf file and rebuild the    */
 		/* rules for this interface.                     */
@@ -527,8 +525,6 @@ elseif ($_POST['Submit']) {
 		/* If 'preproc_auto_rule_disable' is off, then clear log file */
 		if ($natent['preproc_auto_rule_disable'] == 'off')
 			@unlink("{$disabled_rules_log}");
-
-		conf_mount_ro();
 
 		/*******************************************************/
 		/* Signal Snort to reload Host Attribute Table if one  */

--- a/config/snort/snort_rules.php
+++ b/config/snort/snort_rules.php
@@ -319,25 +319,21 @@ if ($_GET['act'] == "resetall" && !empty($rules_map)) {
 }
 
 if ($_POST['clear']) {
-	conf_mount_rw();
 	unset($a_rule[$id]['customrules']);
 	write_config();
 	$rebuild_rules = true;
 	snort_generate_conf($a_rule[$id]);
 	$rebuild_rules = false;
-	conf_mount_ro();
 	header("Location: /snort/snort_rules.php?id={$id}&openruleset={$currentruleset}");
 	exit;
 }
 
 if ($_POST['customrules']) {
-	conf_mount_rw();
 	$a_rule[$id]['customrules'] = base64_encode($_POST['customrules']);
 	write_config();
 	$rebuild_rules = true;
 	snort_generate_conf($a_rule[$id]);
 	$rebuild_rules = false;
-	conf_mount_ro();
 	$output = "";
 	$retcode = "";
 	exec("/usr/local/bin/snort -T -c {$snortdir}/snort_{$snort_uuid}_{$if_real}/snort.conf 2>&1", $output, $retcode);
@@ -356,7 +352,6 @@ if ($_POST['customrules']) {
 }
 
 else if ($_POST['apply']) {
-	conf_mount_rw();
 	/* Save new configuration */
 	write_config();
 
@@ -367,7 +362,6 @@ else if ($_POST['apply']) {
 	$rebuild_rules = true;
 	snort_generate_conf($a_rule[$id]);
 	$rebuild_rules = false;
-	conf_mount_ro();
 
 	/* Soft-restart Snort to live-load new rules */
 	snort_reload_config($a_rule[$id]);

--- a/config/snort/snort_rulesets.php
+++ b/config/snort/snort_rulesets.php
@@ -145,7 +145,6 @@ if ($_POST["Submit"]) {
 			@unlink("{$snortdir}/snort_{$snort_uuid}_{$if_real}/rules/{$flowbit_rules_file}");
 	}
 
-	conf_mount_rw();
 	write_config();
 
 	/*************************************************/
@@ -155,7 +154,6 @@ if ($_POST["Submit"]) {
 	$rebuild_rules = true;
 	snort_generate_conf($a_nat[$id]);
 	$rebuild_rules = false;
-	conf_mount_ro();
 
 	/* Soft-restart Snort to live-load new rules */
 	snort_reload_config($a_nat[$id]);


### PR DESCRIPTION
This update incorporates Ermal's comments from Pull Request 571 (Snort pkg v3.0.2).  Unnecessary calls to conf_mount_rw() and conf_mount_ro() are removed.  A call to mount the file system read/write in the snort_generate_conf() function was found to be missing, and the call was added there.  That missing function call was the root of the original error reported on the Support Forum about "...writing to read-only file system...".

No change in core functionality is contained in this code edit, thus the Snort package version remains at 2.9.5.5 v3.0.2.
