### PR TITLE
Snort 2.9.7.0 v3.2.3 - Bug fix update

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -324,10 +324,11 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 	if (($externallist && $localnet == 'yes') || (!$externallist && (!$whitelist || $localnet == 'yes' || empty($localnet)))) {
 		if (is_ipaddr($snortip)) {
 			if ($snortcfg['interface'] <> "wan") {
-				$sn = get_interface_subnet($snortcfg['interface']);
-				$ip = gen_subnet($snortip, $sn) . "/{$sn}";
-				if (!in_array($ip, $home_net))
-					$home_net[] = $ip;
+				if ($sn = get_interface_subnet($snortcfg['interface'])) {
+					$ip = gen_subnet($snortip, $sn) . "/{$sn}";
+					if (!in_array($ip, $home_net))
+						$home_net[] = $ip;
+				}
 			}
 		}
 	}
@@ -346,10 +347,11 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 	if (($externallist && $localnet == 'yes') || (!$externallist && (!$whitelist || $localnet == 'yes' || empty($localnet)))) {
 		if (is_ipaddrv6($snortip)) {
 			if ($snortcfg['interface'] <> "wan") {
-				$sn = get_interface_subnetv6($snortcfg['interface']);
-				$ip = gen_subnetv6($snortip, $sn). "/{$sn}";
-				if (!in_array($ip, $home_net))
-					$home_net[] = $ip;
+				if ($sn = get_interface_subnetv6($snortcfg['interface'])) {
+					$ip = gen_subnetv6($snortip, $sn). "/{$sn}";
+					if (!in_array($ip, $home_net))
+						$home_net[] = $ip;
+				}
 			}
 		}
 	}
@@ -383,10 +385,11 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 				continue;
 			$subnet = get_interface_ip($int);
 			if (is_ipaddrv4($subnet)) {
-				$sn = get_interface_subnet($int);
-				$ip = gen_subnet($subnet, $sn) . "/{$sn}";
-				if (!in_array($ip, $home_net))
-					$home_net[] = $ip;
+				if ($sn = get_interface_subnet($int)) {
+					$ip = gen_subnet($subnet, $sn) . "/{$sn}";
+					if (!in_array($ip, $home_net))
+						$home_net[] = $ip;
+				}
 			}
 
 			$subnet = get_interface_ipv6($int);
@@ -394,10 +397,11 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 			if (strpos($subnet, "%") !== FALSE)
 				$subnet = substr($subnet, 0, strpos($subnet, "%"));
 			if (is_ipaddrv6($subnet)) {
-				$sn = get_interface_subnetv6($int);
-				$ip = gen_subnetv6($subnet, $sn). "/{$sn}";
-				if (!in_array($ip, $home_net))
-					$home_net[] = $ip;
+				if ($sn = get_interface_subnetv6($int)) {
+					$ip = gen_subnetv6($subnet, $sn). "/{$sn}";
+					if (!in_array($ip, $home_net))
+						$home_net[] = $ip;
+				}
 			}
 
 			// Add link-local address

--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -814,7 +814,9 @@ function snort_snortloglimit_install_cron($should_install=TRUE) {
 	if ($should_install && snort_cron_job_exists("/usr/local/pkg/snort/snort_check_cron_misc.inc", TRUE, "*/5"))
 		return;
 
-	// Else install the new or updated cron job
+	// Else install the new or updated cron job by removing the
+	// existing job first, then installing the new or updated job.
+	install_cron_job("snort_check_cron_misc.inc", false);
 	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php -f /usr/local/pkg/snort/snort_check_cron_misc.inc", $should_install, "*/5");
 }
 
@@ -921,7 +923,9 @@ function snort_rm_blocked_install_cron($should_install) {
 
 	// Else install the new or updated cron job
 	if ($should_install) {
-		install_cron_job($command, $should_install, $snort_rm_blocked_min, $snort_rm_blocked_hr, $snort_rm_blocked_mday, $snort_rm_blocked_month, $snort_rm_blocked_wday, "root");
+		// Remove the existing job first, then install the new or updated job
+		install_cron_job("snort2c", false);
+		install_cron_job($command, true, $snort_rm_blocked_min, $snort_rm_blocked_hr, $snort_rm_blocked_mday, $snort_rm_blocked_month, $snort_rm_blocked_wday, "root");
 	}
 }
 
@@ -1009,8 +1013,11 @@ function snort_rules_up_install_cron($should_install) {
 		return;
 
 	// Else install the new or updated cron job
-	if ($should_install)
+	if ($should_install) {
+		// Remove the existing job first, then install the new or updated job
+		install_cron_job("snort_check_for_rule_updates.php", false);
 		install_cron_job($command, $should_install, $snort_rules_up_min, $snort_rules_up_hr, $snort_rules_up_mday, $snort_rules_up_month, $snort_rules_up_wday, "root");
+	}
 }
 
 /* Only run when all ifaces needed to sync. Expects filesystem rw */

--- a/config/snort/snort.xml
+++ b/config/snort/snort.xml
@@ -47,7 +47,7 @@
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>Snort</name>
 	<version>2.9.7.0</version>
-	<title>Services:2.9.7.0 pkg v3.2.2</title>
+	<title>Services:2.9.7.0 pkg v3.2.3</title>
 	<include_file>/usr/local/pkg/snort/snort.inc</include_file>
 	<menu>
 		<name>Snort</name>

--- a/config/snort/snort_migrate_config.php
+++ b/config/snort/snort_migrate_config.php
@@ -533,7 +533,7 @@ unset($r);
 
 // Log a message if we changed anything
 if ($updated_cfg) {
-	$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.2";
+	$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.2.3";
 	log_error("[Snort] Settings successfully migrated to new configuration format...");
 }
 else

--- a/config/snort/snort_post_install.php
+++ b/config/snort/snort_post_install.php
@@ -115,6 +115,27 @@ if ($pkgid >= 0) {
 /* Define a default Dashboard Widget Container for Snort */
 $snort_widget_container = "snort_alerts-container:col2:close";
 
+/*********************************************************/
+/* START OF BUG FIX CODE                                 */
+/*                                                       */
+/* Remove any Snort cron tasks that may have been left   */
+/* from a previous uninstall due to a bug that saved     */
+/* edited cron tasks as new ones while still leaving     */
+/* the original task.  Correct cron task entries will    */
+/* be recreated below if saved settings are detected.    */
+/*********************************************************/
+$cron_count = 0;
+while (snort_cron_job_exists("snort2c", FALSE)) {
+	install_cron_job("snort2c", false);
+	$cron_count++;
+}
+if ($cron_count > 0)
+	log_error(gettext("[Snort] Removed {$cron_count} duplicate 'remove_blocked_hosts' cron task(s)."));
+
+/*********************************************************/
+/* END OF BUG FIX CODE                                   */
+/*********************************************************/
+
 /* remake saved settings */
 if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 	log_error(gettext("[Snort] Saved settings detected... rebuilding installation with saved settings..."));

--- a/config/snort/snort_post_install.php
+++ b/config/snort/snort_post_install.php
@@ -263,8 +263,8 @@ if (stristr($config['widgets']['sequence'], "snort_alerts-container") === FALSE)
 	$config['widgets']['sequence'] .= ",{$snort_widget_container}";
 
 /* Update Snort package version in configuration */
-$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.2";
-write_config("Snort pkg v3.2: post-install configuration saved.");
+$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.2.3";
+write_config("Snort pkg v3.2.3: post-install configuration saved.");
 
 /* Done with post-install, so clear flag */
 unset($g['snort_postinstall']);

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -339,7 +339,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET=PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;snort_UNSET=PULLEDPORK FILEINSPECT HA;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.7.0 pkg v3.2.2</version>
+		<version>2.9.7.0 pkg v3.2.3</version>
 		<required_version>2.2</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -469,7 +469,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET=PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;snort_UNSET=PULLEDPORK FILEINSPECT HA;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.7.0 pkg v3.2.2</version>
+		<version>2.9.7.0 pkg v3.2.3</version>
 		<required_version>2.1</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -456,7 +456,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET=PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;snort_UNSET=PULLEDPORK FILEINSPECT HA;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.7.0 pkg v3.2.2</version>
+		<version>2.9.7.0 pkg v3.2.3</version>
 		<required_version>2.1</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>


### PR DESCRIPTION
Snort 2.9.7.0 pkg v3.2.3
==================
This update for the Snort package corrects two reported bugs in the GUI code.  This is a bug fix release only and no features were added or modified.

Bug Fixes
-------------
1. Multiple cron task entries are generated when editing "rules update" and "remove blocked hosts" intervals.
2. In rare instances, a blank network and subnet string results in an invalid slash "/" character in a PASS LIST.