### PR TITLE
haproxy-devel, fix extra sni acl's, allow a ipalias to be entered for source ip filter, remove old haproxy from 2.2 package.xml

### DIFF
--- a/config/haproxy-devel/haproxy.inc
+++ b/config/haproxy-devel/haproxy.inc
@@ -32,6 +32,7 @@
 require_once("functions.inc");
 require_once("pkg-utils.inc");
 require_once("notices.inc");
+require_once("filter.inc");
 require_once("haproxy_utils.inc");
 require_once("haproxy_xmlrpcsyncclient.inc");
 
@@ -66,7 +67,7 @@ $a_acltypes["ssl_c_verify"] = array('name' => 'SSL Client certificate valid.',
 				'mode' => 'http', 'syntax' => 'ssl_fc_has_crt ssl_c_verify 0 ');
 $a_acltypes["ssl_c_ca_commonname"] = array('name' => 'SSL Client issued by CA common-name:',
 				'mode' => 'http', 'syntax' => 'ssl_c_i_dn(CN) %1$s');
-$a_acltypes["source_ip"] = array('name' => 'Source IP:',
+$a_acltypes["source_ip"] = array('name' => 'Source IP matches IP or Alias:',
 				'mode' => '', 'syntax' => 'src %1$s');
 $a_acltypes["backendservercount"] = array('name' => 'Minimum count usable servers:',
 				'mode' => '', 'syntax' => 'nbsrv(%2$s) ge %1$d', 'parameters' => 'value,backendname');
@@ -78,11 +79,13 @@ $a_acltypes["traffic_is_ssl"] = array('name' => 'Traffic is ssl (no value needed
 $a_acltypes["ssl_sni_matches"] = array('name' => 'Server Name Indication TLS extension matches:', 'inspect-delay' => '5',
 				'mode' => 'https', 'syntax' => 'req.ssl_sni -i %1$s', 'advancedoptions' => "tcp-request content accept if { req.ssl_hello_type 1 }");
 $a_acltypes["ssl_sni_contains"] = array('name' => 'Server Name Indication TLS extension contains:', 'inspect-delay' => '5',
-				'mode' => 'https', 'syntax' => 'req.ssl_sni -m sub -i example %1$s', 'advancedoptions' => "tcp-request content accept if { req.ssl_hello_type 1 }");
+				'mode' => 'https', 'syntax' => 'req.ssl_sni -m sub -i %1$s', 'advancedoptions' => "tcp-request content accept if { req.ssl_hello_type 1 }");
 $a_acltypes["ssl_sni_starts_with"] = array('name' => 'Server Name Indication TLS extension starts with:', 'inspect-delay' => '5',
-				'mode' => 'https', 'syntax' => 'req.ssl_sni -m beg -i example %1$s', 'advancedoptions' => "tcp-request content accept if { req.ssl_hello_type 1 }");
+				'mode' => 'https', 'syntax' => 'req.ssl_sni -m beg -i %1$s', 'advancedoptions' => "tcp-request content accept if { req.ssl_hello_type 1 }");
 $a_acltypes["ssl_sni_ends_with"] = array('name' => 'Server Name Indication TLS extension ends with:', 'inspect-delay' => '5',
-				'mode' => 'https', 'syntax' => 'req.ssl_sni -m end -i example %1$s', 'advancedoptions' => "tcp-request content accept if { req.ssl_hello_type 1 }");
+				'mode' => 'https', 'syntax' => 'req.ssl_sni -m end -i %1$s', 'advancedoptions' => "tcp-request content accept if { req.ssl_hello_type 1 }");
+$a_acltypes["custom"] = array('name' => 'Custom acl:',
+				'mode' => '', 'syntax' => '%1$s');
 
 global $a_checktypes;
 $a_checktypes = array();
@@ -95,7 +98,7 @@ $a_checktypes['HTTP'] = array('name' => 'HTTP', 'syntax' => 'httpchk',
 // 'Agent' was added in HAProxy1.5dev18, and removed in 1.5dev20, in favor of the seperate agent-check option.
 $a_checktypes['Agent'] = array('name' => 'Agent', 'syntax' => 'lb-agent-chk', 'usedifferenport' => 'yes', 
 	'descr' => 'Use a TCP connection to read an ASCII string of the form 100%,75%,drain,down (others in haproxy manual)',
-	deprecated => true);
+	'deprecated' => true);
 $a_checktypes['LDAP'] = array('name' => 'LDAP', 'syntax' => 'ldap-check',
 	'descr' => 'Use LDAPv3 health checks for server testing');
 $a_checktypes['MySQL'] = array('name' => 'MySQL', 'syntax' => 'mysql-check',
@@ -259,6 +262,16 @@ function haproxy_portoralias_to_list($port_or_alias) {
 	}
 	else 
 		return null;
+}
+
+function haproxy_hostoralias_to_list($host_or_alias) {
+	if (is_alias($host_or_alias)){
+		$result = filter_expand_alias_array($host_or_alias);
+	} else {
+		$result = array();
+		$result[] = $host_or_alias;
+	}
+	return $result;
 }
 
 function haproxy_custom_php_deinstall_command() {
@@ -1144,8 +1157,16 @@ function haproxy_writeconf($configpath) {
 						// Filter out acls for different modes
 						if ($acl['mode'] != '' && $acl['mode'] != strtolower($bind['type']))
 							continue;
-
-						$expr = sprintf($acl['syntax'],$entry['value'],$poolname);
+						if (($entry['expression'] == "source_ip") && is_alias($entry['value'])) {
+							$filename = "$configpath/ipalias_{$entry['value']}.lst";
+							$listitems = haproxy_hostoralias_to_list($entry['value']);
+							$fd_alias = fopen("$filename", "w");
+							foreach($listitems as $item)
+								fwrite($fd_alias, $item."\r\n");
+							fclose($fd_alias);
+							$expr = "src -f $filename";
+						} else
+							$expr = sprintf($acl['syntax'],$entry['value'],$poolname);
 
 						$aclname = $i . "_" . $entry['name'];
 						$aclnames .= $aclname." ";
@@ -1560,31 +1581,6 @@ function get_haproxy_frontends($excludeitem="") {
 	return $result;
 }
 
-function explode_ports($ports_list) {
-	$ports_list = split(",", $ports_list);
-	$result = array();
-	foreach($ports_list as $port){
-		//$result = array_merge($result,haproxy_portoralias_to_list($port));
-		$items = haproxy_portoralias_to_list($port);
-		foreach($items as $item){
-			if (is_portrange($item)) {
-				$portrange = explode(":", $item);
-				for($i=$portrange[0];$i<=$portrange[1];$i++)
-					$result[] = $i;
-			} else if (is_port($item)) // in pfSense 2.1 is_port returns true for a portrange also..
-				$result[] = $item;
-		}
-	}
-	//$result = group_ports($result); << deze maakt er weer portranges van.. maar zoekt wel de unieke. wat dan wel weer handig was.
-	return $result;
-}
-
-function get_frontend_ports($mainfrontend) {
-
-	$ports = $mainfrontend['port'];	
-	return explode_ports($ports);
-}
-
 function generate_cert_acl($crt, $defaultport, $nondefaultport){
 	// The host header send by a browser will contain the portnumber when a nondefault port is used for the server side.
 
@@ -1620,19 +1616,18 @@ function get_frontend_acls($frontend) {
 	
 		$poolname = $frontend['backend_serverpool'] . "_" . strtolower($frontend['type']);
 		$aclname = "SNI_" . $poolname;
-		//$ports = get_frontend_ports($mainfrontend);
 		
-		if ($frontend['ssloffloadacl'] || $frontend['ssloffloadaclnondefault']) {
+		if (isset($frontend['ssloffloadacl']) || isset($frontend['ssloffloadaclnondefault'])) {
 			$cert = lookup_cert($frontend['ssloffloadcert']);
 			$cert_cn = cert_get_cn($cert['crt']);
 			$descr = haproxy_escape_acl_name($cert['descr']);
 			unset($cert);
 			
 			$acl_item = array();
-			if ($frontend['ssloffloadacl'] && $frontend['ssloffloadaclnondefault']) {
+			if (isset($frontend['ssloffloadacl']) && isset($frontend['ssloffloadaclnondefault'])) {
 				$acl_item['descr'] = "Certificate ACL match regex: ^{$cert_cn}(:([0-9]){1,5})?$";
 				$acl_item['ref'] = array('name' => "{$aclname}_{$descr}",'expression' => 'host_regex', 'value' => "^{$cert_cn}(:([0-9]){1,5})?$");
-			} elseif ($frontend['ssloffloadaclnondefault']) {
+			} elseif (isset($frontend['ssloffloadaclnondefault'])) {
 				$acl_item['descr'] = "Certificate ACL starts with: {$cert_cn}:";
 				$acl_item['ref'] = array('name' => "{$aclname}_{$descr}",'expression' => 'host_starts_with', 'value' => $cert_cn.":");
 			} else {
@@ -1641,7 +1636,7 @@ function get_frontend_acls($frontend) {
 			}
 			$result[] = $acl_item;
 		}
-		if ($frontend['ssloffloadacladditional'] || $frontend['ssloffloadacladditionalnondefault']) {
+		if (isset($frontend['ssloffloadacladditional']) || isset($frontend['ssloffloadacladditionalnondefault'])) {
 			$certs = $frontend['ha_certificates']['item'];
 			if (is_array($certs)){
 				foreach($certs as $certref){
@@ -1651,10 +1646,10 @@ function get_frontend_acls($frontend) {
 					unset($cert);
 					
 					$acl_item = array();
-					if ($frontend['ssloffloadacladditional'] && $frontend['ssloffloadacladditionalnondefault']) {
+					if (isset($frontend['ssloffloadacladditional']) && isset($frontend['ssloffloadacladditionalnondefault'])) {
 						$acl_item['descr'] = "Certificate ACL match regex: ^{$cert_cn}(:([0-9]){1,5})?$";
 						$acl_item['ref'] = array('name' => "{$aclname}_{$descr}",'expression' => 'host_regex', 'value' => "^({$cert_cn}(($)|(:.*)))");
-					} elseif ($frontend['ssloffloadacladditionalnondefault']) {
+					} elseif (isset($frontend['ssloffloadacladditionalnondefault'])) {
 						$acl_item['descr'] = "Certificate ACL starts with: {$cert_cn}:";
 						$acl_item['ref'] = array('name' => "{$aclname}_{$descr}",'expression' => 'host_starts_with', 'value' => $cert_cn.":");
 					} else {

--- a/config/haproxy-devel/haproxy_listeners.php
+++ b/config/haproxy-devel/haproxy_listeners.php
@@ -134,10 +134,12 @@ include("head.inc");
 		$img_cert = "/themes/{$g['theme']}/images/icons/icon_frmfld_cert.png";
 		$img_adv = "/themes/{$g['theme']}/images/icons/icon_advanced.gif";
 		$img_acl = "/themes/{$g['theme']}/images/icons/icon_ts_rule.gif";
+		$textgray = "";
+		$first = true;		
 		$last_frontend_shared = false;
 		foreach ($a_frontend_grouped as $a_frontend) {
 			usort($a_frontend,'sort_sharedfrontends');
-			if (count($a_frontend) > 1 || $last_frontend_shared) {
+			if ((count($a_frontend) > 1 || $last_frontend_shared) && !$first) {
 				?> <tr class="<?=$textgray?>"><td colspan="7">&nbsp;</td></tr> <?	
 			}
 			$last_frontend_shared = count($a_frontend) > 1;
@@ -162,8 +164,8 @@ include("head.inc");
 					if (strtolower($frontend['type']) == "http" && $frontend['ssloffload']) {
 						$cert = lookup_cert($frontend['ssloffloadcert']);
 						$descr = htmlspecialchars($cert['descr']);
-						$certs = $frontend['ha_certificates']['item'];
-						if (is_array($certs)){
+						if (is_array($frontend['ha_certificates']) && is_array($frontend['ha_certificates']['item'])) {
+							$certs = $frontend['ha_certificates']['item'];
 							if (count($certs) > 0){
 								foreach($certs as $certitem){
 									$cert = lookup_cert($certitem['ssl_certificate']);
@@ -182,12 +184,12 @@ include("head.inc");
 					
 					$backend_serverpool = $frontend['backend_serverpool'];
 					$backend = get_backend($backend_serverpool );
-					if ($backend && is_array($backend['ha_servers']['item'])){
+					if ($backend && is_array($backend['ha_servers']) && is_array($backend['ha_servers']['item'])){
 						$servers = $backend['ha_servers']['item'];
 						$backend_serverpool_hint = gettext("Servers in pool:");
 						if (is_array($servers)){
 							foreach($servers as $server){
-								if ($server['forwardto'] && $server['forwardto'] != "")
+								if (isset($server['forwardto']) && $server['forwardto'] != "")
 									$backend_serverpool_hint .= "\n[".$server['forwardto']."]";
 								else								
 									$backend_serverpool_hint .= "\n".$server['address'].":".$server['port'];

--- a/config/haproxy-devel/haproxy_pool_edit.php
+++ b/config/haproxy-devel/haproxy_pool_edit.php
@@ -196,26 +196,16 @@ if ($_POST) {
 	$reqdfields = explode(" ", "name");
 	$reqdfieldsn = explode(",", "Name");		
 
-	$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-	if ($pf_version < 2.1)
-		$input_errors = eval('do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors); return $input_errors;');
-	else
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if ($_POST['stats_enabled']) {
 		$reqdfields = explode(" ", "name stats_uri");
 		$reqdfieldsn = explode(",", "Name,Stats Uri");		
-		if ($pf_version < 2.1)
-			$input_errors = eval('do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors); return $input_errors;');
-		else
-			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 		if ($_POST['stats_username']) {
 			$reqdfields = explode(" ", "stats_password stats_realm");
 			$reqdfieldsn = explode(",", "Stats Password,Stats Realm");		
-			if ($pf_version < 2.1)
-				$input_errors = eval('do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors); return $input_errors;');
-			else
-				do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
+			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 		}
 	}
 	
@@ -317,7 +307,7 @@ if ($_POST) {
 		} else {
 			$a_pools[] = $pool;
 		}
-	if (!$input_errors) {
+	if (!isset($input_errors)) {
 		if ($changecount > 0) {
 			touch($d_haproxyconfdirty_path);
 			write_config($changedesc);			
@@ -333,10 +323,6 @@ if ($_POST) {
 	}
 	$pconfig['a_servers']=&$a_pools[$id]['ha_servers']['item'];	
 }
-
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version < 2.0)
-	$one_two = true;
 
 $closehead = false;
 $pgtitle = "HAProxy: Backend server pool: Edit";
@@ -453,10 +439,7 @@ foreach($simplefields as $field){
 	}
 </script>
 <?php include("fbegin.inc"); ?>
-<?php if ($input_errors) print_input_errors($input_errors); ?>
-<?php if($one_two): ?>
-<p class="pgtitle"><?=$pgtitle?></p>
-<?php endif; ?>
+<?php if (isset($input_errors)) print_input_errors($input_errors); ?>
 	<form action="haproxy_pool_edit.php" method="post" name="iform" id="iform">
 	
 	<table width="100%" border="0" cellpadding="0" cellspacing="0">

--- a/config/haproxy-devel/haproxy_socketinfo.inc
+++ b/config/haproxy-devel/haproxy_socketinfo.inc
@@ -122,6 +122,8 @@ function haproxy_get_clients($show_traffic = false){// "show sess"
 	$clients=array();
 	$sessions = haproxy_socket_command("show sess");
 	foreach($sessions as $line) {
+		if (trim($line) == "")
+			continue;
 		list($sessid,$proto,$src,$fe,$be,$srv,$ts,$age,$calls,$rq,$rp,$s0,$s1,$exp) = explode(" ", $line);
 		#Retrieve data
 		$sessid = explode(":", $sessid);
@@ -149,10 +151,10 @@ function haproxy_get_clients($show_traffic = false){// "show sess"
 			$session_data = haproxy_socket_command("show sess {$client['sessid']}");
 			$client['session_data'] = $session_data;
 			
-			$req = explode(" ",$session_data[13]);
+			$req = explode(" ",$session_data[12]);
 			$x = explode("=",$req[7]);
 			$client['session_datareq'] = $x[1];
-			$res = explode(" ",$session_data[16]);
+			$res = explode(" ",$session_data[15]);
 			$x = explode("=",$res[7]);
 			$client['session_datares'] = $x[1];
 		}

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -134,39 +134,6 @@
 		<configurationfile>anyterm.xml</configurationfile>
 	</package>
 	<package>
-		<name>haproxy</name>
-		<pkginfolink>https://doc.pfsense.org/index.php/haproxy_package</pkginfolink>
-		<descr><![CDATA[The Reliable, High Performance TCP/HTTP Load Balancer<br />
-				This package implements both TCP and HTTP balance features from Haproxy.<br />
-				Supports acl's for smart backend switching.]]></descr>
-		<website>http://haproxy.1wt.eu/</website>
-		<category>Services</category>
-		<version>1.4.24_1 pkg v 1.2.5</version>
-		<status>Release</status>
-		<required_version>2.2</required_version>
-		<config_file>https://packages.pfsense.org/packages/config/haproxy/haproxy.xml</config_file>
-		<configurationfile>haproxy.xml</configurationfile>
-		<depends_on_package_pbi>haproxy-1.4.24_1-##ARCH##.pbi</depends_on_package_pbi>
-		<build_pbi>
-			<port>net/haproxy</port>
-		</build_pbi>
-	</package>
-	<package>
-		<name>haproxy-full</name>
-		<pkginfolink>https://doc.pfsense.org/index.php/haproxy_package</pkginfolink>
-		<descr><![CDATA[The Reliable, High Performance TCP/HTTP Load Balancer<br />
-				This package implements both TCP and HTTP balance features from Haproxy.<br />
-				(Legacy version)]]></descr>
-		<website>http://haproxy.1wt.eu/</website>
-		<category>Services</category>
-		<version>1.4.24_1 pkg v 1.1.1</version>
-		<status>Release</status>
-		<required_version>2.2</required_version>
-		<config_file>https://packages.pfsense.org/packages/config/haproxy-legacy/haproxy.xml</config_file>
-		<configurationfile>haproxy.xml</configurationfile>
-		<depends_on_package_pbi>haproxy-1.4.24_1-##ARCH##.pbi</depends_on_package_pbi>
-	</package>
-	<package>
 		<name>haproxy-devel</name>
 		<pkginfolink>https://doc.pfsense.org/index.php/haproxy_package</pkginfolink>
 		<descr><![CDATA[The Reliable, High Performance TCP/HTTP(s) Load Balancer<br />
@@ -174,12 +141,12 @@
 				Supports acl's for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5-dev26 pkg v 0.8</version>
+		<version>1.5.3 pkg v 0.11</version>
 		<status>Release</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>
 		<configurationfile>haproxy.xml</configurationfile>
-		<depends_on_package_pbi>haproxy-devel-1.5-dev26-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>haproxy-devel-1.5.3-##ARCH##.pbi</depends_on_package_pbi>
 		<build_pbi>
 			<ports_before>security/openssl</ports_before>
 			<custom_name>haproxy-devel</custom_name>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -178,7 +178,7 @@
 				Supports acl's for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.10</version>
+		<version>1.5.3 pkg v 0.11</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -165,7 +165,7 @@
 				Supports acl's for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.10</version>
+		<version>1.5.3 pkg v 0.11</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>


### PR DESCRIPTION
haproxy-devel
-fix extra sni acl's
-allow a ipalias to be entered for source ip filtering
-update pfSense 2.2 binary
-remove old haproxy packages from 2.2
-fix some php warnings
-no checking for <2.1 is needed as haproxy 1.5.x minimum version requirement has always been pfSense 2.1
-removed unused functions
