### PR TITLE
Snort 2.9.6.2 pkg v3.1.5 -- Bug fix for start failure on nano installs after a reboot

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -51,7 +51,7 @@ $snortver = array();
 exec("/usr/local/bin/snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-26", $snortver);
 
 /* Used to indicate latest version of this include file has been loaded */
-$pfSense_snort_version = "3.1.4";
+$pfSense_snort_version = "3.1.5";
 
 /* get installed package version for display */
 $snort_package_version = "Snort {$config['installedpackages']['package'][get_pkg_id("snort")]['version']}";

--- a/config/snort/snort.xml
+++ b/config/snort/snort.xml
@@ -47,7 +47,7 @@
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>Snort</name>
 	<version>2.9.6.2</version>
-	<title>Services:2.9.6.2 pkg v3.1.4</title>
+	<title>Services:2.9.6.2 pkg v3.1.5</title>
 	<include_file>/usr/local/pkg/snort/snort.inc</include_file>
 	<menu>
 		<name>Snort</name>

--- a/config/snort/snort_migrate_config.php
+++ b/config/snort/snort_migrate_config.php
@@ -490,7 +490,7 @@ unset($r);
 
 // Log a message if we changed anything
 if ($updated_cfg) {
-	$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.1.4";
+	$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.1.5";
 	log_error("[Snort] Saving configuration settings in new format...");
 	log_error("[Snort] Settings successfully migrated to new configuration format...");
 }

--- a/config/snort/snort_post_install.php
+++ b/config/snort/snort_post_install.php
@@ -263,8 +263,8 @@ if (stristr($config['widgets']['sequence'], "snort_alerts-container") === FALSE)
 	$config['widgets']['sequence'] .= ",{$snort_widget_container}";
 
 /* Update Snort package version in configuration */
-$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.1.4";
-write_config("Snort pkg v3.1.4: post-install configuration saved.");
+$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.1.5";
+write_config("Snort pkg v3.1.5: post-install configuration saved.");
 
 /* Done with post-install, so clear flag */
 unset($g['snort_postinstall']);

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -331,7 +331,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP;snort_SET=TARGETBASED PERFPROFILE SOURCEFIRE GRE IPV6 MPLS NORMALIZER ZLIB;snort_UNSET=PULLEDPORK;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.6.2 pkg v3.1.4</version>
+		<version>2.9.6.2 pkg v3.1.5</version>
 		<required_version>2.2</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -469,7 +469,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET=TARGETBASED PERFPROFILE SOURCEFIRE GRE IPV6 MPLS NORMALIZER ZLIB;snort_UNSET=PULLEDPORK;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.6.2 pkg v3.1.4</version>
+		<version>2.9.6.2 pkg v3.1.5</version>
 		<required_version>2.1</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -456,7 +456,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP;snort_SET=TARGETBASED PERFPROFILE SOURCEFIRE GRE IPV6 MPLS NORMALIZER ZLIB;snort_UNSET=PULLEDPORK;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.6.2 pkg v3.1.4</version>
+		<version>2.9.6.2 pkg v3.1.5</version>
 		<required_version>2.1</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>


### PR DESCRIPTION
# Snort 2.9.6.2 v3.1.5

This is a bug fix update.  The binary version is unchanged and no new features were added.  One bug was fixed.
## Bug Fixes
1.  Snort fails to automatically start following a firewall reboot on nanoBSD installs of pfSense.
