### PR TITLE
squid 3.4 - fixes #4196 and #4197

### DIFF
--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -407,6 +407,24 @@ function squid_before_form_general(&$pkg) {
 	for ($i = 0; $i < count($values) - 1; $i++)
 		$field['options']['option'][] = array('name' => $names[$i], 'value' => $values[$i]);
 }
+function squid_validate_antivirus($post, &$input_errors) {
+	global $config;
+	if ($post['enable']=="on"){
+		if($post['squidclamav'] && preg_match("/(\S+proxy.domain\S+)/",$post['squidclamav'],$a_match)){
+			$input_errors[] ="Squidclamav warns redirect points to sample config domain ({$a_match[1]})";
+			$input_errors[] ="Change redirect info on 'squidclamav.conf' field to pfsense gui or an external host. ";
+			}
+		if($post['c-icap_conf']) {
+			if( !preg_match("/squid_clamav/",$post['c-icap_conf'])){
+				$input_errors[] ="c-icap Squidclamav service definition  is no present.";
+				$input_errors[] ="Add 'Service squid_clamav squidclamav.so'(without quotes) to 'c-icap.conf' field in order to get it working.";
+				}
+			if (preg_match("/(Manager:Apassword\S+)/",$post['c-icap_conf'],$c_match)){
+				$input_errors[] ="Remove ldap configuration'{$c_match[1]}' from 'c-icap.conf' field.";
+			}
+		}
+	}
+}
 
 function squid_validate_general($post, &$input_errors) {
 	global $config;
@@ -613,7 +631,7 @@ function squid_validate_traffic($post, &$input_errors) {
 }
 
 function squid_validate_reverse($post, &$input_errors) {
-
+	global $config;
 	if(!empty($post['reverse_ip'])) {
 		$reverse_ip = explode(";", ($post['reverse_ip']));
 		foreach ($reverse_ip as $reip) {
@@ -626,13 +644,20 @@ function squid_validate_reverse($post, &$input_errors) {
 		$input_errors[] = 'The field \'external FQDN\' must contain a valid domain name';
 
 	$port = trim($post['reverse_http_port']);
+	preg_match("/(\d+)/",`sysctl net.inet.ip.portrange.first`,$portrange);
 	if (!empty($port) && !is_port($port))
 		$input_errors[] = 'The field \'reverse HTTP port\' must contain a valid port number';
-
+	if (!empty($port) && is_port($port) && $port < $portrange[1]){
+		$input_errors[] = "The field 'reverse HTTP port' must contain a port number higher then net.inet.ip.portrange.first sysctl value({$portrange[1]}).";
+		$input_errors[] = "To listen on low ports, change portrange.first sysctl value to 0 on system tunable options and restart squid daemon.";
+	}
 	$port = trim($post['reverse_https_port']);
 	if (!empty($port) && !is_port($port))
 		$input_errors[] = 'The field \'reverse HTTPS port\' must contain a valid port number';
-
+	if (!empty($port) && is_port($port) && $port < $portrange[1]){
+		$input_errors[] = "The field 'reverse HTTPS port' must contain a port number higher then net.inet.ip.portrange.first sysctl value({$portrange[1]}).";
+		$input_errors[] = "To listen on low ports, change portrange.first sysctl value to 0 on system tunable options and restart squid daemon.";
+	}
 	if ($post['reverse_ssl_cert'] == 'none')
 		$input_errors[] = 'A valid certificate for the external interface must be selected';
 
@@ -940,7 +965,12 @@ function squid_resync_general() {
 	}
 	$icp_port = ($settings['icp_port'] ? $settings['icp_port'] : 0);
 	$dns_v4_first= ($settings['dns_v4_first'] == "on" ? "on" : "off" );
-	$pidfile = "{$g['varrun_path']}/squid.pid";
+	$piddir="{$g['varrun_path']}/squid";
+	$pidfile = "{$piddir}/squid.pid";
+	if (!is_dir($piddir)){
+		make_dirs($piddir);
+		squid_chown_recursive($piddir, 'proxy', 'wheel');
+		}
 	$language = ($settings['error_language'] ? $settings['error_language'] : 'en');
 	$icondir = SQUID_CONFBASE . '/icons';
 	$hostname = ($settings['visible_hostname'] ? $settings['visible_hostname'] : 'localhost');
@@ -1325,35 +1355,6 @@ function squid_resync_antivirus(){
 		}
 		if (is_array($config['installedpackages']['squid']))
 			$squid_config=$config['installedpackages']['squid']['config'][0];
-		$clwarn="clwarn.cgi.en_EN";
-		if (preg_match("/de/i",$squid_config['error_language']))
-			$clwarn="clwarn.cgi.de_DE";
-		if (preg_match("/ru/i",$squid_config['error_language']))
-			$clwarn="clwarn.cgi.ru_RU";
-		if (preg_match("/fr/i",$squid_config['error_language']))
-			$clwarn="clwarn.cgi.fr_FR";
-		if (preg_match("/pt_br/i",$squid_config['error_language']))
-			$clwarn="clwarn.cgi.pt_BR";
-		$clwarn_file="/usr/local/www/clwarn.cgi";
-		copy(SQUID_LOCALBASE."/libexec/squidclamav/{$clwarn}",$clwarn_file);
-
-		#fix perl path on clwarn.cgi
-		$clwarn_file_new=file_get_contents($clwarn_file);
-		$c_pattern[]="@/usr/\S+/perl@";
-		$c_replacement[]=SQUID_BASE."/bin/perl";
-		/*$c_pattern[]="@redirect \S+/clwarn.cgi@";
-		$gui_proto=$config['system']['webgui']['protocol'];
-		$gui_port=$config['system']['webgui']['port'];
-		if($gui_port == "") {
-			$gui_port($gui_proto == "http"?"80":"443");
-			}
-		$c_replacement[]=SQUID_LOCALBASE."redirect {$gui_proto}://127.0.0.1:{$gui_port}/clwarn.cgi";
-		*/
-		$clwarn_file_new=preg_replace($c_pattern, $c_replacement,$clwarn_file_new);
-		file_put_contents($clwarn_file, $clwarn_file_new,LOCK_EX);
-
-		#fix clwarn.cgi file permission
-		chmod($clwarn_file,0755);
 
 		$conf = <<< EOF
 icap_enable on
@@ -1364,11 +1365,10 @@ icap_client_username_header X-Authenticated-User
 icap_preview_enable on
 icap_preview_size 1024
 
-icap_service service_req reqmod_precache bypass=0 icap://127.0.0.1:1344/squidclamav
-icap_service service_resp respmod_precache bypass=0 icap://127.0.0.1:1344/squidclamav
-
-adaptation_access service_req allow all
-adaptation_access service_resp allow all
+icap_service service_avi_req reqmod_precache icap://[::1]:1344/squid_clamav bypass=off
+adaptation_access service_avi_req allow all
+icap_service service_avi_resp respmod_precache icap://[::1]:1344/squid_clamav bypass=on
+adaptation_access service_avi_resp allow all
 
 EOF;
 		#check if icap is enabled on rc.conf.local
@@ -1395,29 +1395,41 @@ EOF;
 			if (file_exists(SQUID_LOCALBASE."/etc/c-icap/squidclamav.conf.default")){
 				$sample_file=file_get_contents(SQUID_LOCALBASE."/etc/c-icap/squidclamav.conf.default");
 				$clamav_m[0]="@/var/run/clamav/clamd.ctl@";
+				$clamav_m[1]="@cgi-bin/clwarn.cgi@";
 				$clamav_r[0]="/var/run/clamav/clamd.sock";
+				$clamav_r[1]="squid_clwarn.php";
 				file_put_contents(SQUID_LOCALBASE."/etc/c-icap/squidclamav.conf.sample",preg_replace($clamav_m,$clamav_r,$sample_file),LOCK_EX);
 			}
 		#c-icap.conf
 		if (!file_exists(SQUID_LOCALBASE."/etc/c-icap/c-icap.conf.sample"))
 			if (file_exists(SQUID_LOCALBASE."/etc/c-icap/c-icap.conf.default")){
 				$sample_file=file_get_contents(SQUID_LOCALBASE."/etc/c-icap/c-icap.conf.default");
-				if (! preg_match ("/squidclamav/"))
-					$sample_file.="\nService squidclamav squidclamav.so\n";
-
-				file_put_contents(SQUID_LOCALBASE."/etc/c-icap/c-icap.conf.sample",$sample_file,LOCK_EX);
+				if (! preg_match("/squid_clamav/",$sample_file))
+					$sample_file.="\nService squid_clamav squidclamav.so\n";
+				$cicap_m[0]="@Manager:Apassword\S+@";
+				$cicap_r[0]="";
+				file_put_contents(SQUID_LOCALBASE."/etc/c-icap/c-icap.conf.sample",preg_replace($cicap_m,$cicap_r,$sample_file),LOCK_EX);
 			}
+		//check squidclamav files until pbis are gone(https://redmine.pfsense.org/issues/4197)
+		$ln_icap= array('bin/c-icap','bin/c-icap-client','c-icap-config','c-icap-libicapapi-config','c-icap-stretch','lib/c_icap','share/c_icap','etc/c-icap');
+		foreach ($ln_icap as $ln){
+			if (!file_exists("/usr/local/{$ln}") && file_exists(SQUID_LOCALBASE."/{$ln}"))
+				symlink(SQUID_LOCALBASE."/{$ln}","/usr/local/{$ln}");
+		}
+		if (!file_exists("/usr/local/lib/libicapapi.so.3") && file_exists(SQUID_LOCALBASE."/lib/libicapapi.so.3.0.5"))
+			symlink(SQUID_LOCALBASE."/lib/libicapapi.so.3.0.5","/usr/local/lib/libicapapi.so.3");
+
 		$loadsample=0;
 		if ($antivirus_config['squidclamav'] =="" && file_exists(SQUID_LOCALBASE."/etc/c-icap/squidclamav.conf.sample")){
-			$config['installedpackages']['squidantivirus']['config'][0]['squidclamav']=base64_encode(file_get_contents(SQUID_LOCALBASE."/etc/c-icap/squidclamav.conf.sample"));
+			$config['installedpackages']['squidantivirus']['config'][0]['squidclamav']=base64_encode(str_replace( "\r", "",file_get_contents(SQUID_LOCALBASE."/etc/c-icap/squidclamav.conf.sample")));
 			$loadsample++;
 		}
 		if ($antivirus_config['c-icap_conf'] =="" && file_exists(SQUID_LOCALBASE."/etc/c-icap/c-icap.conf.sample")){
-			$config['installedpackages']['squidantivirus']['config'][0]['c-icap_conf']=base64_encode(file_get_contents(SQUID_LOCALBASE."/etc/c-icap/c-icap.conf.sample"));
+			$config['installedpackages']['squidantivirus']['config'][0]['c-icap_conf']=base64_encode(str_replace( "\r", "",file_get_contents(SQUID_LOCALBASE."/etc/c-icap/c-icap.conf.sample")));
 			$loadsample++;
 		}
-		if ($antivirus_config['squidclamav'] =="" && file_exists(SQUID_LOCALBASE."/etc/c-icap/c-icap.magic.default")){
-			$config['installedpackages']['squidantivirus']['config'][0]['c-icap_magic']=base64_encode(file_get_contents(SQUID_LOCALBASE."/etc/c-icap/c-icap.magic.default"));
+		if ($antivirus_config['c-icap_magic'] =="" && file_exists(SQUID_LOCALBASE."/etc/c-icap/c-icap.magic.sample")){
+			$config['installedpackages']['squidantivirus']['config'][0]['c-icap_magic']=base64_encode(str_replace( "\r", "",file_get_contents(SQUID_LOCALBASE."/etc/c-icap/c-icap.magic.sample")));
 			$loadsample++;
 		}
 		if($loadsample > 0){
@@ -1462,11 +1474,20 @@ EOF;
 				$sample_file=file_get_contents($c_icap_rcfile);
 				$cicapm[0]="@c_icap_user=.*}@";
 				$cicapr[0]='c_icap_user="clamav"}';
+				$cicapm[1]="@/usr/local@";
+				$cicapr[1]=SQUID_LOCALBASE;
 				file_put_contents($c_icap_rcfile,preg_replace($cicapm,$cicapr,$sample_file),LOCK_EX);
 				}
 			mwexec_bg("/usr/local/etc/rc.d/c-icap start");
 			}
 		#check clamav
+		$clamav_rcfile="/usr/local/etc/rc.d/clamva-clamd";
+			if (file_exists($clamav_rcfile)){
+				$sample_file=file_get_contents($clamav_rcfile);
+				$clamm[0]="@/usr/local@";
+				$clamr[0]=SQUID_LOCALBASE;
+				file_put_contents($clamav_rcfile,preg_replace($clamm,$clamr,$sample_file),LOCK_EX);
+				}
 		if (is_process_running("clamd"))
 			mwexec_bg("/usr/local/etc/rc.d/clamav-clamd reload");
 		else
@@ -2272,6 +2293,7 @@ function squid_write_rcfile() {
 	$rc = array();
 	$rc['file'] = 'squid.sh';
 	$rc['start'] = <<<EOD
+#sysctl net.inet.ip.portrange.reservedhigh=0
 if [ -z "`ps auxw | grep "[s]quid "|awk '{print $2}'`" ];then
 	{$squid_base}/sbin/squid -f {$squid_conffile_var}
 fi

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -648,14 +648,14 @@ function squid_validate_reverse($post, &$input_errors) {
 	if (!empty($port) && !is_port($port))
 		$input_errors[] = 'The field \'reverse HTTP port\' must contain a valid port number';
 	if (!empty($port) && is_port($port) && $port < $portrange[1]){
-		$input_errors[] = "The field 'reverse HTTP port' must contain a port number higher then net.inet.ip.portrange.first sysctl value({$portrange[1]}).";
+		$input_errors[] = "The field 'reverse HTTP port' must contain a port number higher than net.inet.ip.portrange.first sysctl value({$portrange[1]}).";
 		$input_errors[] = "To listen on low ports, change portrange.first sysctl value to 0 on system tunable options and restart squid daemon.";
 	}
 	$port = trim($post['reverse_https_port']);
 	if (!empty($port) && !is_port($port))
 		$input_errors[] = 'The field \'reverse HTTPS port\' must contain a valid port number';
 	if (!empty($port) && is_port($port) && $port < $portrange[1]){
-		$input_errors[] = "The field 'reverse HTTPS port' must contain a port number higher then net.inet.ip.portrange.first sysctl value({$portrange[1]}).";
+		$input_errors[] = "The field 'reverse HTTPS port' must contain a port number higher than net.inet.ip.portrange.first sysctl value({$portrange[1]}).";
 		$input_errors[] = "To listen on low ports, change portrange.first sysctl value to 0 on system tunable options and restart squid daemon.";
 	}
 	if ($post['reverse_ssl_cert'] == 'none')

--- a/config/squid3/34/squid.xml
+++ b/config/squid3/34/squid.xml
@@ -239,6 +239,11 @@
 		<item>https://packages.pfsense.org/packages/config/squid3/34/squid_log_parser.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
+	    <prefix>/usr/local/www/</prefix>
+	    <chmod>0755</chmod>
+		<item>https://packages.pfsense.org/packages/config/squid3/34/squid_clwarn.php</item>
+	</additional_files_needed>
+	<additional_files_needed>
 	    <prefix>/usr/local/www/shortcuts/</prefix>
 	    <chmod>0755</chmod>
 		<item>https://packages.pfsense.org/packages/config/squid3/34/pkg_squid.inc</item>

--- a/config/squid3/34/squid_antivirus.xml
+++ b/config/squid3/34/squid_antivirus.xml
@@ -151,6 +151,7 @@
 		</field>
 	</fields>
 	<custom_php_validation_command>
+		squid_validate_antivirus($_POST, $input_errors);
 	</custom_php_validation_command>
 	<custom_php_resync_config_command>
 		squid_resync();

--- a/config/squid3/34/squid_clwarn.php
+++ b/config/squid3/34/squid_clwarn.php
@@ -1,0 +1,95 @@
+<?php
+/* ========================================================================== */
+/*
+	squid_clwarn.php
+	part of pfSense (http://www.pfSense.com)
+	Copyright (C) 2015 Marcello Coutinho
+	All rights reserved.
+                                                                              */
+/* ========================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	 1. Redistributions of source code must retain the above copyright notice,
+		this list of conditions and the following disclaimer.
+
+	 2. Redistributions in binary form must reproduce the above copyright
+		notice, this list of conditions and the following disclaimer in the
+		documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+                                                                              */
+/* ========================================================================== */
+$VERSION = '6.10';
+ $url = $_REQUEST['url'];
+$virus=($_REQUEST['virus']?$_REQUEST['virus']:$_REQUEST['malware']);
+$source = preg_replace("@/-@","",$_REQUEST['source']);
+$user = $_REQUEST['user'];
+
+
+$TITLE_VIRUS = "SquidClamAv $VERSION: Virus detected!";
+$subtitle = 'Virus name';
+$errorreturn = 'This file cannot be downloaded.';
+$urlerror = 'contains a virus';
+if (preg_match("/Safebrowsing/",$virus)) {
+	$TITLE_VIRUS = "SquidClamAv $VERSION: Unsafe Browsing detected";
+	$subtitle = 'Malware / pishing type';
+	$urlerror = 'is listed as suspicious';
+	$errorreturn = 'This page can not be displayed';
+}
+
+# Remove clamd infos
+$vp[0]="/stream: /";
+$vp[1]="/ FOUND/";
+$vr[0]="";
+$vr[1]="";
+
+$virus = preg_replace($vp,$vr,$virus);
+
+
+?>
+<style type="text/css">
+	.visu {
+	border:1px solid #C0C0C0;
+	color:#FFFFFF;
+	  position: relative;
+	  min-width: 13em;
+	  max-width: 52em;
+	  margin: 4em auto;
+	  border: 1px solid ThreeDShadow;
+	  border-radius: 10px;
+	  padding: 3em;
+	  -moz-padding-start: 30px;
+	background-color: #8b0000;
+}
+.visu h2, .visu h3, .visu h4 {
+	font-size:130%;
+	font-family:"times new roman", times, serif;
+	font-style:normal;
+	font-weight:bolder;
+}
+</style>
+	<div class="visu">
+	<h2><?=$TITLE_VIRUS?></h2>
+	<hr>
+	<p>
+	The requested URL <?=$url?> <?=$urlerror?><br>
+	<?=$subtitle?>: <?=$virus?>
+		<p>
+	<?=$errorreturn?>
+	<p>
+	Origin: <?=$source?> / <?=$user?>
+	<p>
+	<hr>
+	<font color="blue"> Powered by <a href="http://squidclamav.darold.net/">SquidClamAv <?=$VERSION?></a>.</font>
+	</div>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -909,16 +909,16 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>3.4.10_2 pkg 0.2.2</version>
+		<version>3.4.10_2 pkg 0.2.3</version>
 		<status>beta</status>
 		<required_version>2.2</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>
 		<build_pbi>
 			<ports_before>www/libwww security/cyrus-sasl2</ports_before>
 			<port>www/squid</port>
-			<ports_after>www/squid_radius_auth security/clamav www/squidclamav security/ca_root_nss www/c-icap-modules</ports_after>
+			<ports_after>www/squid_radius_auth security/clamav www/squidclamav security/ca_root_nss www/c-icap-modules devel/pcre</ports_after>
 		</build_pbi>
-		<build_options>squid_UNSET_FORCE=AUTH_SASL AUTH_SMB AUTH_SQL DEBUG TP_IPFW DNS_HELPER  ESI FS_ROCK TP_IPF NETTLE  STACKTRACES VIA_DB  DOCS EXAMPLES;squid_SET_FORCE=ARP_ACL AUTH_KERB AUTH_LDAP AUTH_NIS DELAY_POOLS ECAP FOLLOW_XFF FS_AUFS FS_DISKD HTCP ICAP ICMP IDENT IPV6 KQUEUE LARGEFILE SNMP SSL SSL_CRTD LAX_HTTP TP_PF WCCP WCCPV2 CACHE_DIGESTS</build_options>
+		<build_options>c-icap_SET_FORCE=LARGE_FILES squid_UNSET_FORCE=AUTH_SASL AUTH_SMB AUTH_SQL DEBUG TP_IPFW DNS_HELPER  ESI FS_ROCK TP_IPF NETTLE  STACKTRACES VIA_DB  DOCS EXAMPLES;squid_SET_FORCE=ARP_ACL AUTH_KERB AUTH_LDAP AUTH_NIS DELAY_POOLS ECAP FOLLOW_XFF FS_AUFS FS_DISKD HTCP ICAP ICMP IDENT IPV6 KQUEUE LARGEFILE SNMP SSL SSL_CRTD LAX_HTTP TP_PF WCCP WCCPV2 CACHE_DIGESTS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/squid3/34/squid.xml</config_file>
 		<configurationfile>squid.xml</configurationfile>
 		<depends_on_package_pbi>squid-3.4.10_2-##ARCH##.pbi</depends_on_package_pbi>


### PR DESCRIPTION
/var/run/squid check
squidclamav symbolic links
antivirus tab check config
c-icap rc.d file path checks
clamd rc.d file path checks
squid_clwarn.php replacement for clwarn.cgi to do not need perl install