### PR TITLE
mailscanner, allow de-installation of the package (on 2.2 ?).

### DIFF
--- a/config/mailscanner/mailscanner.inc
+++ b/config/mailscanner/mailscanner.inc
@@ -29,7 +29,7 @@
 */
 $shortcut_section = "mailscanner";
 require_once("util.inc");
-require("globals.inc");
+require_once("globals.inc");
 #require("guiconfig.inc");
 
 $pf_version=substr(trim(file_get_contents("/etc/version")),0,3);


### PR DESCRIPTION
mailscanner, allow de-installation of the package (on 2.2 ?).
solves: [ PHP ERROR Type:64, File:/etc/inc/globals.inc, Line: 176, Message: Cannot redeclare platform_booting() (previously declared in /etc/inc/globals.inc:168)]
