### PR TITLE
Remove the correct snort.sh on deinstall

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -3094,7 +3094,7 @@ function snort_deinstall() {
 	log_error(gettext("[Snort] Snort package uninstall in progress..."));
 
 	/* Remove our rc.d startup shell script */
-	unlink_if_exists("{$rcdir}snort_pkg.sh");
+	unlink_if_exists("{$rcdir}snort.sh");
 
 	/* Make sure all active Snort processes are terminated */
 	/* Log a message only if a running process is detected */

--- a/config/snort/snort.xml
+++ b/config/snort/snort.xml
@@ -47,7 +47,7 @@
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>Snort</name>
 	<version>2.9.7.0</version>
-	<title>Services:2.9.7.0 pkg v3.2.1</title>
+	<title>Services:2.9.7.0 pkg v3.2.2</title>
 	<include_file>/usr/local/pkg/snort/snort.inc</include_file>
 	<menu>
 		<name>Snort</name>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -355,7 +355,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET=PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;snort_UNSET=PULLEDPORK FILEINSPECT HA;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.7.0 pkg v3.2.1</version>
+		<version>2.9.7.0 pkg v3.2.2</version>
 		<required_version>2.2</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -469,7 +469,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET=PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;snort_UNSET=PULLEDPORK FILEINSPECT HA;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.7.0 pkg v3.2.1</version>
+		<version>2.9.7.0 pkg v3.2.2</version>
 		<required_version>2.1</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -456,7 +456,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET=PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;snort_UNSET=PULLEDPORK FILEINSPECT HA;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.7.0 pkg v3.2.1</version>
+		<version>2.9.7.0 pkg v3.2.2</version>
 		<required_version>2.1</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>


### PR DESCRIPTION
Forum report: https://forum.pfsense.org/index.php?topic=86562.0

@bmeeks8 - this just looked wrong, because the end of snort_create_rc() has:
	/* write out snort.sh */
	@file_put_contents("{$rcdir}snort.sh", $snort_sh_text);
	@chmod("{$rcdir}snort.sh", 0755);

which seems to clearly create snort.sh
I do not run snort, so I haven't tested this! Feel free to ignore my pull request, and include this fix in the next set of snort bug fixes and version bump.