### PR TITLE
Handle port aliases & validate port before attempting to use, to prevent "erroring out"

### DIFF
--- a/config/anyterm/access_anyterm.php
+++ b/config/anyterm/access_anyterm.php
@@ -32,13 +32,23 @@ require("guiconfig.inc");
 if($config['installedpackages']['anyterm']['config'][0]['stunnelport']) {
 	$port = $config['installedpackages']['anyterm']['config'][0]['stunnelport'];
 	$httpors = "https";
-} else {
+} elseif ($config['installedpackages']['anyterm']['config'][0]['port']) {
 	$port = $config['installedpackages']['anyterm']['config'][0]['port'];
 	$httpors = "http";
+} else {
+	/* No port defined, redirect to Anyterm settings for now */
+	Header("/pkg_edit.php?xml=anyterm.xml&id=0");
 }
 
-$location = "{$_SERVER['SERVER_ADDR']}:{$port}/anyterm.html";
+if (is_alias($port) && alias_get_type($name) == "port")
+	$port = alias_expand($port);
 
-Header("Location: {$httpors}://{$location}");
+if (is_numericint($port) && $port <= 65535) {
+	$location = "{$_SERVER['SERVER_ADDR']}:{$port}/anyterm.html";
+	Header("Location: {$httpors}://{$location}");
+} else {
+	/* Port defined but not valid, redirect to Anyterm settings for now */
+	Header("/pkg_edit.php?xml=anyterm.xml&id=0");
+}
 
 ?>


### PR DESCRIPTION
Anyterm settings accept textual input for the port (useful: an alias can be specified, e.g., for fw ACL rules). 

However the code used to make the subsequent connection errors out nastily if an alias or non-port is used, since it assumes $port exists, is valid, and is already numeric -- but none of these are necessarily true, should assume and check "in case" that data is meaningful before slapping it into a URL.

This patch 
1) explicitly checks that a port is actually defined;
2) handles textual data such as a port alias; and 
3) provides at least rudimentary error handling for invalid data (like Unbound, an attempt to use the functional tab if data is bad, returns the user to the package "Settings" tab instead).
