### PR TITLE
haproxy-devel,fix sslcheckbox from automatically turning on, allow immediate frontend sharing when duplicating

### DIFF
--- a/config/haproxy-devel/haproxy_listeners_edit.php
+++ b/config/haproxy-devel/haproxy_listeners_edit.php
@@ -238,8 +238,8 @@ $pgtitle = "HAProxy: Frontend: Edit";
 include("head.inc");
 
 if (!isset($_GET['dup']))
-	$excludefrontent = $pconfig['name'];
-$primaryfrontends = get_haproxy_frontends($excludefrontent);
+	$excludefrontend = $pconfig['name'];
+$primaryfrontends = get_haproxy_frontends($excludefrontend);
 $interfaces = haproxy_get_bindable_interfaces();
 
 ?>


### PR DESCRIPTION
-fix sslcheckbox that was automatically turning on when editing
-allow 2nd clones to be linked to the original primary frontend when making them shared
