### PR TITLE
Fix 4282 vnstat symlinks for PBI compatibility fail to install

### DIFF
--- a/config/vnstat2/vnstat2.inc
+++ b/config/vnstat2/vnstat2.inc
@@ -114,8 +114,8 @@ EOF;
 	fwrite($hf2, $vnstat_conf_file);
 	fclose($hf2);
 	// Reinstall the symlink for the PBI, if this is a PBI install. (note: -f to overwrite any existing file)
-	if (file_exists('/usr/pbi/vnstat-i386')) { exec("ln -sf /usr/local/etc/vnstat.conf /usr/pbi/vnstat-i386/etc/vnstat.conf"); }
-	if (file_exists('/usr/pbi/vnstat-amd64')) { exec("ln -sf /usr/local/etc/vnstat.conf /usr/pbi/vnstat-amd64/etc/vnstat.conf"); }
+	if (file_exists('/usr/pbi/vnstat-i386')) { symlink("/usr/local/etc/vnstat.conf", "/usr/pbi/vnstat-i386/etc/vnstat.conf"); }
+	if (file_exists('/usr/pbi/vnstat-amd64')) { symlink("/usr/local/etc/vnstat.conf", "/usr/pbi/vnstat-amd64/etc/vnstat.conf"); }
 }
 
 function create_vnstati_image() {

--- a/config/vnstat2/vnstat2.inc
+++ b/config/vnstat2/vnstat2.inc
@@ -149,6 +149,9 @@ function vnstat_install_config() {
 //	exec("[ -d /var/db/vnstat ] && mv /var/db/vnstat /conf/vnstat");
 	exec("[ -d /usr/local/pkg/vnstat2/vnstat ] && mv /usr/local/pkg/vnstat2/vnstat /conf/vnstat");
 	exec("[ ! -d /conf/vnstat ] && mkdir /conf/vnstat");
+// Check for pbi install and arch type then create symlinks (note: -f to overwrite any file that was installed by the package)
+	if (file_exists('/usr/pbi/vnstat-i386')) { exec("ln -sf /usr/local/etc/vnstat.conf /usr/pbi/vnstat-i386/etc/vnstat.conf"); }
+	if (file_exists('/usr/pbi/vnstat-amd64')) { exec("ln -sf /usr/local/etc/vnstat.conf /usr/pbi/vnstat-amd64/etc/vnstat.conf"); }
 // Add MonthRotate value to config.xml and write /usr/local/etc/vnstat.conf
 	$no_monthrotate = $config['installedpackages']['vnstat2']['config'][0]['monthrotate'];	
 	if ($no_monthrotate == ""){

--- a/config/vnstat2/vnstat2.inc
+++ b/config/vnstat2/vnstat2.inc
@@ -113,6 +113,9 @@ EOF;
 	}
 	fwrite($hf2, $vnstat_conf_file);
 	fclose($hf2);
+	// Reinstall the symlink for the PBI, if this is a PBI install. (note: -f to overwrite any existing file)
+	if (file_exists('/usr/pbi/vnstat-i386')) { exec("ln -sf /usr/local/etc/vnstat.conf /usr/pbi/vnstat-i386/etc/vnstat.conf"); }
+	if (file_exists('/usr/pbi/vnstat-amd64')) { exec("ln -sf /usr/local/etc/vnstat.conf /usr/pbi/vnstat-amd64/etc/vnstat.conf"); }
 }
 
 function create_vnstati_image() {
@@ -146,9 +149,6 @@ function vnstat_install_config() {
 //	exec("[ -d /var/db/vnstat ] && mv /var/db/vnstat /conf/vnstat");
 	exec("[ -d /usr/local/pkg/vnstat2/vnstat ] && mv /usr/local/pkg/vnstat2/vnstat /conf/vnstat");
 	exec("[ ! -d /conf/vnstat ] && mkdir /conf/vnstat");
-// Check for pbi install and arch type then create symlinks
-	if (file_exists('/usr/pbi/vnstat-i386')) { exec("ln -s /usr/local/etc/vnstat.conf /usr/pbi/vnstat-i386/etc/vnstat.conf"); }
-	if (file_exists('/usr/pbi/vnstat-amd64')) { exec("ln -s /usr/local/etc/vnstat.conf /usr/pbi/vnstat-amd64/etc/vnstat.conf"); }
 // Add MonthRotate value to config.xml and write /usr/local/etc/vnstat.conf
 	$no_monthrotate = $config['installedpackages']['vnstat2']['config'][0]['monthrotate'];	
 	if ($no_monthrotate == ""){

--- a/config/vnstat2/vnstat2.inc
+++ b/config/vnstat2/vnstat2.inc
@@ -114,8 +114,8 @@ EOF;
 	fwrite($hf2, $vnstat_conf_file);
 	fclose($hf2);
 	// Reinstall the symlink for the PBI, if this is a PBI install. (note: -f to overwrite any existing file)
-	if (file_exists('/usr/pbi/vnstat-i386')) { symlink("/usr/local/etc/vnstat.conf", "/usr/pbi/vnstat-i386/etc/vnstat.conf"); }
-	if (file_exists('/usr/pbi/vnstat-amd64')) { symlink("/usr/local/etc/vnstat.conf", "/usr/pbi/vnstat-amd64/etc/vnstat.conf"); }
+	if (file_exists('/usr/pbi/vnstat-i386')) { exec("ln -sf /usr/local/etc/vnstat.conf /usr/pbi/vnstat-i386/etc/vnstat.conf"); }
+	if (file_exists('/usr/pbi/vnstat-amd64')) { exec("ln -sf /usr/local/etc/vnstat.conf /usr/pbi/vnstat-amd64/etc/vnstat.conf"); }
 }
 
 function create_vnstati_image() {

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -591,7 +591,7 @@
 		<build_pbi>
 			<port>net/vnstat</port>
 		</build_pbi>
-		<version>1.11_6,2</version>
+		<version>1.11_6,3</version>
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<maintainer>crazypark2@yahoo.dk</maintainer>


### PR DESCRIPTION
The package installs a symlink in an attempt to redirect the /usr/local/etc/vnstat.conf into the PBI directory for the binary to use, however this symlink will fail to overwrite the vnstat.conf that the package included. I suspect this symlink gets destroyed anyways when the file is overwritten by the configuration page. Therefore, the solution is to reinstall the symlink as a matter of course in writing the configuration file.

Fixes #4282