### PR TITLE
haproxy-devel, bugfix, undefined variable caused javascript error

### DIFF
--- a/config/haproxy-devel/haproxy_htmllist.inc
+++ b/config/haproxy-devel/haproxy_htmllist.inc
@@ -225,7 +225,7 @@ function haproxy_htmllist_js(){
 		var items;
 		var i = tableId.lastIndexOf('_');
 		var items_name = prefix+"_"+tableId.substr(i+1);
-		items = eval(items_name);
+		items = eval("typeof "+items_name+" !== 'undefined' ? "+items_name+" : {}");
 		return items;
 	}
 


### PR DESCRIPTION
haproxy-devel, bugfix, undefined variable caused javascript error, now htmllist_get_select_items returns a empty object instead of an error.
