### PR TITLE
Add --no-header to /usr/local/bin/php cron execution command

### DIFF
--- a/config/sarg/sarg.inc
+++ b/config/sarg/sarg.inc
@@ -354,7 +354,7 @@ function sync_package_sarg() {
 			else
 				$new_cron['item'][]=$cron;
 			}
-		$cron_cmd="/usr/local/bin/php /usr/local/www/sarg.php";
+		$cron_cmd="/usr/local/bin/php --no-header /usr/local/www/sarg.php";
 		$sarg_schedule_id=0;
 		if (is_array($config['installedpackages']['sargschedule']['config']))
 			foreach ($config['installedpackages']['sargschedule']['config'] as $sarg_schedule){


### PR DESCRIPTION
Without --no-header, on every cron sarg execution, the php script outputs the line "Content-type: text/html". This will be emailed
