### PR TITLE
OpenVPN export fix index typo

### DIFF
--- a/config/openvpn-client-export/vpn_openvpn_export.php
+++ b/config/openvpn-client-export/vpn_openvpn_export.php
@@ -601,7 +601,7 @@ function useproxy_changed(obj) {
 						<td width="78%" class="vtable">
 							<select name="server" id="server" class="formselect" onchange="server_changed()">
 								<?php foreach($ras_server as & $server): ?>
-								<option value="<?=$server['sindex'];?>"><?=$server['name'];?></option>
+								<option value="<?=$server['index'];?>"><?=$server['name'];?></option>
 								<?php endforeach; ?>
 							</select>
 						</td>


### PR DESCRIPTION
The $server array here has and "index" key, not an "sindex" key.
Actually nothing was broken by this. When the user switches server selections, server_changed() is called. That uses JavaScript and selectedIndex to work out which entry the user selected. selectedIndex is a zero-based number. It matches the zero-based index of servers, which was built from the zero-based indexes of $ras_server array, which was built from data in the config. So by good luck or good management, this array index name typo is not actually a bug.
I noticed it while investigating forum https://forum.pfsense.org/index.php?topic=86263.0