### PR TITLE
haproxy-devel, on a new install a 'corrupted' empty array was created by the configuration conversion process.

### DIFF
--- a/config/haproxy-devel/haproxy.inc
+++ b/config/haproxy-devel/haproxy.inc
@@ -405,9 +405,8 @@ EOD;
 		$writeconfigupdate = true;
 	}
 	// update config to "haproxy-devel 1.5-dev19 pkg v0.5"
-	$a_backends = &$config['installedpackages']['haproxy']['ha_backends']['item'];
-	if(is_array($a_backends)) {
-		foreach ($a_backends as &$bind) {
+	if(is_array($config['installedpackages']['haproxy']['ha_backends']['item'])) {
+		foreach ($config['installedpackages']['haproxy']['ha_backends']['item'] as &$bind) {
 			if($bind['httpclose'] && $bind['httpclose'] == "yes" ) {
 				$bind['httpclose'] = "httpclose";
 				$writeconfigupdate = true;


### PR DESCRIPTION
haproxy-devel, on a new install a 'corrupted' empty array was created by the configuration conversion process.
