### PR TITLE
Adding button to clear havp access log

### DIFF
--- a/config/havp/antivirus.php
+++ b/config/havp/antivirus.php
@@ -176,6 +176,11 @@ if ($_POST['startupdate'] != '') {
 #    else echo "No 'start_antivirus_scanner' function found.";
 }
 
+/* Clear havp access log */
+if ($_POST['clearlog_x'] != '') {
+    file_put_contents(HVDEF_HAVP_ACCESSLOG, '');
+}
+
 # ------------------------------------------------------------------------------
 ?>
 
@@ -356,7 +361,7 @@ if (pfsense_version_A() == '1') {
                   }
                   else echo "<tr><td $stl>Not found</td></tr>";
               ?>              
-              <tr class="listr"><td class="listr" colspan="4"><?php echo get_av_statistic(); ?></td></tr>	              
+              <tr class="listr"><td class="listr" colspan="4"><?php echo get_av_statistic(); ?><?php echo "<div style='float:right;'><input title='Clear antivirus log' name='clearlog' type='image' value='havp' border=0 src='./themes/".$g['theme']."/images/icons/icon_x.gif'>"; ?><font size="-1">&nbsp;Clear log</font></div></td></tr>	              
             </tbody></table>
           </td>
         </tr>


### PR DESCRIPTION
Do not know how to catch button press event, therefor 'clearlog_x' parameter taken from $_POST array during debug (similar to 'start'/'stop' events).
