### PR TITLE
mailreport - Fixed a bug with quarterly report scheduling

### DIFF
--- a/config/mailreport/mailreport.xml
+++ b/config/mailreport/mailreport.xml
@@ -37,7 +37,7 @@
 		]]>
 	</copyright>
 	<name>mailreport</name>
-	<version>2.0.8</version>
+	<version>2.0.9</version>
 	<title>Status: Mail Reports</title>
 	<additional_files_needed>
 		<prefix>/usr/local/bin/</prefix>

--- a/config/mailreport/status_mail_report_edit.php
+++ b/config/mailreport/status_mail_report_edit.php
@@ -178,7 +178,7 @@ if ($_POST) {
 	if ($pconfig['frequency'] == "yearly") {
 		$pconfig['monthofyear'] = isset($pconfig['monthofyear']) ? $pconfig['monthofyear'] : 1;
 		$friendly = "Yearly, on day {$pconfig['dayofmonth']} of {$monthofyear[$pconfig['monthofyear']]} at {$friendlytime}";
-	} else {
+	} elseif ($pconfig['frequency'] != "quarterly") {
 		if (isset($pconfig['monthofyear']))
 			unset($pconfig['monthofyear']);
 	}

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1385,7 +1385,7 @@
 		<name>mailreport</name>
 		<descr>Allows you to setup periodic e-mail reports containing command output, log file contents, and RRD graphs.</descr>
 		<category>Network Management</category>
-		<version>2.0.8</version>
+		<version>2.0.9</version>
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<config_file>http://www.pfsense.com/packages/config/mailreport/mailreport.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1717,7 +1717,7 @@
 		<name>mailreport</name>
 		<descr>Allows you to setup periodic e-mail reports containing command output, log file contents, and RRD graphs.</descr>
 		<category>Network Management</category>
-		<version>2.0.8</version>
+		<version>2.0.9</version>
 		<status>Stable</status>
 		<required_version>2.0</required_version>
 		<config_file>http://www.pfsense.com/packages/config/mailreport/mailreport.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1704,7 +1704,7 @@
 		<name>mailreport</name>
 		<descr>Allows you to setup periodic e-mail reports containing command output, log file contents, and RRD graphs.</descr>
 		<category>Network Management</category>
-		<version>2.0.8</version>
+		<version>2.0.9</version>
 		<status>Stable</status>
 		<required_version>2.0</required_version>
 		<config_file>http://www.pfsense.com/packages/config/mailreport/mailreport.xml</config_file>


### PR DESCRIPTION
`monthofyear` was being unset for all intervals which weren't yearly.  A check was added for quarterly intervals to avoid unsetting `monthofyear` in that case and getting quarterly reports once every month.  The behavior should now be as expected.  Bumped version number accordingly.

Signed-off-by: Daniel Hunsaker danhunsaker@gmail.com
