### PR TITLE
haproxy-devel, extra installation/deinstallation logging, faster handling of port aliases, removing using 'devd' and 'limits'

### DIFF
--- a/config/haproxy-devel/haproxy.inc
+++ b/config/haproxy-devel/haproxy.inc
@@ -241,8 +241,6 @@ function haproxy_custom_php_deinstall_command() {
 	update_output_window($static_output);
 	$static_output .= "HAProxy, deleting haproxy webgui\n";
 	update_output_window($static_output);
-	exec("rm /usr/local/pkg/haproxy*");
-	exec("rm /usr/local/www/haproxy*");
 	exec("rm /usr/local/etc/rc.d/haproxy.sh");
 	$static_output .= "HAProxy, installing cron job if needed\n";
 	update_output_window($static_output);


### PR DESCRIPTION
haproxy-devel, extra installation/deinstallation logging to diagnose issues when the process 'hangs'
-improvements to retrieving port aliases (global $aliastable)
-removing devd config (it didn't work anyway)
-removing downloading and calling 'limits' (it didn't work anyway)
