### PR TITLE
Bugfix: Slave zones honour allow transfer

### DIFF
--- a/config/bind/bind.inc
+++ b/config/bind/bind.inc
@@ -347,7 +347,7 @@ EOD;
         			switch ($zonetype){
         				case "slave":
         				$bind_conf .= "\t\tmasters { $zoneipslave; };\n";
-        				$bind_conf .= "\t\tallow-transfer {none;};\n";
+        				$bind_conf .= "\t\tallow-transfer { $zoneallowtransfer;};\n";
         				$bind_conf .= "\t\tnotify no;\n";
         				break;
         				case "forward":


### PR DESCRIPTION
Fix bug where slave zones didn't honour the allow-transfer setting and wrote "none" in the config at all times
