### PR TITLE
Create lcdproc-0.5.6 pkg v. 0.9.7

### DIFF
--- a/lcdproc-0.5.6 pkg v. 0.9.7
+++ b/lcdproc-0.5.6 pkg v. 0.9.7
@@ -513,6 +513,7 @@
 			1  = All gateway up  */
 		global $g;
 		global $config;
+		$a_gateways = return_gateways_array();
 		$gateways_status = array();
 		$gateways_status = return_gateways_status(true);
 		foreach ($a_gateways as $gname => $gateway)


### PR DESCRIPTION
Fixed the Gateway LED #4 so it now works properly on Crystalfontz Displays.
