### PR TITLE
Fix #4285 lcdproc package is PBI-ignorant

### DIFF
--- a/config/lcdproc/lcdproc.inc
+++ b/config/lcdproc/lcdproc.inc
@@ -371,6 +371,9 @@ EOD;
 			conf_mount_rw();
 			lcdproc_write_script(LCDPROC_CLIENT, $client_script);
 			lcdproc_write_config(LCDPROC_CONFIG, $config_text);
+			// Check for pbi install and arch type then create symlinks (note: -f to overwrite any pre-existing file from the package install)
+			if (file_exists('/usr/pbi/lcdproc-i386')) { exec("ln -sf ".LCDPROC_CONFIG." /usr/pbi/lcdproc-i386/etc/LCDd.conf"); }
+			if (file_exists('/usr/pbi/lcdproc-amd64')) { exec("ln -sf ".LCDPROC_CONFIG." /usr/pbi/lcdproc-amd64/etc/LCDd.conf"); }
 			write_rcfile(array(
 					'file' => 'lcdproc.sh',
 					'start' => $start,

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -928,7 +928,7 @@
 		<descr>LCD display driver</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>lcdproc-0.5.7_1 pkg.v.1.0.1</version>
+		<version>lcdproc-0.5.7_1 pkg.v.1.0.2</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<maintainer>seth.mos@dds.nl</maintainer>


### PR DESCRIPTION
Symlink the configuration into the appropriate PBI root so LCDd can find it.

Fixes #4285