### PR TITLE
Add new X-Forward Mode option to GUI

### DIFF
--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -1030,7 +1030,8 @@ EOD;
 		$conf .= "acl localnet src $src\n";
 		$valid_acls[] = 'localnet';
 	}
-	if ($settings['disable_xforward']) $conf .= "forwarded_for off\n";
+	if ($settings['xforward_mode']) $conf .= "forwarded_for {$settings['xforward_mode']}\n";
+  else $conf .= "forwarded_for on\n"; //only used for first run
 	if ($settings['disable_via']) $conf .= "via off\n";
 	if ($settings['disable_squidversion']) $conf .= "httpd_suppress_version_string on\n";
 	if (!empty($settings['uri_whitespace'])) $conf .= "uri_whitespace {$settings['uri_whitespace']}\n";

--- a/config/squid3/34/squid.xml
+++ b/config/squid3/34/squid.xml
@@ -485,10 +485,18 @@
 			<default_value>en</default_value>
 		</field>
 		<field>
-			<fielddescr>Disable X-Forward</fielddescr>
-			<fieldname>disable_xforward</fieldname>
-			<description>If not set, Squid will include your system's IP address or name in the HTTP requests it forwards.</description>
-			<type>checkbox</type>
+			<fielddescr>X-Forward Mode</fielddescr>
+			<fieldname>xforward_mode</fieldname>
+			<description>&lt;p&gt;&lt;b&gt; on:&lt;/b&gt; Squid will append your client's IP address in the HTTP requests it forwards. (Default)&lt;p&gt;          By default it looks like: X-Forwarded-For: 192.1.2.3  &lt;p&gt; &lt;b&gt; off:&lt;/b&gt; It will appear as: X-Forwarded-For: unknown&lt;p&gt; &lt;b&gt; transparent:&lt;/b&gt; Squid will not alter the X-Forwarded-For header in any way.&lt;p&gt; &lt;b&gt; delete:&lt;/b&gt; Squid will delete the entire X-Forwarded-For header.&lt;p&gt; &lt;b&gt; truncate:&lt;/b&gt; Squid will remove all existing X-Forwarded-For entries, and place the client IP as the sole entry.</description>
+			<type>select</type>
+			<default_value>on</default_value>
+			<options>
+				<option><name>(on)</name><value>on</value></option>
+				<option><name>off</name><value>off</value></option>
+				<option><name>transparent</name><value>transparent</value></option>
+				<option><name>delete</name><value>delete</value></option>
+				<option><name>truncate</name><value>truncate</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Disable VIA</fielddescr>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -909,7 +909,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>3.4.10_2 pkg 0.2.5</version>
+		<version>3.4.10_2 pkg 0.2.6</version>
 		<status>beta</status>
 		<required_version>2.2</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>


### PR DESCRIPTION
removed 'disable_xforward' field and replaced it with 'xforward_mode' since this a re-write of the GUI option
adding 5 forward_for options per
http://www.squid-cache.org/Versions/v3/3.4/cfgman/forwarded_for.html

https://forum.pfsense.org/index.php?topic=85280.msg476632#msg476632