### PR TITLE
Fixes problem stopping haproxy-devel

### DIFF
--- a/config/haproxy-devel/haproxy.inc
+++ b/config/haproxy-devel/haproxy.inc
@@ -189,7 +189,7 @@ function haproxy_custom_php_install_command() {
 
 name="haproxy"
 rcvar=`set_rcvar`
-command="/usr/local/bin/haproxy"
+command="/usr/pbi/haproxy-devel-`uname -m`/sbin/haproxy"
 haproxy_enable=\${haproxy-"YES"}
 
 start_cmd="haproxy_start"


### PR DESCRIPTION
We've experienced problems stopping haproxy from web gui. From command line it said that haproxy was not found.

I found that the path to the executable was not right, and fixed it.
