### PR TITLE
HAVP configurator "Log" option now really using

### DIFF
--- a/config/havp/antivirus.php
+++ b/config/havp/antivirus.php
@@ -204,7 +204,7 @@ if (pfsense_version_A() == '1') {
 	$tab_array[] = array(gettext("General page"), true, "antivirus.php");
 	$tab_array[] = array(gettext("HTTP proxy"), false, "pkg_edit.php?xml=havp.xml&amp;id=0");
 	$tab_array[] = array(gettext("Settings"), false, "pkg_edit.php?xml=havp_avset.xml&amp;id=0");
-	$tab_array[] = array(gettext("Log"), false, "havp_log.php");
+	$tab_array[] = array(gettext("HAVP Log"), false, "havp_log.php");
 
 	display_top_tabs($tab_array);
 ?>

--- a/config/havp/havp.inc
+++ b/config/havp/havp.inc
@@ -633,7 +633,7 @@ function havp_config_havp()
     # log
     $conf[] = "\n# log ";
     $conf[] = "ACCESSLOG      " . HVDEF_HAVP_ACCESSLOG;
-    $conf[] = "ERRORLOG       " . HVDEF_HAVP_ERRORLOG;
+    $conf[] = "ERRORLOG       " . ($havp_config[F_LOG] === 'true' ? HVDEF_HAVP_ERRORLOG : "/dev/null");
     # syslog
     $conf[] = "\n# syslog";
     $conf[] = "USESYSLOG      {$havp_config[F_SYSLOG]}";

--- a/config/havp/havp.xml
+++ b/config/havp/havp.xml
@@ -293,16 +293,16 @@
 						<default_value>on</default_value>
                 </field>				
                 <field>
-                        <fielddescr>Log</fielddescr>
+                        <fielddescr>HAVP Log</fielddescr>
                         <fieldname>log</fieldname>
-                        <description>Check this for enable log.</description>
+                        <description>Check this for enable HAVP log.</description>
                         <type>checkbox</type>
                         <enablefields>syslog</enablefields>
                 </field>
                 <field>
-                        <fielddescr>Syslog</fielddescr>
+                        <fielddescr>HAVP Syslog</fielddescr>
                         <fieldname>syslog</fieldname>
-                        <description>Check this for enable Syslog.</description>
+                        <description>Check this for enable HAVP Syslog.</description>
                         <type>checkbox</type>
                 </field>
         </fields>

--- a/config/havp/havp.xml
+++ b/config/havp/havp.xml
@@ -56,7 +56,7 @@
                         <url>/pkg_edit.php?xml=havp_avset.xml&amp;id=0</url>
                 </tab>
                 <tab>
-                        <text>Log</text>
+                        <text>HAVP Log</text>
                         <url>/havp_log.php</url>
                 </tab>
         </tabs>

--- a/config/havp/havp_avset.xml
+++ b/config/havp/havp_avset.xml
@@ -24,7 +24,7 @@
                         <active/>
                 </tab>
                 <tab>
-                        <text>Log</text>
+                        <text>HAVP Log</text>
                         <url>/havp_log.php</url>
                 </tab>
         </tabs>

--- a/config/havp/havp_log.php
+++ b/config/havp/havp_log.php
@@ -79,7 +79,7 @@ include("head.inc");
 	$tab_array[] = array(gettext("General page"), false, "antivirus.php");
 	$tab_array[] = array(gettext("HTTP proxy"), false, "pkg_edit.php?xml=havp.xml&amp;id=0");
 	$tab_array[] = array(gettext("Settings"), false, "pkg_edit.php?xml=havp_avset.xml&amp;id=0");
-	$tab_array[] = array(gettext("Log"), true, "havp_log.php");
+	$tab_array[] = array(gettext("HAVP Log"), true, "havp_log.php");
 	display_top_tabs($tab_array);
 ?>
   </td></tr>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1060,7 +1060,7 @@
 			<ports_after>security/clamav</ports_after>
 		</build_pbi>
 		<build_options>CLAMAVUSER=havp;CLAMAVGROUP=havp</build_options>
-		<version>0.91_3 pkg v1.04</version>
+		<version>0.91_3 pkg v1.05</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/havp/havp.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1394,7 +1394,7 @@
 		<depends_on_package_pbi>havp-0.91_1-i386.pbi</depends_on_package_pbi>
 		<build_port_path>/usr/ports/www/havp</build_port_path>
 		<build_options>CLAMAVUSER=havp;CLAMAVGROUP=havp</build_options>
-		<version>0.91_1 pkg v1.04</version>
+		<version>0.91_1 pkg v1.05</version>
 		<status>BETA</status>
 		<required_version>1.2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/havp/havp.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1381,7 +1381,7 @@
 		<depends_on_package_pbi>havp-0.91_1-amd64.pbi</depends_on_package_pbi>
 		<build_port_path>/usr/ports/www/havp</build_port_path>
 		<build_options>CLAMAVUSER=havp;CLAMAVGROUP=havp</build_options>
-		<version>0.91_1 pkg v1.04</version>
+		<version>0.91_1 pkg v1.05</version>
 		<status>BETA</status>
 		<required_version>1.2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/havp/havp.xml</config_file>


### PR DESCRIPTION
HAVP webConfigurator "Log" checkbox not using at all. Error logs was written always, regardless of "Log" option. Change this behaviour to reflect configurator option. Note: HAVP access log writes always because of virus attentions.