### PR TITLE
Add new Suricata 1.4.6 IDS BETA package v0.1

### DIFF
--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1608,7 +1608,7 @@
 		<category>Security</category>
 		<version>1.4.6 pkg v0.1</version>
 		<status>BETA</status>
-		<required_version>3.0</required_version>
+		<required_version>2.1</required_version>
 		<config_file>http://www.pfsense.org/packages/config/suricata/suricata.xml</config_file>
 		<configurationfile>suricata.xml</configurationfile>
 		<build_pbi>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -2049,7 +2049,7 @@
 		<category>Security</category>
 		<version>1.4.6 pkg v0.1</version>
 		<status>BETA</status>
-		<required_version>3.0</required_version>
+		<required_version>2.1</required_version>
 		<config_file>http://www.pfsense.org/packages/config/suricata/suricata.xml</config_file>
 		<configurationfile>suricata.xml</configurationfile>
 		<build_pbi>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -2036,7 +2036,7 @@
 		<category>Security</category>
 		<version>1.4.6 pkg v0.1</version>
 		<status>BETA</status>
-		<required_version>3.0</required_version>
+		<required_version>2.1</required_version>
 		<config_file>http://www.pfsense.org/packages/config/suricata/suricata.xml</config_file>
 		<configurationfile>suricata.xml</configurationfile>
 		<build_pbi>


### PR DESCRIPTION
Set required pfSense version to 2.1 to debut new Suricata 1.4.6 BETA package.
