### PR TITLE
Suricata 1.4.6 pkg v1.0.1 - Update license to include proper attribution for previous work

### DIFF
--- a/config/suricata/suricata.inc
+++ b/config/suricata/suricata.inc
@@ -1,30 +1,41 @@
 <?php
 /*
-	suricata.inc
+ * suricata.inc
+ *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
+ * Copyright (C) 2014 Bill Meeks
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
 
-	Copyright (C) 2014 Bill Meeks
-	All rights reserved.
-
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions are met:
-
-	1. Redistributions of source code must retain the above copyright notice,
-	this list of conditions and the following disclaimer.
-
-	2. Redistributions in binary form must reproduce the above copyright
-	notice, this list of conditions and the following disclaimer in the
-	documentation and/or other materials provided with the distribution.
-
-	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-	POSSIBILITY OF SUCH DAMAGE.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
 */
 require_once("pfsense-utils.inc");
 require_once("config.inc");

--- a/config/suricata/suricata.xml
+++ b/config/suricata/suricata.xml
@@ -9,33 +9,42 @@
 /*
     suricata.xml
     part of the Suricata package for pfSense
-    Copyright (C) 2014 Bill meeks
 
-    All rights reserved.            
+   Significant portions are based on original work done for the Snort
+   package for pfSense from the following contributors:
+   
+   Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+   Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+   Copyright (C) 2006 Scott Ullrich
+   Copyright (C) 2009 Robert Zelaya Sr. Developer
+   Copyright (C) 2012 Ermal Luci
+   All rights reserved.
+  
+   Adapted for Suricata by:
+   Copyright (C) 2014 Bill Meeks
+   All rights reserved.
+  
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+  
+   2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+  
+   THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+   AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+   AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+   OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
 			                                                      */
-/* ========================================================================== */
-/*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-     1. Redistributions of source code MUST retain the above copyright notice,
-        this list of conditions and the following disclaimer.
-
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
-
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
 /* ========================================================================== */
 	]]>
 	</copyright>

--- a/config/suricata/suricata_alerts.php
+++ b/config/suricata/suricata_alerts.php
@@ -3,19 +3,30 @@
  * suricata_alerts.php
  * part of pfSense
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
  * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE

--- a/config/suricata/suricata_app_parsers.php
+++ b/config/suricata/suricata_app_parsers.php
@@ -3,12 +3,23 @@
  * suricata_app_parsers.php
  * part of pfSense
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_barnyard.php
+++ b/config/suricata/suricata_barnyard.php
@@ -3,12 +3,23 @@
  * suricata_barnyard.php
  * part of pfSense
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_blocked.php
+++ b/config/suricata/suricata_blocked.php
@@ -2,11 +2,23 @@
 /*
  * suricata_blocked.php
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_check_cron_misc.inc
+++ b/config/suricata/suricata_check_cron_misc.inc
@@ -3,12 +3,23 @@
  * suricata_check_cron_misc.inc
  * part of pfSense
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_check_for_rule_updates.php
+++ b/config/suricata/suricata_check_for_rule_updates.php
@@ -2,19 +2,30 @@
 /*
  * suricata_check_for_rule_updates.php
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
  * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE

--- a/config/suricata/suricata_define_vars.php
+++ b/config/suricata/suricata_define_vars.php
@@ -3,12 +3,23 @@
  * suricata_define_vars.php
  * part of pfSense
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_download_rules.php
+++ b/config/suricata/suricata_download_rules.php
@@ -2,19 +2,31 @@
 /*
  * suricata_download_rules.php
  *
+ *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
  * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE

--- a/config/suricata/suricata_download_updates.php
+++ b/config/suricata/suricata_download_updates.php
@@ -3,19 +3,30 @@
  * suricata_download_updates.php
  * part of pfSense
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
  * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE

--- a/config/suricata/suricata_flow_stream.php
+++ b/config/suricata/suricata_flow_stream.php
@@ -3,12 +3,23 @@
  * suricata_flow_stream.php
  * part of pfSense
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_generate_yaml.php
+++ b/config/suricata/suricata_generate_yaml.php
@@ -1,30 +1,41 @@
 <?php
 /*
-	suricata_generate_yaml.php
+ * suricata_generate_yaml.php
+ *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
+ * Copyright (C) 2014 Bill Meeks
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
 
-	Copyright (C) 2014 Bill Meeks
-	All rights reserved.
-
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions are met:
-
-	1. Redistributions of source code must retain the above copyright notice,
-	this list of conditions and the following disclaimer.
-
-	2. Redistributions in binary form must reproduce the above copyright
-	notice, this list of conditions and the following disclaimer in the
-	documentation and/or other materials provided with the distribution.
-
-	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-	POSSIBILITY OF SUCH DAMAGE.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
 */
 
 // Create required Suricata directories if they don't exist

--- a/config/suricata/suricata_global.php
+++ b/config/suricata/suricata_global.php
@@ -3,12 +3,23 @@
  * suricata_global.php
  * part of pfSense
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_interfaces.php
+++ b/config/suricata/suricata_interfaces.php
@@ -2,19 +2,30 @@
 /*
  * suricata_interfaces.php
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
  * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE

--- a/config/suricata/suricata_interfaces_edit.php
+++ b/config/suricata/suricata_interfaces_edit.php
@@ -2,19 +2,30 @@
 /*
  * suricata_interfaces_edit.php
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
  * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE

--- a/config/suricata/suricata_libhtp_policy_engine.php
+++ b/config/suricata/suricata_libhtp_policy_engine.php
@@ -1,12 +1,24 @@
 <?php
 /*
  * suricata_libhtp_policy_engine.php
+ *
+ * Portions of this code are based on original work done for the
+ * Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_logs_browser.php
+++ b/config/suricata/suricata_logs_browser.php
@@ -1,30 +1,41 @@
 <?php
 /*
-	suricata_logs_browser.php
+ * suricata_logs_browser.php
+ *
+ * Portions of this code are based on original work done for the
+ * Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
+ * Copyright (C) 2014 Bill Meeks
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
 
-	Copyright (C) 2014 Bill Meeks
-	All rights reserved.
-
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions are met:
-
-	1. Redistributions of source code must retain the above copyright notice,
-	this list of conditions and the following disclaimer.
-
-	2. Redistributions in binary form must reproduce the above copyright
-	notice, this list of conditions and the following disclaimer in the
-	documentation and/or other materials provided with the distribution.
-
-	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-	POSSIBILITY OF SUCH DAMAGE.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
 */
 
 require_once("guiconfig.inc");

--- a/config/suricata/suricata_logs_mgmt.php
+++ b/config/suricata/suricata_logs_mgmt.php
@@ -1,14 +1,24 @@
 <?php
 /*
  * suricata_logs_mgmt.php
- * part of pfSense
  *
+ * Portions of this code are based on original work done for the
+ * Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_os_policy_engine.php
+++ b/config/suricata/suricata_os_policy_engine.php
@@ -1,12 +1,24 @@
 <?php
 /*
  * suricata_os_policy_engine.php
+ *
+ * Portions of this code are based on original work done for the
+ * Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_passlist.php
+++ b/config/suricata/suricata_passlist.php
@@ -2,12 +2,23 @@
 /*
  * suricata_passlist.php
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_passlist_edit.php
+++ b/config/suricata/suricata_passlist_edit.php
@@ -1,12 +1,24 @@
 <?php
 /*
  * suricata_passlist_edit.php
+ *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_post_install.php
+++ b/config/suricata/suricata_post_install.php
@@ -2,13 +2,23 @@
 /*
  * suricata_post_install.php
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
- * part of pfSense
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *

--- a/config/suricata/suricata_rules.php
+++ b/config/suricata/suricata_rules.php
@@ -2,19 +2,30 @@
 /*
  * suricata_rules.php
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
  * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE

--- a/config/suricata/suricata_rules_edit.php
+++ b/config/suricata/suricata_rules_edit.php
@@ -2,19 +2,30 @@
 /*
  * suricata_rules_edit.php
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
  * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE

--- a/config/suricata/suricata_rules_flowbits.php
+++ b/config/suricata/suricata_rules_flowbits.php
@@ -1,19 +1,31 @@
 <?php
 /*
  * suricata_rules_flowbits.php
+ *
+ * Portions of this code are based on original work done for the
+ * Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
  * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE

--- a/config/suricata/suricata_rulesets.php
+++ b/config/suricata/suricata_rulesets.php
@@ -2,19 +2,30 @@
 /*
  * suricata_rulesets.php
  *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
  * Copyright (C) 2014 Bill Meeks
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
  * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE

--- a/config/suricata/suricata_suppress.php
+++ b/config/suricata/suricata_suppress.php
@@ -1,30 +1,41 @@
 <?php
 /*
-	suricata_suppress.php
+ * suricata_suppress.php
+ *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
+ * Copyright (C) 2014 Bill Meeks
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
 
-	Copyright (C) 2014 Bill Meeks
-	All rights reserved.
-
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions are met:
-
-	1. Redistributions of source code must retain the above copyright notice,
-	this list of conditions and the following disclaimer.
-
-	2. Redistributions in binary form must reproduce the above copyright
-	notice, this list of conditions and the following disclaimer in the
-	documentation and/or other materials provided with the distribution.
-
-	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-	POSSIBILITY OF SUCH DAMAGE.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
 */
 
 require_once("guiconfig.inc");

--- a/config/suricata/suricata_suppress_edit.php
+++ b/config/suricata/suricata_suppress_edit.php
@@ -1,29 +1,41 @@
 <?php
 /*
  * suricata_suppress_edit.php
-	Copyright (C) 2014 Bill Meeks
-	All rights reserved.
+ *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
+ * Copyright (C) 2014 Bill Meeks
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
 
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions are met:
-
-	1. Redistributions of source code must retain the above copyright notice,
-	this list of conditions and the following disclaimer.
-
-	2. Redistributions in binary form must reproduce the above copyright
-	notice, this list of conditions and the following disclaimer in the
-	documentation and/or other materials provided with the distribution.
-
-	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-	POSSIBILITY OF SUCH DAMAGE.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 require_once("guiconfig.inc");

--- a/config/suricata/suricata_uninstall.php
+++ b/config/suricata/suricata_uninstall.php
@@ -1,30 +1,41 @@
 <?php
 /*
-	suricata_uninstall.php
+ * suricata_uninstall.php
+ *
+ * Significant portions of this code are based on original work done
+ * for the Snort package for pfSense from the following contributors:
+ * 
+ * Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+ * Copyright (C) 2006 Scott Ullrich
+ * Copyright (C) 2009 Robert Zelaya Sr. Developer
+ * Copyright (C) 2012 Ermal Luci
+ * All rights reserved.
+ *
+ * Adapted for Suricata by:
+ * Copyright (C) 2014 Bill Meeks
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
 
-	Copyright (C) 2014 Bill Meeks
-	All rights reserved.
-
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions are met:
-
-	1. Redistributions of source code must retain the above copyright notice,
-	this list of conditions and the following disclaimer.
-
-	2. Redistributions in binary form must reproduce the above copyright
-	notice, this list of conditions and the following disclaimer in the
-	documentation and/or other materials provided with the distribution.
-
-	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-	POSSIBILITY OF SUCH DAMAGE.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
 */
 
 require_once("/usr/local/pkg/suricata/suricata.inc");


### PR DESCRIPTION
This update adds required attribution for prior code used in the Suricata GUI package.  There are no changes in functionality and thus the package version is not updated.
