### PR TITLE
Update sarg_schedule.xml

### DIFF
--- a/config/sarg/sarg_schedule.xml
+++ b/config/sarg/sarg_schedule.xml
@@ -144,7 +144,7 @@
 						To force sarg to create a report only for specific days, use:<br>
 						<b>TODAY:</b>&nbsp;&nbsp;-d `date +%d/%m/%Y`<br>
 						<b>YESTERDAY:</b>&nbsp;&nbsp;-d `date -v-1d +%d/%m/%Y`<br>
-						<b>WEEKAGO:</b>&nbsp;&nbsp;-d `date -v-1w +%d/%m/%Y`- `date -v-1d +%d/%m/%Y`<br>
+						<b>WEEKAGO:</b>&nbsp;&nbsp;-d `date -v-1w +%d/%m/%Y`-`date -v-1d +%d/%m/%Y`<br>
 						<b>MONTHAGO:</b>&nbsp;&nbsp;-d `date -v-1m +01/%m/%Y`-`date -v-1m +31/%m/%Y`]]></description>
 			<type>input</type>
 			<size>50</size>


### PR DESCRIPTION
if the example is followed, the extra space after the fourth dash in the WEEKAGO example causes the schedule to fail.
