### PR TITLE
Fixed phpservice status not being able to extract status from ps.

### DIFF
--- a/config/phpservice/phpservice.xml
+++ b/config/phpservice/phpservice.xml
@@ -56,6 +56,9 @@
 		<rcfile>phpservice.sh</rcfile>
 		<executable>phpservice</executable>
 		<description>PHP run from a command line as a service.</description>    
+		<custom_php_service_status_command>
+			exec("/bin/pgrep -f phpservice");
+		</custom_php_service_status_command>
 	</service>
 	<tabs>
 		<tab>


### PR DESCRIPTION
This fixes the Status/Services display of the phpservice package.
This should apply to 2.1.5 as well.