### PR TITLE
pfBlockerNG - Fix Cron Update + improvements

### DIFF
--- a/config/pfblockerng/geoipupdate.sh
+++ b/config/pfblockerng/geoipupdate.sh
@@ -23,19 +23,23 @@
 # may be met by including the following in all advertising and documentation
 # mentioning features of or use of this database.
 
-# Folder Locations
+mtype=$(/usr/bin/uname -m);
+
+# Application Locations
 pathfetch=/usr/bin/fetch
 pathtar=/usr/bin/tar
 pathgunzip=/usr/bin/gunzip
 
-# File Locations
+# Folder Locations
 pathdb=/var/db/pfblockerng
+pathpbi=/usr/pbi/pfblockerng-$mtype/share/GeoIP
 pathlog=/var/log/pfblockerng
+
+# File Locations
 errorlog=$pathlog/geoip.log
-pathgeoipdatgz=$pathdb/GeoIP.dat.gz
-pathgeoipdatgzv6=$pathdb/GeoIPv6.dat.gz
-pathgeoipdat=$pathdb/GeoIP.dat
-pathgeoipdatv6=$pathdb/GeoIPv6.dat
+geoipdat=/GeoIP.dat
+geoipdatv6=/GeoIPv6.dat
+
 pathgeoipcc=$pathdb/country_continent.csv
 pathgeoipcsv4=$pathdb/GeoIPCountryCSV.zip
 pathgeoipcsvfinal4=$pathdb/GeoIPCountryWhois.csv
@@ -56,12 +60,12 @@ binaryupdate() {
 
 echo " ** Downloading MaxMind GeoLite IPv4 Binary Database (For Reputation/Alerts Processes) **"; echo
 URL="http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz"
-$pathfetch -v -o $pathgeoipdatgz -T 20 $URL
+$pathfetch -v -o $pathpbi$geoipdat.gz -T 20 $URL
 if [ "$?" -eq "0" ]; then
-	$pathgunzip -f $pathgeoipdatgz
+	$pathgunzip -f $pathpbi$geoipdat.gz
 	echo; echo " ( MaxMind IPv4 GeoIP.dat has been updated )"; echo
 	echo "Current Date/Timestamp:"
-	/bin/ls -alh $pathgeoipdat
+	/bin/ls -alh $pathpbi$geoipdat
 	echo
 else
 	echo; echo " => MaxMind IPv4 GeoIP.dat Update [ FAILED ]"; echo
@@ -72,12 +76,12 @@ fi
 
 echo; echo " ** Downloading MaxMind GeoLite IPv6 Binary Database (For Reputation/Alerts Processes) **"; echo
 URL="http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz"
-$pathfetch -v -o $pathgeoipdatgzv6 -T 20 $URL
+$pathfetch -v -o $pathpbi$geoipdatv6.gz -T 20 $URL
 if [ "$?" -eq "0" ]; then
-	$pathgunzip -f $pathgeoipdatgzv6
+	$pathgunzip -f $pathpbi$geoipdatv6.gz
 	echo; echo " ( MaxMind IPv6 GeoIPv6.dat has been updated )"; echo
 	echo "Current Date/Timestamp:"
-	/bin/ls -alh $pathgeoipdatv6
+	/bin/ls -alh $pathpbi$geoipdatv6
 	echo
 else
 	echo; echo " => MaxMind IPv6 GeoIPv6.dat Update [ FAILED ]"; echo

--- a/config/pfblockerng/pfblockerng.inc
+++ b/config/pfblockerng/pfblockerng.inc
@@ -2341,9 +2341,6 @@ function pfblockerng_php_install_command() {
 	update_output_window(gettext("Downloading MaxMind Country Databases. This may take a minute..."));
 	exec("/bin/sh /usr/local/pkg/pfblockerng/geoipupdate.sh all >> {$pfb['geolog']} 2>&1");
 
-	@rename("{$pfb['dbdir']}/GeoIP.dat", "{$pfb['ccdir']}/GeoIP.dat");
-	@rename("{$pfb['dbdir']}/GeoIPv6.dat", "{$pfb['ccdir']}/GeoIPv6.dat");
-
 	update_output_window(gettext("MaxMind Country Database downloads completed..."));
 	update_output_window(gettext("Converting MaxMind Country Databases for pfBlockerNG. This may take a few minutes..."));
 	pfblockerng_uc_countries();

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -115,9 +115,9 @@
 				Provision to download from diverse List formats. Advanced Integration<br />
 				for Emerging Threats IQRisk IP Reputation Threat Sources.]]></descr>
 		<category>Firewall</category>
-		<pkginfolink>https://forum.pfsense.org/index.php?topic=86212.msg483663#msg483663</pkginfolink>
+		<pkginfolink>https://forum.pfsense.org/index.php?topic=86212.0</pkginfolink>
 		<config_file>https://packages.pfsense.org/packages/config/pfblockerng/pfblockerng.xml</config_file>
-		<version>1.01</version>
+		<version>1.02</version>
 		<status>Beta</status>
 		<required_version>2.2</required_version>
 		<maintainer>BBCan177@gmail.com</maintainer>


### PR DESCRIPTION
Changes:

1) Add missing variable ($pfbfolder) to Cron Update Function
2) Modify how include files are loaded.
3) Reputation Tab only requires IPv4. Simplify code to only use IPv4 for this function
4) Update geoipupdate.sh to use new PBI folder Location and remove Archive files after conversion.