### PR TITLE
Suricata - Update build options for 2.0.6 PBI pkg.

### DIFF
--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1461,7 +1461,7 @@
 			<port>security/suricata</port>
 			<ports_after>security/barnyard2</ports_after>
 		</build_pbi>
-		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;suricata_SET=IPFW PORTS_PCAP GEOIP JSON;suricata_UNSET=PRELUDE TESTS HTP_PORT</build_options>
+		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;suricata_SET=IPFW PORTS_PCAP GEOIP JSON NSS LUAJIT HTP_PORT;suricata_UNSET=PRELUDE TESTS SC LUA</build_options>
 		<depends_on_package_pbi>suricata-2.0.4-##ARCH##.pbi</depends_on_package_pbi>
 	</package>
 </packages>


### PR DESCRIPTION
Suricata 2.0.6
------------------
This updates the PBI build options for the Suricata package to match up with the latest OPTIONS knobs from FreeBSD Ports.  This update is currently only for pfSense 2.2 and higher.

Please build new Suricata 2.0.6 PBI packages for pfSense 2.2 after merging this update.
