### PR TITLE
ntopng - add checkbox to enable historical data storage

### DIFF
--- a/config/ntopng/ntopng.xml
+++ b/config/ntopng/ntopng.xml
@@ -199,7 +199,7 @@
 		//  Add support for --data-dir /somewhere, --httpdocs-dir /somewhereelse,
 		//  --dump-timeline (on/off) --http-port, --https-port
 
-		$start .= "\t/usr/local/bin/ntopng -s -e {$dump_flows} {$ifaces} {$dns_mode} {$aggregations} {$local_networks} &";
+		$start .= "\t/usr/local/bin/ntopng -d /var/db/ntopng -G /var/run/ntopng.pid -s -e {$dump_flows} {$ifaces} {$dns_mode} {$aggregations} {$local_networks} &";
 		write_rcfile(array(
 					"file" => "ntopng.sh",
 					"start" => $start,

--- a/config/ntopng/ntopng.xml
+++ b/config/ntopng/ntopng.xml
@@ -118,6 +118,12 @@
 				<option><value>lanonly</value><name>Consider only LAN interface local</name></option>
 			</options>
 		</field>
+		<field>
+			<fielddescr>Historical Data Storage</fielddescr>
+			<fieldname>dump_flows</fieldname>
+			<description>Turn historical data storages on</description>
+			<type>checkbox</type>
+		</field>
 	</fields>
 	<custom_php_global_functions>
 	<![CDATA[
@@ -175,6 +181,11 @@
 				break;
 		}
 
+		// Historical Data Storage, Dump expired flows
+		if ($ntopng_config['dump_flows'] >= on) {
+			$dump_flows = "-F";
+		}
+		
 		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 		if ($pf_version >= 2.2) {
 			$redis_path = "/usr/pbi/ntopng-" . php_uname("m") . "/local/bin";
@@ -188,7 +199,7 @@
 		//  Add support for --data-dir /somewhere, --httpdocs-dir /somewhereelse,
 		//  --dump-timeline (on/off) --http-port, --https-port
 
-		$start .= "\t/usr/local/bin/ntopng -s -e {$ifaces} {$dns_mode} {$aggregations} {$local_networks} &";
+		$start .= "\t/usr/local/bin/ntopng -s -e {$dump_flows} {$ifaces} {$dns_mode} {$aggregations} {$local_networks} &";
 		write_rcfile(array(
 					"file" => "ntopng.sh",
 					"start" => $start,

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -258,7 +258,7 @@
 			<ports_before>databases/redis databases/gdbm net/GeoIP x11-fonts/font-util x11-fonts/webfonts graphics/graphviz</ports_before>
 			<port>net/ntopng</port>
 		</build_pbi>
-		<version>1.2.1 v0.2</version>
+		<version>1.2.1 v0.3</version>
 		<status>ALPHA</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/ntopng/ntopng.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -365,7 +365,7 @@
 			<ports_before>databases/redis databases/gdbm net/GeoIP x11-fonts/font-util x11-fonts/webfonts graphics/graphviz</ports_before>
 			<port>net/ntopng</port>
 		</build_pbi>
-		<version>1.1 v0.2</version>
+		<version>1.1 v0.3</version>
 		<status>ALPHA</status>
 		<required_version>2.1.4</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/ntopng/ntopng.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -352,7 +352,7 @@
 			<ports_before>databases/redis databases/gdbm net/GeoIP x11-fonts/font-util x11-fonts/webfonts graphics/graphviz</ports_before>
 			<port>net/ntopng</port>
 		</build_pbi>
-		<version>1.1 v0.2</version>
+		<version>1.1 v0.3</version>
 		<status>ALPHA</status>
 		<required_version>2.1.4</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/ntopng/ntopng.xml</config_file>


### PR DESCRIPTION
add checkbox to enable historical data storage

ntopng Command Line Options:
--dump-flows | -F
Dump expired flows. If ntopng is compiled with sqlite support, flows can dumped persistently on disk using this option. Databases are created daily under /db.

https://forum.pfsense.org/index.php?topic=80461.msg473467#msg473467