### PR TITLE
add puppet agent for pfSense

### DIFF
--- a/config/puppet/puppet.conf.php
+++ b/config/puppet/puppet.conf.php
@@ -1,0 +1,53 @@
+<?php
+/*
+   puppet.conf.php
+   part of the puppet package for pfSense
+   Copyright (C) 2014 Frank Wall <fw@moov.de>
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+   AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+   AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+   OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+// create puppet.conf
+$puppetconf=<<<EOF
+# DO NOT EDIT! File managed by pfSense.
+[main]
+color = ansi
+configtimeout = {$configtimeout}m
+environment = {$environment}
+manage_internal_file_permissions = true
+mkusers = false
+#parser = future
+splaylimit = 1800
+splay = true
+#syslogfacility = daemon
+
+[agent]
+certname = {$certname}
+pluginsync = true
+report = true
+server = {$server}
+show_diff = false
+
+EOF;
+?>

--- a/config/puppet/puppet.inc
+++ b/config/puppet/puppet.inc
@@ -1,0 +1,196 @@
+<?php
+/* $Id$ */
+/* ========================================================================== */
+/*
+    puppet.inc
+    part of the puppet package for pfSense
+    Copyright (C) 2014 Frank Wall <fw@moov.de>
+
+    based on the apcupsd package for pfSense
+    Copyright (C) 2013 Danilo G. Baio <dbaio@bsd.com.br>
+
+    All rights reserved.            
+			                                                      */
+/* ========================================================================== */
+/*
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+                                                                              */
+/* ========================================================================== */
+require_once("util.inc");
+require_once("functions.inc");
+require_once("pkg-utils.inc");
+require_once('service-utils.inc');
+require_once("globals.inc");
+
+// check pfsense version
+$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
+if ($pfs_version > 2.0){
+	define('PUPPET_BASE', '/usr/pbi/puppet-' . php_uname("m"));
+} else {
+	define('PUPPET_BASE', '/usr/local');
+}
+
+// define globals
+define('FACTER_CMD', PUPPET_BASE . '/bin/facter');
+define('PUPPET_AGENTLOG', '/var/log/puppet.log');
+define('PUPPET_AGENTPID', '/var/run/puppet/agent.pid');
+define('PUPPET_CMD', PUPPET_BASE . '/bin/puppet');
+define('PUPPET_CONFFILE', PUPPET_BASE . '/etc/puppet/puppet.conf');
+define('PUPPET_DATADIR', '/var/puppet');
+define('PUPPET_GROUP', 'puppet');
+define('PUPPET_PIDDIR', '/var/run/puppet');
+define('PUPPET_RCFILE', PUPPET_BASE . '/etc/rc.d/puppet');
+define('PUPPET_RUN_SUMMARY', '/var/puppet/state/last_run_summary.yaml');
+define('PUPPET_USER', 'puppet');
+
+function php_install_puppet() {
+	global $config, $g;
+
+	conf_mount_rw();
+        exec("/usr/bin/sed -i -e 's/puppet_enable=\"NO\"/puppet_enable=\"YES\"/g' " . PUPPET_RCFILE);
+	conf_mount_ro();
+}
+
+function php_deinstall_puppet() {
+	global $config, $g;
+
+	conf_mount_rw();
+
+	// Stop agent and cleanup.
+	exec(PUPPET_RCFILE . ' stop');
+	exec('/usr/bin/killall puppet');
+	unlink_if_exists(PUPPET_RCFILE);
+	unlink_if_exists(PUPPET_CONFFILE);
+	unlink_if_exists(PUPPET_AGENTLOG);
+	unlink_if_exists(PUPPET_AGENTPID);
+
+	// Purging the datadir would reset the agent during upgrades.
+	//if (is_dir(PUPPET_DATADIR))
+	//	exec('/bin/rm -r ' . PUPPET_DATADIR);
+
+	// Purge obsolete package data
+	if (is_dir(PUPPET_PIDDIR))
+		exec('/bin/rm -r ' . PUPPET_PIDDIR);
+
+	// Remove user and group
+        exec('/usr/sbin/pw userdel ' . PUPPET_USER);
+        exec('/usr/sbin/pw groupdel ' . PUPPET_GROUP);
+
+	conf_mount_ro();
+}
+
+function validate_input_puppet($post,&$input_errors) {
+
+	if  (isset($post['enable'])){
+	
+		if ($post['configtimeout'] != '' && !is_numericint($post['configtimeout'])) {
+			$input_errors[]='Config Timeout is not numeric.';
+		}
+
+	} // agent enabled
+}
+
+function sync_package_puppet() {
+	global $config, $g;
+
+	conf_mount_rw();
+
+	file_put_contents('/tmp/puppet_test', 'puppet test 123' . PUPPET_BASE, LOCK_EX);
+	file_put_contents('/usr/local/etc/puppet/puppet_test', "puppet test: " . PUPPET_CONFFILE, LOCK_EX);
+
+	// puppet settings
+	if (is_array($config['installedpackages']['puppet'])) {
+		$puppet_config = $config['installedpackages']['puppet']['config'][0];
+		if ($puppet_config['enable'] == 'on') {
+			$certname = ($puppet_config['certname'] != '' ? "{$puppet_config['certname']}" : "{$config['system']['hostname']}.{$config['system']['domain']}");
+			$configtimeout = ($puppet_config['configtimeout'] != '' ? "{$puppet_config['configtimeout']}" : '2');
+			$environment = ($puppet_config['environment'] != '' ? "{$puppet_config['environment']}" : 'production');
+			$server = ($puppet_config['server'] != '' ? "{$puppet_config['server']}" : 'puppet');
+	
+			include("/usr/local/pkg/puppet.conf.php");
+			file_put_contents(PUPPET_CONFFILE, $puppetconf, LOCK_EX);
+		}
+	}
+
+	// puppet service
+	if (is_array($puppet_config) && $puppet_config['enable'] == 'on') {
+		puppet_restart();
+	} else {
+		puppet_stop();
+	}
+
+	conf_mount_ro();
+}
+
+// Facter output
+function puppet_facts() {
+    exec("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin " . FACTER_CMD . " --puppet 2>&1", $output);
+    return implode("\n", $output);
+}
+
+// Puppet fingerprint
+function puppet_fingerprint() {
+    exec("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin " . PUPPET_CMD . " agent --fingerprint 2>&1", $output);
+    return implode("\n", $output);
+}
+
+// Puppet run summary
+function puppet_run_summary() {
+    $checks = array('changed', 'failed', 'failure', 'failed_to_restart', 'out_of_sync', 'scheduled', 'skipped');
+    $summary = array();
+    foreach ($checks as $check) {
+        exec("/usr/bin/awk '/$check:/ {print \$2}' " . PUPPET_RUN_SUMMARY, $output);
+        if (empty($output)) {
+            $summary[$check] = 'unknown error';
+        } else {
+            $summary[$check] = implode("\n", $output);
+        }
+        unset($output);
+    }
+    return $summary;
+}
+
+// Service status
+function puppet_servicestatus() {
+    if (is_pid_running("PUPPET_AGENTPID")) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+// Startup function
+function puppet_start() {
+	mwexec_bg(PUPPET_RCFILE . ' start');
+}
+
+// Shutdown function
+function puppet_stop() {
+	mwexec_bg(PUPPET_RCFILE . ' onestop');
+}
+
+// Restart function
+function puppet_restart() {
+	mwexec_bg(PUPPET_RCFILE . ' restart');
+}
+
+?>

--- a/config/puppet/puppet.xml
+++ b/config/puppet/puppet.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packagegui>
+<copyright>
+	<![CDATA[
+/* $Id$ */
+/* ========================================================================== */
+/*
+    puppet.xml
+    part of the puppet package for pfSense
+    Copyright (C) 2014 Frank Wall <fw@moov.de>
+	
+    All rights reserved.            
+			                                                      */
+/* ========================================================================== */
+/*
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+                                                                              */
+/* ========================================================================== */
+	]]>
+	</copyright>
+	<name>Puppet</name>
+	<title>Services: Puppet Agent</title>
+	<category>Services</category>
+	<version>3.6.2_1</version>
+	<include_file>/usr/local/pkg/puppet.inc</include_file>
+	<addedit_string>Puppet has been created/modified.</addedit_string>
+	<delete_string>Puppet has been deleted.</delete_string>
+	<restart_command>/usr/local/etc/rc.d/puppet onerestart</restart_command>
+	<additional_files_needed>
+		<item>https://packages.pfsense.org/packages/config/puppet/puppet.inc</item>
+		<prefix>/usr/local/pkg/</prefix>
+		<chmod>0755</chmod>
+	</additional_files_needed>
+	<additional_files_needed>
+		<item>https://packages.pfsense.org/packages/config/puppet/puppet_status.php</item>
+		<prefix>/usr/local/www/</prefix>
+		<chmod>0755</chmod>
+	</additional_files_needed>
+	<additional_files_needed>
+		<item>https://packages.pfsense.org/packages/config/puppet/puppet_facts.php</item>
+		<prefix>/usr/local/www/</prefix>
+		<chmod>0755</chmod>
+	</additional_files_needed>
+	<additional_files_needed>
+		<item>https://packages.pfsense.org/packages/config/puppet/puppet_debug.php</item>
+		<prefix>/usr/local/www/</prefix>
+		<chmod>0755</chmod>
+	</additional_files_needed>
+	<additional_files_needed>
+		<item>https://packages.pfsense.org/packages/config/puppet/puppet.conf.php</item>
+		<prefix>/usr/local/pkg/</prefix>
+		<chmod>0755</chmod>
+	</additional_files_needed>
+	<menu>
+		<name>Puppet</name>
+		<tooltiptext>Setup puppet specific settings</tooltiptext>
+		<section>Services</section>
+		<url>/pkg_edit.php?xml=puppet.xml&amp;id=0</url>
+	</menu>
+	<service>
+		<name>puppet</name>
+		<rcfile>puppet</rcfile>
+		<executable>ruby19</executable>
+		<description>Configuration management framework written in Ruby</description>
+                <custom_php_service_status_command>is_pid_running('/var/run/puppet/agent.pid');</custom_php_service_status_command>
+	</service>
+	<tabs>
+		<tab>
+			<text>Settings</text>
+			<url>/pkg_edit.php?xml=puppet.xml&amp;id=0</url>
+			<active/>
+		</tab>
+		<tab>
+			<text>Status</text>
+			<url>puppet_status.php</url>
+		</tab>
+		<tab>
+			<text>Facts</text>
+			<url>puppet_facts.php</url>
+		</tab>
+		<tab>
+			<text>Debug</text>
+			<url>puppet_debug.php</url>
+		</tab>
+	</tabs>
+	<fields>
+		<field>
+			<name>Agent configuration parameters</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Enable</fielddescr>
+			<fieldname>enable</fieldname>
+			<description>Enable Puppet Agent</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Puppet Server</fielddescr>
+			<fieldname>server</fieldname>
+			<description><![CDATA[The server to which the puppet agent should connect.
+<br>
+<strong>Default: puppet</strong>
+			]]></description>
+			<type>input</type>
+			<size>64</size>
+		</field>
+		<field>
+			<fielddescr>Environment</fielddescr>
+			<fieldname>environment</fieldname>
+			<description><![CDATA[The  environment Puppet is running in. For clients (e.g., puppet agent)
+		           this determines the environment itself, which is used to  find  modules
+		           and  much  more.  For  servers  (i.e., puppet master) this provides the
+		           default environment for nodes we know nothing about.
+<br>
+<strong>Default: production</strong>
+			]]></description>
+		         <type>input</type>
+		         <size>64</size>
+		</field>
+		<field>
+			<fielddescr>Config Timeout</fielddescr>
+			<fieldname>configtimeout</fieldname>
+			<description><![CDATA[How  long  the client should wait for the configuration to be retrieved
+		           before considering it a failure. This can help reduce flapping  if  too
+		           many  clients  contact  the  server  at one time. Can be specified as a
+		          duration.
+<br>
+<strong>Default: 2 (minutes)</strong>
+			]]></description>
+		         <type>input</type>
+		         <size>2</size>
+		</field>
+	</fields>
+	<custom_php_install_command>php_install_puppet();</custom_php_install_command>
+	<custom_php_command_before_form></custom_php_command_before_form>
+	<custom_php_after_head_command></custom_php_after_head_command>
+	<custom_php_after_form_command></custom_php_after_form_command>
+	<custom_php_validation_command>validate_input_puppet($_POST, &amp;$input_errors);</custom_php_validation_command>
+	<custom_add_php_command></custom_add_php_command>
+	<custom_php_resync_config_command>sync_package_puppet();</custom_php_resync_config_command>
+	<custom_php_deinstall_command>php_deinstall_puppet();</custom_php_deinstall_command>
+</packagegui>

--- a/config/puppet/puppet_debug.php
+++ b/config/puppet/puppet_debug.php
@@ -1,0 +1,115 @@
+<?php
+/* $Id$ */
+/* ========================================================================== */
+/*
+    puppet_debug.php
+    part of the puppet package for pfSense
+    Copyright (C) 2014 Frank Wall <fw@moov.de>
+
+    All rights reserved.            
+			                                                      */
+/* ========================================================================== */
+/*
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+                                                                              */
+/* ========================================================================== */
+
+require('guiconfig.inc');
+require_once('service-utils.inc');
+require_once('globals.inc');
+require_once('/usr/local/pkg/puppet.inc');
+
+$pgtitle = 'Services: Puppet Agent';
+include('head.inc');
+
+function puts( $arg ) { echo "$arg\n"; }	
+
+?>
+
+<style>
+<!--
+
+input {
+   font-family: courier new, courier;
+   font-weight: normal;
+   font-size: 9pt;
+}
+
+pre {
+   border: 2px solid #435370;
+   background: #F0F0F0;
+   padding: 1em;
+   font-family: courier new, courier;
+   white-space: pre;
+   line-height: 10pt;
+   font-size: 10pt;
+}
+
+.label {
+   font-family: tahoma, verdana, arial, helvetica;
+   font-size: 11px;
+   font-weight: bold;
+}
+
+.button {
+   font-family: tahoma, verdana, arial, helvetica;
+   font-weight: bold;
+   font-size: 11px;
+}
+
+-->
+</style>
+</head>
+<body link="#0000CC" vlink="#0000CC" alink="#0000CC">
+
+	<?php include("fbegin.inc"); ?>
+	
+<div id="mainlevel">
+		<table width="100%" border="0" cellpadding="0" cellspacing="0">
+			<tr><td>
+		<?php
+			$tab_array = array();
+			$tab_array[] = array(gettext("Settings"), false, "/pkg_edit.php?xml=puppet.xml&amp;id=0");
+			$tab_array[] = array(gettext("Status"), false, "/puppet_status.php");
+			$tab_array[] = array(gettext("Facts"), false, "/puppet_facts.php");
+			$tab_array[] = array(gettext("Debug"), true, "/puppet_debug.php");
+			display_top_tabs($tab_array);
+		?>
+			</td></tr>
+		</table>
+</div>
+
+<div id="mainarea" style="padding-top: 0px; padding-bottom: 0px; ">
+	<table class="tabcont" width="100%" border="0" cellspacing="0" cellpadding="6">
+		<tr><td><b>Cert fingerprint:</b><br>
+<?php
+    $fingerprint = puppet_fingerprint();
+    puts("$fingerprint");
+?>
+		</td></tr>
+	</table>
+</div>	
+<?php 
+include("fend.inc");
+?>
+</body>
+</html>

--- a/config/puppet/puppet_facts.php
+++ b/config/puppet/puppet_facts.php
@@ -1,0 +1,117 @@
+<?php
+/* $Id$ */
+/* ========================================================================== */
+/*
+    puppet_facts.php
+    part of the puppet package for pfSense
+    Copyright (C) 2014 Frank Wall <fw@moov.de>
+
+    All rights reserved.            
+			                                                      */
+/* ========================================================================== */
+/*
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+                                                                              */
+/* ========================================================================== */
+
+require('guiconfig.inc');
+require_once('service-utils.inc');
+require_once('globals.inc');
+require_once('/usr/local/pkg/puppet.inc');
+
+$pgtitle = 'Services: Puppet Agent';
+include('head.inc');
+
+function puts( $arg ) { echo "$arg\n"; }	
+
+?>
+
+<style>
+<!--
+
+input {
+   font-family: courier new, courier;
+   font-weight: normal;
+   font-size: 9pt;
+}
+
+pre {
+   border: 2px solid #435370;
+   background: #F0F0F0;
+   padding: 1em;
+   font-family: courier new, courier;
+   white-space: pre;
+   line-height: 10pt;
+   font-size: 10pt;
+}
+
+.label {
+   font-family: tahoma, verdana, arial, helvetica;
+   font-size: 11px;
+   font-weight: bold;
+}
+
+.button {
+   font-family: tahoma, verdana, arial, helvetica;
+   font-weight: bold;
+   font-size: 11px;
+}
+
+-->
+</style>
+</head>
+<body link="#0000CC" vlink="#0000CC" alink="#0000CC">
+
+	<?php include("fbegin.inc"); ?>
+	
+<div id="mainlevel">
+		<table width="100%" border="0" cellpadding="0" cellspacing="0">
+			<tr><td>
+		<?php
+			$tab_array = array();
+			$tab_array[] = array(gettext("Settings"), false, "/pkg_edit.php?xml=puppet.xml&amp;id=0");
+			$tab_array[] = array(gettext("Status"), false, "/puppet_status.php");
+			$tab_array[] = array(gettext("Facts"), true, "/puppet_facts.php");
+			$tab_array[] = array(gettext("Debug"), false, "/puppet_debug.php");
+			display_top_tabs($tab_array);
+		?>
+			</td></tr>
+		</table>
+</div>
+
+<div id="mainarea" style="padding-top: 0px; padding-bottom: 0px; ">
+	<table class="tabcont" width="100%" border="0" cellspacing="0" cellpadding="6">
+		<tr><td><b>Facter output:</b>
+<?php
+    puts('<pre style="word-break:break-all; white-space: -moz-pre-wrap !important; white-space: -pre-wrap; white-space: -o-pre-wrap; white-space: pre-wrap; word-wrap: break-word;">');
+    $facts = puppet_facts();
+    echo htmlspecialchars($facts);
+    puts('</pre>');
+?>
+		</td></tr>
+	</table>
+</div>	
+<?php 
+include("fend.inc");
+?>
+</body>
+</html>

--- a/config/puppet/puppet_status.php
+++ b/config/puppet/puppet_status.php
@@ -1,0 +1,149 @@
+<?php
+/* $Id$ */
+/* ========================================================================== */
+/*
+    puppet_status.php
+    part of the puppet package for pfSense
+    Copyright (C) 2014 Frank Wall <fw@moov.de>
+
+    All rights reserved.            
+			                                                      */
+/* ========================================================================== */
+/*
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+                                                                              */
+/* ========================================================================== */
+
+require('guiconfig.inc');
+require_once('service-utils.inc');
+require_once('globals.inc');
+require_once('/usr/local/pkg/puppet.inc');
+
+$pgtitle = 'Services: Puppet Agent';
+include('head.inc');
+
+function puts( $arg ) { echo "$arg\n"; }	
+
+?>
+
+<style>
+<!--
+
+input {
+   font-family: courier new, courier;
+   font-weight: normal;
+   font-size: 9pt;
+}
+
+pre {
+   border: 2px solid #435370;
+   background: #F0F0F0;
+   padding: 1em;
+   font-family: courier new, courier;
+   white-space: pre;
+   line-height: 10pt;
+   font-size: 10pt;
+}
+
+.label {
+   font-family: tahoma, verdana, arial, helvetica;
+   font-size: 11px;
+   font-weight: bold;
+}
+
+.button {
+   font-family: tahoma, verdana, arial, helvetica;
+   font-weight: bold;
+   font-size: 11px;
+}
+
+-->
+</style>
+</head>
+<body link="#0000CC" vlink="#0000CC" alink="#0000CC">
+
+	<?php include("fbegin.inc"); ?>
+	
+<div id="mainlevel">
+		<table width="100%" border="0" cellpadding="0" cellspacing="0">
+			<tr><td>
+		<?php
+			$tab_array = array();
+			$tab_array[] = array(gettext("Settings"), false, "/pkg_edit.php?xml=puppet.xml&amp;id=0");
+			$tab_array[] = array(gettext("Status"), true, "/puppet_status.php");
+			$tab_array[] = array(gettext("Facts"), false, "/puppet_facts.php");
+			$tab_array[] = array(gettext("Debug"), false, "/puppet_debug.php");
+			display_top_tabs($tab_array);
+		?>
+			</td></tr>
+		</table>
+</div>
+
+<div id="mainarea" style="padding-top: 0px; padding-bottom: 0px; ">
+	<table class="tabcont" width="100%" border="0" cellspacing="0" cellpadding="6">
+		<tr><td>
+<?php
+    global $config, $g;
+    $puppet_config = $config['installedpackages']['puppet']['config'][0];
+    puts('Service Status: ');
+    if ($puppet_config['enable']) {
+	puts('<b>enabled</b>.');
+    } else {
+	puts('<b>disabled</b>.');
+    }
+?>
+		</td></tr>
+		<tr><td>
+<?php
+    puts('Agent Status: ');
+    if (is_service_running('puppet')) {
+	puts('<b>running</b>.');
+    } else {
+	puts('<b>NOT running</b>.');
+    }
+?>
+		</td></tr>
+		<tr><td>
+<?php
+    puts('Last Puppet Run: ');
+    if (file_exists(PUPPET_RUN_SUMMARY)) {
+	puts('<br>');
+	$summary = puppet_run_summary();
+        if ( !empty($summary) ) {
+	    foreach ($summary as $key => $value) {
+		puts(" ==> $key: " . $value . "<br>");
+	    }
+        } else {
+	    puts("<b>failed prematurely</b> (report/summary is empty).");
+        }
+    } else {
+	puts("<b>failed prematurely</b> (no report/summary).");
+    }
+?>
+		</td></tr>
+	</table>
+</div>	
+<?php 
+include("fend.inc");
+?>
+</body>
+</html>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1540,5 +1540,27 @@
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;suricata_SET=IPFW PORTS_PCAP TESTS;suricata_UNSET=PRELUDE</build_options>
 		<depends_on_package_pbi>suricata-1.4.6-##ARCH##.pbi</depends_on_package_pbi>
 	</package>
+	<package>
+	    <name>Puppet</name>
+	    <pkginfolink>https://doc.pfsense.org/index.php/Puppet_Package</pkginfolink>
+	    <website>http://puppetlabs.com/</website>
+	    <descr>Puppet lets you centrally manage every important aspect of your system using a cross-platform specification language that manages all the separate elements normally aggregated in different files, like users, cron jobs, and hosts, along with obviously discrete elements like packages, services, and files.</descr>
+	    <category>Services</category>
+	    <version>3.6.2_1</version>
+	    <status>Release</status>
+	    <required_version>2.1</required_version>
+	    <config_file>https://packages.pfsense.org/packages/config/puppet/puppet.xml</config_file>
+	    <maintainer>fw@moov.de</maintainer>
+	    <depends_on_package_pbi>puppet-3.6.2_1-##ARCH##.pbi</depends_on_package_pbi>
+	    <configurationfile>puppet.xml</configurationfile>
+	    <build_port_path>/usr/ports/</build_port_path>
+	    <build_pbi>
+		<custom_name>puppet</custom_name>
+		<ports_before>textproc/augeas sysutils/dmidecode devel/libexecinfo devel/libffi converters/libiconv textproc/libxml2 textproc/libyaml converters/ruby-iconv lang/ruby19 devel/ruby-gems archivers/rubygem-bzip2 sysutils/rubygem-facter sysutils/rubygem-hiera devel/rubygem-json_pure textproc/rubygem-augeas</ports_before>
+		<port>sysutils/puppet</port>
+	    </build_pbi>
+	    <build_options>DEPENDS_CLEAN=""; puppet_SET+=PACKAGE_ORIGIN; puppet_UNSET+=DOCS EXAMPLES PACKAGE_ROOT</build_options>
+	    <after_install_info>NOTE: First, you need to configure and enable the puppet agent under Services/Puppet. It will then try to request a certificate. You need to sign the certificate on your puppet master and run the puppet agent again.</after_install_info>
+	</package>
 </packages>
 </pfsensepkgs>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1995,5 +1995,29 @@
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
 		<depends_on_package_pbi>suricata-1.4.6-i386.pbi</depends_on_package_pbi>
 	</package>
+	<package>
+	    <name>Puppet</name>
+	    <pkginfolink>https://doc.pfsense.org/index.php/Puppet_Package</pkginfolink>
+	    <website>http://puppetlabs.com/</website>
+	    <descr>Puppet lets you centrally manage every important aspect of your system using a cross-platform specification language that manages all the separate elements normally aggregated in different files, like users, cron jobs, and hosts, along with obviously discrete elements like packages, services, and files.</descr>
+	    <category>Services</category>
+	    <version>3.6.2_1</version>
+	    <status>Release</status>
+	    <required_version>2.1</required_version>
+	    <config_file>https://packages.pfsense.org/packages/config/puppet/puppet.xml</config_file>
+	    <maintainer>fw@moov.de</maintainer>
+	    <depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
+	    <depends_on_package></depends_on_package>
+	    <depends_on_package_pbi>puppet-3.6.2_1-i386.pbi</depends_on_package_pbi>
+	    <configurationfile>puppet.xml</configurationfile>
+	    <build_port_path>/usr/ports/</build_port_path>
+	    <build_pbi>
+		<custom_name>puppet</custom_name>
+		<ports_before>textproc/augeas sysutils/dmidecode devel/libexecinfo devel/libffi converters/libiconv textproc/libxml2 textproc/libyaml converters/ruby-iconv lang/ruby19 devel/ruby-gems archivers/rubygem-bzip2 sysutils/rubygem-facter sysutils/rubygem-hiera devel/rubygem-json_pure textproc/rubygem-augeas</ports_before>
+		<port>sysutils/puppet</port>
+	    </build_pbi>
+	    <build_options>DEPENDS_CLEAN=""; puppet_SET+=PACKAGE_ORIGIN; puppet_UNSET+=DOCS EXAMPLES PACKAGE_ROOT</build_options>
+	    <after_install_info>NOTE: First, you need to configure and enable the puppet agent under Services/Puppet. It will then try to request a certificate. You need to sign the certificate on your puppet master and run the puppet agent again.</after_install_info>
+	</package>
 </packages>
 </pfsensepkgs>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1982,5 +1982,29 @@
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
 		<depends_on_package_pbi>suricata-1.4.6-amd64.pbi</depends_on_package_pbi>
 	</package>
+	<package>
+	    <name>Puppet</name>
+	    <pkginfolink>https://doc.pfsense.org/index.php/Puppet_Package</pkginfolink>
+	    <website>http://puppetlabs.com/</website>
+	    <descr>Puppet lets you centrally manage every important aspect of your system using a cross-platform specification language that manages all the separate elements normally aggregated in different files, like users, cron jobs, and hosts, along with obviously discrete elements like packages, services, and files.</descr>
+	    <category>Services</category>
+	    <version>3.6.2_1</version>
+	    <status>Release</status>
+	    <required_version>2.1</required_version>
+	    <config_file>https://packages.pfsense.org/packages/config/puppet/puppet.xml</config_file>
+	    <maintainer>fw@moov.de</maintainer>
+	    <depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
+	    <depends_on_package></depends_on_package>
+	    <depends_on_package_pbi>puppet-3.6.2_1-amd64.pbi</depends_on_package_pbi>
+	    <configurationfile>puppet.xml</configurationfile>
+	    <build_port_path>/usr/ports/</build_port_path>
+	    <build_pbi>
+		<custom_name>puppet</custom_name>
+		<ports_before>textproc/augeas sysutils/dmidecode devel/libexecinfo devel/libffi converters/libiconv textproc/libxml2 textproc/libyaml converters/ruby-iconv lang/ruby19 devel/ruby-gems archivers/rubygem-bzip2 sysutils/rubygem-facter sysutils/rubygem-hiera devel/rubygem-json_pure textproc/rubygem-augeas</ports_before>
+		<port>sysutils/puppet</port>
+	    </build_pbi>
+	    <build_options>DEPENDS_CLEAN=""; puppet_SET+=PACKAGE_ORIGIN; puppet_UNSET+=DOCS EXAMPLES PACKAGE_ROOT</build_options>
+	    <after_install_info>NOTE: First, you need to configure and enable the puppet agent under Services/Puppet. It will then try to request a certificate. You need to sign the certificate on your puppet master and run the puppet agent again.</after_install_info>
+	</package>
 </packages>
 </pfsensepkgs>


### PR DESCRIPTION
Finally, a puppet agent for pfSense!

- tested on pfSense 2.1.2-2.1.4 amd64 (should work on i386 and 2.2 too)
- includes some GUI components to configure the puppet agent
- dependency converters/ruby-iconv requires DEPENDS_CLEAN="" in build_options for a successful PBI build on FreeBSD 8.x and 9.x (see [1] and [2])

[1] https://github.com/pcbsd/pcbsd/blob/master/src-sh/pbi-manager/pbi-manager#L1817
[2] https://github.com/freebsd/freebsd-ports/blob/master/converters/ruby-iconv/Makefile#L34