### PR TITLE
haproxy-devel, fix showing wrong type of acl's when the primary frontend switched

### DIFF
--- a/config/haproxy-devel/haproxy_listeners_edit.php
+++ b/config/haproxy-devel/haproxy_listeners_edit.php
@@ -261,7 +261,14 @@ $interfaces = haproxy_get_bindable_interfaces();
 	function htmllist_get_select_options(tableId) {
 		var seltext;
 		seltext = "";
-		var type = d.getElementById("type").value;
+		var type;
+		var secondary = d.getElementById("secondary");
+		var primary_frontend = d.getElementById("primary_frontend");		
+		if ((secondary !== null) && (secondary.checked))
+			type = primaryfrontends[primary_frontend.value]['ref']['type'];
+		else
+			type = d.getElementById("type").value;
+		
 		if (tableId == 'tableA_acltable'){	
 			if (type == 'health')
 				seltext = "<?php echo haproxy_js_acl_select('health');?>";
@@ -297,10 +304,10 @@ $interfaces = haproxy_get_bindable_interfaces();
 	function updatevisibility()	{
 		d = document;
 		ssloffload = d.getElementById("ssloffload");
-		type = d.getElementById("type");
-		secondary = d.getElementById("secondary");
-		primary_frontend = d.getElementById("primary_frontend");
 		
+		var type;
+		var secondary = d.getElementById("secondary");
+		var primary_frontend = d.getElementById("primary_frontend");		
 		if ((secondary !== null) && (secondary.checked))
 			type = primaryfrontends[primary_frontend.value]['ref']['type'];
 		else


### PR DESCRIPTION
haproxy-devel, fix showing wrong type of acl's when the primary frontend switched
