### PR TITLE
Suricata Package:  Fix typos where "Snort" should be "Suricata" in labels.

### DIFF
--- a/config/suricata/suricata_global.php
+++ b/config/suricata/suricata_global.php
@@ -236,13 +236,13 @@ if ($input_errors)
 			<tr>
 				<td valign="top" width="8%"><input name="enable_etopen_rules" type="checkbox" value="on" onclick="enable_et_rules();" 
 				<?php if ($config['installedpackages']['suricata']['config'][0]['enable_etopen_rules']=="on") echo "checked"; ?>/></td>
-				<td><span class="vexpl"><?php echo gettext("ETOpen is an open source set of Snort rules whose coverage " .
+				<td><span class="vexpl"><?php echo gettext("ETOpen is an open source set of Suricata rules whose coverage " .
 				"is more limited than ETPro."); ?></span></td>
 			</tr>
 			<tr>
 				<td valign="top" width="8%"><input name="enable_etpro_rules" type="checkbox" value="on" onclick="enable_pro_rules();" 
 				<?php if ($config['installedpackages']['suricata']['config'][0]['enable_etpro_rules']=="on") echo "checked"; ?>/></td>
-				<td><span class="vexpl"><?php echo gettext("ETPro for Snort offers daily updates and extensive coverage of current malware threats."); ?></span></td>
+				<td><span class="vexpl"><?php echo gettext("ETPro for Suricata offers daily updates and extensive coverage of current malware threats."); ?></span></td>
 			</tr>
 		<tr>
 			<td>&nbsp;</td>


### PR DESCRIPTION
Suricata 2.0.4 pkg v2.1.3
===================
This update for Suricata simply corrects two typos where "Snort" is used instead of "Suricata" in some descriptive text on the GLOBAL SETTINGS tab.  There are no changes to functionality and a package version bump is not required.

Bug Fixes:
--------------
1. Change "Snort" to "Suricata" in text for ET-Open and ET-Pro rule descriptions on GLOBAL SETTINGS tab.