### PR TITLE
Separate CAs for client certs and server cert chain

### DIFF
--- a/config/apache_mod_security-dev/apache_mod_security.inc
+++ b/config/apache_mod_security-dev/apache_mod_security.inc
@@ -569,9 +569,14 @@ EOF;
 							$vh_config.= " SSLCertificateKeyFile ". APACHEDIR . "/etc/apache22/{$virtualhost["ssl_cert"]}.key\n";
 			       			}
 						}
-					$svr_ca =lookup_ca($virtualhost["reverse_int_ca"]);
+					$svr_ca =lookup_ca($virtualhost["ssl_cert_chain"]);
 					if ($svr_ca != false) {
-							file_put_contents(APACHEDIR . "/etc/apache22/{$virtualhost["reverse_int_ca"]}.crt",apache_textarea_decode($svr_ca['crt']),LOCK_EX);
+							file_put_contents(APACHEDIR . "/etc/apache22/{$virtualhost["ssl_cert_chain"]}.crt",apache_textarea_decode($svr_ca['crt']),LOCK_EX);
+							$vh_config.= " SSLCertificateChainFile ". APACHEDIR . "/etc/apache22/{$virtualhost["ssl_cert_chain"]}.crt\n";
+							}
+					$cli_ca =lookup_ca($virtualhost["reverse_int_ca"]);
+					if ($cli_ca != false) {
+							file_put_contents(APACHEDIR . "/etc/apache22/{$virtualhost["reverse_int_ca"]}.crt",apache_textarea_decode($cli_ca['crt']),LOCK_EX);
 							$vh_config.= " SSLCACertificateFile ". APACHEDIR . "/etc/apache22/{$virtualhost["reverse_int_ca"]}.crt\n";
 							}
 					}

--- a/config/apache_mod_security-dev/apache_virtualhost.xml
+++ b/config/apache_mod_security-dev/apache_virtualhost.xml
@@ -267,9 +267,19 @@
 			<show_disable_value>none</show_disable_value>
 		</field>
 		<field>
-			<fielddescr>Intermediate CA certificate (optional)</fielddescr>
+			<fielddescr>HTTPS SSL certificate chain</fielddescr>
+			<fieldname>ssl_cert_chain</fieldname>
+			<description>Select intermediate CA assigned to server certificate. Not all certificates require this.</description>
+			<type>select_source</type>
+			<source><![CDATA[$config['ca']]]></source>
+			<source_name>descr</source_name>
+			<source_value>refid</source_value>
+			<show_disable_value>none</show_disable_value>
+		</field>
+		<field>
+			<fielddescr>Client certificates CA (optional)</fielddescr>
 			<fieldname>reverse_int_ca</fieldname>
-			<description>Select intermediate CA assigned to certificate. Not all certificates require this.</description>
+			<description>Select CA assigned to client certificates.</description>
 			<type>select_source</type>
 			<source><![CDATA[$config['ca']]]></source>
 			<source_name>descr</source_name>


### PR DESCRIPTION
- Modified the VirtualHost screen to make more clear the difference between "server certificate chain" and "client certification authority"
- Modified configuration generation accordingly with proper options (SSLCertificateChainFile for server cert chain, SSLCACertificateFile for client certificates) according to Apache documentation

I ended up needing this as I use pfSense as a HTTPS reverse proxy, with a public server certificate that required specifying the full certificate chain, and client certificate authentication that required validating against my custom CA, therefore requiring both settings in Apache configuration. (Also, SSLCACertificateFile was used where SSLCertificateChainFile would have been appropriate, but this point is now moot)
