### PR TITLE
Change way of stop openbgpd and add status on rc file bgpd.sh

### DIFF
--- a/config/openbgpd/openbgpd.inc
+++ b/config/openbgpd/openbgpd.inc
@@ -190,24 +190,26 @@ function openbgpd_install_conf() {
 
 	// Create rc.d file
 	$create_bgpd_sh = <<<EOF
+#!/bin/sh
+
 rc_start() {
-	if [ `pw groupshow {$pkg_group} 2>&1 | grep -c "pw: unknown group"` -gt 0 ]; then
+if [ `pw groupshow {$pkg_group} 2>&1 | grep -c "pw: unknown group"` -gt 0 ]; then
 		/usr/sbin/pw groupadd {$pkg_group} -g {$pkg_gid}
-	fi
-	if [ `pw usershow {$pkg_login} 2>&1 | grep -c "pw: no such user"` -gt 0 ]; then
+fi
+if [ `pw usershow {$pkg_login} 2>&1 | grep -c "pw: no such user"` -gt 0 ]; then
 		/usr/sbin/pw useradd {$pkg_login} -u {$pkg_uid} -g {$pkg_gid} -c "{$pkg_gecos}" -d {$pkg_homedir} -s {$pkg_shell}
-	fi
+fi
 
-	/bin/mkdir -p {$bgpd_config_base}
-	/usr/sbin/chown -R root:wheel {$bgpd_config_base}
-	/bin/chmod 0600  {$bgpd_config_base}/bgpd.conf
+/bin/mkdir -p {$bgpd_config_base}
+/usr/sbin/chown -R root:wheel {$bgpd_config_base}
+/bin/chmod 0600  {$bgpd_config_base}/bgpd.conf
 
-	NUMBGPD=`ps auxw | grep -c '[b]gpd.*parent'`
-	if [ \${NUMBGPD} -lt 1 ] ; then
+NUMBGPD=`ps auxw | grep -c '[b]gpd.*parent'`
+if [ \${NUMBGPD} -lt 1 ] ; then
 		{$pkg_bin}/bgpd -f {$bgpd_config_base}/bgpd.conf
-	else
+else
 		{$pkg_bin}/bgpctl reload
-	fi
+fi
 }
 
 rc_stop() {


### PR DESCRIPTION
The bgpd contains two linked process with him, In the rc file openbgpd is stoped by an killall command,  when the command kill the session engine, he automatically stop the another processes, but killall command try to stop the another processes too, generating an error on system.log file.

Trying to stop the session engine by the 'kill -15' command, and to verify if another processes is running before to use the killall command can be a better way to stop the bgpd.

Add status option in the rc file can help to see if the service is running.
