### PR TITLE
Update Suricata PBI to version 2.0.6

### DIFF
--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1452,7 +1452,7 @@
 		<website>http://suricata-ids.org/</website>
 		<descr><![CDATA[High Performance Network IDS, IPS and Security Monitoring engine by OISF.]]></descr>
 		<category>Security</category>
-		<version>2.0.4 pkg v2.1.3</version>
+		<version>2.0.6 pkg v2.1.3</version>
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/suricata/suricata.xml</config_file>
@@ -1462,7 +1462,7 @@
 			<ports_after>security/barnyard2</ports_after>
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;suricata_SET=IPFW PORTS_PCAP GEOIP JSON NSS LUAJIT HTP_PORT;suricata_UNSET=PRELUDE TESTS SC LUA</build_options>
-		<depends_on_package_pbi>suricata-2.0.4-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>suricata-2.0.6-##ARCH##.pbi</depends_on_package_pbi>
 	</package>
 </packages>
 </pfsensepkgs>


### PR DESCRIPTION
Suricata 2.0.6 pkg v2.1.3
---------------------------------
This updates the binary version of the Suricata PBI package to 2.0.6 and brings the pfPorts version to the same level as the FreeBSD port.  Information on the upstream bug fixes in this release can be found at http://suricata-ids.org/2015/01/15/suricata-2-0-6-available/.