### PR TITLE
Add an Advanced Parameters to the proxy settings.

### DIFF
--- a/config/zabbix2/zabbix2-proxy.xml
+++ b/config/zabbix2/zabbix2-proxy.xml
@@ -129,6 +129,16 @@
 			<size>10</size>
 			<required>true</required>
 		</field>
+                <field>
+			<fielddescr>Advanced Parameters</fielddescr>
+			<fieldname>advancedparams</fieldname>
+			<encoding>base64</encoding>
+			<type>textarea</type>
+			<rows>5</rows>
+			<cols>50</cols>
+			<description>Advanced paramete. There are some rearly used parameters that sometimes need defined. Value has form, example: StartDiscoverers=10</description>
+		</field>
+
 	</fields>
 	<custom_php_install_command>sync_package_zabbix2();</custom_php_install_command>
 	<custom_php_command_before_form></custom_php_command_before_form>

--- a/config/zabbix2/zabbix2.inc
+++ b/config/zabbix2/zabbix2.inc
@@ -193,6 +193,7 @@ function sync_package_zabbix2(){
 		$zbproxy_config = $config['installedpackages']['zabbixproxy']['config'][0];
 		if ($zbproxy_config['proxyenabled']=="on"){
 			$Mode=(is_numericint($zbproxy_config['proxymode'])?$zbproxy_config['proxymode'] : 0);
+                        $AdvancedParams=base64_decode($zbagent_config['advancedparams']);
 		
 			$zbproxy_conf_file = <<< EOF
 Server={$zbproxy_config['server']}
@@ -206,6 +207,7 @@ FpingLocation=/usr/local/sbin/fping
 #there's currently no fping6 (IPv6) dependency in the package, but if there was, the binary would likely also be in /usr/local/sbin
 Fping6Location=/usr/local/sbin/fping6
 ProxyMode={$Mode}
+{$AdvancedParams}
 
 EOF;
 			file_put_contents(ZABBIX_PROXY_BASE . "/etc/zabbix22/zabbix_proxy.conf", strtr($zbproxy_conf_file, array("\r" => "")));


### PR DESCRIPTION
Simple patch to add an Advanced Parameters to Zabbix Proxy to allow custom Paramters to be applied to the config. 
