### PR TITLE
Handle port aliases & validate port on use

### DIFF
--- a/config/anyterm/anyterm.inc
+++ b/config/anyterm/anyterm.inc
@@ -36,6 +36,7 @@ function anyterm_deinstall() {
 }
 
 function anyterm_install() {
+	require_once("filter.inc");
 	global $g, $config;
 
 	conf_mount_rw();
@@ -45,11 +46,20 @@ function anyterm_install() {
 	`fetch -q -o /usr/local/sbin/ https://packages.pfsense.org/packages/config/anyterm/binaries{$freebsdv}/anytermd`;
 	exec("chmod a+rx /usr/local/sbin/anytermd");
 
-	if($config['installedpackages']['anyterm']['config'][0]['username']) 
-		$port = " --port {$config['installedpackages']['anyterm']['config'][0]['port']}";
+	if($config['installedpackages']['anyterm']['config'][0]['username']) {
+		$port = $config['installedpackages']['anyterm']['config'][0]['port'];
+		if (is_alias($port) && alias_get_type($port) == "port")
+			$port = intval(filter_expand_alias($port)); 
+			/* Alias name + 3 digit port seemed to add unexpected spaces => alias not numeric => error.
+			   Issue is in alias handling, can't be fixed here, for now work around using intval() */
+		if (!is_numericint($port) || $port > 65535) {
+			/* Port defined but not valid, redirect to Anyterm settings for now */
+			Header("/pkg_edit.php?xml=anyterm.xml&id=0");
+		}
+	}
 
 	// This will bring up the pfSense style menu
-	$anytermd_command = "anytermd --user root --command '/etc/rc.initial' --auth trivial $port";
+	$anytermd_command = "anytermd --user root --command '/etc/rc.initial' --auth trivial --port $port";
 
 			$anyterm = <<<EOD
 #!/bin/sh


### PR DESCRIPTION
Anyterm settings accept textual input for the port (useful: an alias can be specified, e.g., for fw ACL rules). 

But the code for the actual service errors out nastily if an alias or non-port is used, since it assumes $port exists, is valid, and is already numeric.  None of these are necessarily true, it should instead check the data is meaningful and resolve if a port alias, before using raw text.

Tested, works.  Effects of patch:

1) explicitly checks a port is defined;
2) correctly handle port if textual (i.e., port alias) and validate value obtained (numeric 1-65535) within both server and client code
3) provides at least rudimentary error handling for invalid data (like Unbound, an attempt to use the functional tab if data is bad, returns the user to the package "Settings" tab instead).


NOTE - there is a small alias handling issue revealed by this - if you define an alias "AnytermPort" as port 999, then the contents of $config['aliases']['AnytermPort'] is left padded with spaces ("  999" not "999"), and filter_expand_alias() returns this value which fails since (is_numericint($port) && $port <-=65535) isn't true due to padding. Workaround - using intval() first, since the fix is in alias handling not here.