### PR TITLE
zabbix2 - update packages to 2.4.2 - first step

### DIFF
--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1369,8 +1369,8 @@
 		<configurationfile>zabbix2-agent.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
 		<build_pbi>
-			<custom_name>zabbix22-agent</custom_name>
-			<port>net-mgmt/zabbix22-agent</port>
+			<custom_name>zabbix24-agent</custom_name>
+			<port>net-mgmt/zabbix24-agent</port>
 		</build_pbi>
 		<depends_on_package_pbi>zabbix22-agent-2.2.7-##ARCH##.pbi</depends_on_package_pbi>
 	</package>
@@ -1385,8 +1385,8 @@
 		<configurationfile>zabbix2-proxy.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
 		<build_pbi>
-			<custom_name>zabbix22-proxy</custom_name>
-			<port>net-mgmt/zabbix22-proxy</port>
+			<custom_name>zabbix24-proxy</custom_name>
+			<port>net-mgmt/zabbix24-proxy</port>
 		</build_pbi>
 		<build_options>OPTIONS_SET+= SQLITE IPV6;OPTIONS_UNSET+= MYSQL JABBER GSSAPI</build_options>
 		<depends_on_package_pbi>zabbix22-proxy-2.2.7-##ARCH##.pbi</depends_on_package_pbi>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1760,10 +1760,10 @@
 		<required_version>2.0</required_version>
 		<configurationfile>zabbix2-agent.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
-		<build_port_path>/usr/ports/net-mgmt/zabbix22-agent</build_port_path>
+		<build_port_path>/usr/ports/net-mgmt/zabbix24-agent</build_port_path>
 		<build_pbi>
-			<custom_name>zabbix22-agent</custom_name>
-			<port>net-mgmt/zabbix22-agent</port>
+			<custom_name>zabbix24-agent</custom_name>
+			<port>net-mgmt/zabbix24-agent</port>
 		</build_pbi>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
 		<depends_on_package>zabbix22-agent-2.2.5.tbz</depends_on_package>
@@ -1779,10 +1779,10 @@
 		<required_version>2.0</required_version>
 		<configurationfile>zabbix2-proxy.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
-		<build_port_path>/usr/ports/net-mgmt/zabbix22-proxy</build_port_path>
+		<build_port_path>/usr/ports/net-mgmt/zabbix24-proxy</build_port_path>
 		<build_pbi>
-			<custom_name>zabbix22-proxy</custom_name>
-			<port>net-mgmt/zabbix22-proxy</port>
+			<custom_name>zabbix24-proxy</custom_name>
+			<port>net-mgmt/zabbix24-proxy</port>
 		</build_pbi>
 		<build_options>OPTIONS_SET+= SQLITE IPV6;OPTIONS_UNSET+= MYSQL JABBER GSSAPI</build_options>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1760,10 +1760,9 @@
 		<required_version>2.0</required_version>
 		<configurationfile>zabbix2-agent.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
-		<build_port_path>/usr/ports/net-mgmt/zabbix24-agent</build_port_path>
 		<build_pbi>
-			<custom_name>zabbix24-agent</custom_name>
-			<port>net-mgmt/zabbix24-agent</port>
+			<custom_name>zabbix22-agent</custom_name>
+			<port>net-mgmt/zabbix22-agent</port>
 		</build_pbi>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
 		<depends_on_package>zabbix22-agent-2.2.5.tbz</depends_on_package>
@@ -1779,10 +1778,9 @@
 		<required_version>2.0</required_version>
 		<configurationfile>zabbix2-proxy.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
-		<build_port_path>/usr/ports/net-mgmt/zabbix24-proxy</build_port_path>
 		<build_pbi>
-			<custom_name>zabbix24-proxy</custom_name>
-			<port>net-mgmt/zabbix24-proxy</port>
+			<custom_name>zabbix22-proxy</custom_name>
+			<port>net-mgmt/zabbix22-proxy</port>
 		</build_pbi>
 		<build_options>OPTIONS_SET+= SQLITE IPV6;OPTIONS_UNSET+= MYSQL JABBER GSSAPI</build_options>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1747,10 +1747,9 @@
 		<required_version>2.0</required_version>
 		<configurationfile>zabbix2-agent.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
-		<build_port_path>/usr/ports/net-mgmt/zabbix24-agent</build_port_path>
 		<build_pbi>
-			<custom_name>zabbix24-agent</custom_name>
-			<port>net-mgmt/zabbix24-agent</port>
+			<custom_name>zabbix22-agent</custom_name>
+			<port>net-mgmt/zabbix22-agent</port>
 		</build_pbi>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
 		<depends_on_package>zabbix22-agent-2.2.5.tbz</depends_on_package>
@@ -1766,10 +1765,9 @@
 		<required_version>2.0</required_version>
 		<configurationfile>zabbix2-proxy.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
-		<build_port_path>/usr/ports/net-mgmt/zabbix24-proxy</build_port_path>
 		<build_pbi>
-			<custom_name>zabbix24-proxy</custom_name>
-			<port>net-mgmt/zabbix24-proxy</port>
+			<custom_name>zabbix22-proxy</custom_name>
+			<port>net-mgmt/zabbix22-proxy</port>
 		</build_pbi>
 		<build_options>OPTIONS_SET+= SQLITE IPV6;OPTIONS_UNSET+= MYSQL JABBER GSSAPI</build_options>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1747,10 +1747,10 @@
 		<required_version>2.0</required_version>
 		<configurationfile>zabbix2-agent.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
-		<build_port_path>/usr/ports/net-mgmt/zabbix22-agent</build_port_path>
+		<build_port_path>/usr/ports/net-mgmt/zabbix24-agent</build_port_path>
 		<build_pbi>
-			<custom_name>zabbix22-agent</custom_name>
-			<port>net-mgmt/zabbix22-agent</port>
+			<custom_name>zabbix24-agent</custom_name>
+			<port>net-mgmt/zabbix24-agent</port>
 		</build_pbi>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
 		<depends_on_package>zabbix22-agent-2.2.5.tbz</depends_on_package>
@@ -1766,10 +1766,10 @@
 		<required_version>2.0</required_version>
 		<configurationfile>zabbix2-proxy.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
-		<build_port_path>/usr/ports/net-mgmt/zabbix22-proxy</build_port_path>
+		<build_port_path>/usr/ports/net-mgmt/zabbix24-proxy</build_port_path>
 		<build_pbi>
-			<custom_name>zabbix22-proxy</custom_name>
-			<port>net-mgmt/zabbix22-proxy</port>
+			<custom_name>zabbix24-proxy</custom_name>
+			<port>net-mgmt/zabbix24-proxy</port>
 		</build_pbi>
 		<build_options>OPTIONS_SET+= SQLITE IPV6;OPTIONS_UNSET+= MYSQL JABBER GSSAPI</build_options>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>


### PR DESCRIPTION
Preparing for upgrade.
Need to build all binaries: zabbix2 agent and proxy