### PR TITLE
Add option "fast hello"

### DIFF
--- a/config/quagga_ospfd/quagga_ospfd.inc
+++ b/config/quagga_ospfd/quagga_ospfd.inc
@@ -122,9 +122,11 @@ function quagga_ospfd_install_conf() {
 				if (!empty($conf['retransmitinterval'])) {
 					$conffile .= "  ip ospf retransmit-interval {$conf['retransmitinterval']}\n";
 				}
-				if (!empty($conf['deadtimer'])) {
+				if ($conf['enablefasthello']=='on') {
+					$conffile .= "  ip ospf dead-interval minimal hello-multiplier {$conf['hellomultiplier']}\n";
+				} else if (!empty($conf['deadtimer'])) {
 					$conffile .= "  ip ospf dead-interval {$conf['deadtimer']}\n";
-		}
+				}
 				if (!empty($conf['passive'])) {
 					$passive_interfaces[] = $realif;
 				}
@@ -356,6 +358,9 @@ function quagga_ospfd_validate_interface() {
 	}
 	if ($_POST['md5password'] && empty($_POST['password']))
 		$input_errors[] = "Please input a password.";
+	if ($_POST['enablefasthello'] == 'on' && ($_POST['hellomultiplier'] < 2 || $_POST['hellomultiplier'] > 20 || empty($_POST['hellomultiplier'])))
+		$input_errors[] = "Hello Multiplier needs to be between 2 and 20.";
+	
 }
 
 function quagga_ospfd_validate_input() {

--- a/config/quagga_ospfd/quagga_ospfd_interfaces.xml
+++ b/config/quagga_ospfd/quagga_ospfd_interfaces.xml
@@ -131,7 +131,7 @@
 			<type>input</type>
 		</field>
 		<field>
-			<fielddescr>&lt;b&gt;Fast Hello&lt;/b&gt;</fielddescr>
+			<fielddescr>Fast Hello</fielddescr>
 			<fieldname>enablefasthello</fieldname>
 			<type>checkbox</type>
 			<description>Enable Fast Hello (Dead Timer 1s, Hello Interval 20 - 500 ms).</description>

--- a/config/quagga_ospfd/quagga_ospfd_interfaces.xml
+++ b/config/quagga_ospfd/quagga_ospfd_interfaces.xml
@@ -115,7 +115,7 @@
 		<field>
 			<fielddescr>Hello Interval</fielddescr>
 			<fieldname>hellointervalinseconds</fieldname>
-			<description>Hello Interval this OSPF interface in seconds (Default 10).</description>
+			<description>Hello Interval this OSPF interface in seconds (Default 10). Has no effect if Fast Hello enabled.</description>
 			<type>input</type>
 		</field>
 		<field>
@@ -130,6 +130,20 @@
 			<description>Dead Timer for this OSPF interface in seconds (Default 40).</description>
 			<type>input</type>
 		</field>
+		<field>
+			<fielddescr>&lt;b&gt;Fast Hello&lt;/b&gt;</fielddescr>
+			<fieldname>enablefasthello</fieldname>
+			<type>checkbox</type>
+			<description>Enable Fast Hello (Dead Timer 1s, Hello Interval 20 - 500 ms).</description>
+			<enablefields>hellomultiplier</enablefields>
+		</field>
+		<field>
+			<fielddescr>Hello Multiplier</fielddescr>
+			<fieldname>hellomultiplier</fieldname>
+			<description>The Hello Multiplier specifies how many Hellos to send per second, from 2 (every 500ms) to 20 (every 50ms)</description>
+			<type>input</type>
+		</field>
+		
 	</fields>
 	<custom_php_resync_config_command>
 		quagga_ospfd_install_conf();


### PR DESCRIPTION
ip ospf dead-interval minimal hello-multiplier <2-20>

dead-interval is set to 1 second
hello-multiplier specifies how many "hellos" to send per second

Signed-off-by: pkilla <pkilla@yandex.ru>