### PR TITLE
Snort 2.9.6.2 pkg v3.1.1 -- Bug fix update

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -51,7 +51,7 @@ $snortver = array();
 exec("/usr/local/bin/snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-26", $snortver);
 
 /* Used to indicate latest version of this include file has been loaded */
-$pfSense_snort_version = "3.1";
+$pfSense_snort_version = "3.1.1";
 
 /* get installed package version for display */
 $snort_package_version = "Snort {$config['installedpackages']['package'][get_pkg_id("snort")]['version']}";

--- a/config/snort/snort.xml
+++ b/config/snort/snort.xml
@@ -47,7 +47,7 @@
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>Snort</name>
 	<version>2.9.6.2</version>
-	<title>Services:2.9.6.2 pkg v3.1</title>
+	<title>Services:2.9.6.2 pkg v3.1.1</title>
 	<include_file>/usr/local/pkg/snort/snort.inc</include_file>
 	<menu>
 		<name>Snort</name>
@@ -279,7 +279,7 @@
 	</custom_add_php_command>
 	<custom_php_resync_config_command>
 		<![CDATA[
-		if ($GLOBALS['pfSense_snort_version'] == "3.1")
+		if ($GLOBALS['pfSense_snort_version'] == "3.1.1")
 		sync_snort_package_config();
 		]]>
 	</custom_php_resync_config_command>

--- a/config/snort/snort_migrate_config.php
+++ b/config/snort/snort_migrate_config.php
@@ -459,7 +459,7 @@ unset($r);
 
 // Write out the new configuration to disk if we changed anything
 if ($updated_cfg) {
-	$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.1";
+	$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.1.1";
 	log_error("[Snort] Saving configuration settings in new format...");
 	write_config("Snort pkg: migrate existing settings to new format as part of package upgrade.");
 	log_error("[Snort] Settings successfully migrated to new configuration format...");

--- a/config/snort/snort_post_install.php
+++ b/config/snort/snort_post_install.php
@@ -178,7 +178,7 @@ if (stristr($config['widgets']['sequence'], "snort_alerts-container") === FALSE)
 	$config['widgets']['sequence'] .= ",{$snort_widget_container}";
 
 /* Update Snort package version in configuration */
-$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.1";
+$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.1.1";
 write_config("Snort pkg: post-install configuration saved.");
 
 /* Done with post-install, so clear flag */

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -358,7 +358,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP;snort_SET=TARGETBASED PERFPROFILE SOURCEFIRE GRE IPV6 MPLS NORMALIZER ZLIB;snort_UNSET=PULLEDPORK;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.6.2 pkg v3.1</version>
+		<version>2.9.6.2 pkg v3.1.1</version>
 		<required_version>2.2</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -497,7 +497,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET=TARGETBASED PERFPROFILE SOURCEFIRE GRE IPV6 MPLS NORMALIZER ZLIB;snort_UNSET=PULLEDPORK;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.6.2 pkg v3.1</version>
+		<version>2.9.6.2 pkg v3.1.1</version>
 		<required_version>2.1</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -484,7 +484,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP;snort_SET=TARGETBASED PERFPROFILE SOURCEFIRE GRE IPV6 MPLS NORMALIZER ZLIB;snort_UNSET=PULLEDPORK;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.6.2 pkg v3.1</version>
+		<version>2.9.6.2 pkg v3.1.1</version>
 		<required_version>2.1</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>


### PR DESCRIPTION
## Snort 2.9.6.2 pkg v3.1.1

This update fixes an incorrect path for the Snort rules update cron task.  The location of the PHP file containing the rules update check/download was changed in the Snort 2.9.6.2 package, however one line of code in a function was missed and not updated with the file's new location.
## Bug Fixes:
1.  Snort automatic rules update cron task does not execute.
