### PR TITLE
Suricata 2.0.6 pkg v2.1.4 - GUI Package Bug Fix Update

### DIFF
--- a/config/suricata/suricata.inc
+++ b/config/suricata/suricata.inc
@@ -327,10 +327,11 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 	if (($externallist && $localnet == 'yes') || (!$externallist && (!$passlist || $localnet == 'yes' || empty($localnet)))) {
 		if (is_ipaddrv4($suricataip)) {
 			if ($suricatacfg['interface'] <> "wan") {
-				$sn = get_interface_subnet($suricatacfg['interface']);
-				$ip = gen_subnet($suricataip, $sn) . "/{$sn}";
-				if (!in_array($ip, $home_net))
-					$home_net[] = $ip;
+				if ($sn = get_interface_subnet($suricatacfg['interface'])) {
+					$ip = gen_subnet($suricataip, $sn) . "/{$sn}";
+					if (!in_array($ip, $home_net))
+						$home_net[] = $ip;
+				}
 			}
 		}
 	}
@@ -349,10 +350,11 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 	if (($externallist && $localnet == 'yes') || (!$externallist && (!$passlist || $localnet == 'yes' || empty($localnet)))) {
 		if (is_ipaddrv6($suricataip)) {
 			if ($suricatacfg['interface'] <> "wan") {
-				$sn = get_interface_subnetv6($suricatacfg['interface']);
-				$ip = gen_subnetv6($suricataip, $sn). "/{$sn}";
-				if (!in_array($ip, $home_net))
-					$home_net[] = $ip;
+				if ($sn = get_interface_subnetv6($suricatacfg['interface'])) {
+					$ip = gen_subnetv6($suricataip, $sn). "/{$sn}";
+					if (!in_array($ip, $home_net))
+						$home_net[] = $ip;
+				}
 			}
 		}
 	}
@@ -386,10 +388,11 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 				continue;
 			$subnet = get_interface_ip($int);
 			if (is_ipaddrv4($subnet)) {
-				$sn = get_interface_subnet($int);
-				$ip = gen_subnet($subnet, $sn) . "/{$sn}";
-				if (!in_array($ip, $home_net))
-					$home_net[] = $ip;
+				if ($sn = get_interface_subnet($int)) {
+					$ip = gen_subnet($subnet, $sn) . "/{$sn}";
+					if (!in_array($ip, $home_net))
+						$home_net[] = $ip;
+				}
 			}
 
 			$subnet = get_interface_ipv6($int);
@@ -397,10 +400,11 @@ function suricata_build_list($suricatacfg, $listname = "", $passlist = false, $e
 			if (strpos($subnet, "%") !== FALSE)
 				$subnet = substr($subnet, 0, strpos($subnet, "%"));
 			if (is_ipaddrv6($subnet)) {
-				$sn = get_interface_subnetv6($int);
-				$ip = gen_subnetv6($subnet, $sn). "/{$sn}";
-				if (!in_array($ip, $home_net))
-					$home_net[] = $ip;
+				if ($sn = get_interface_subnetv6($int)) {
+					$ip = gen_subnetv6($subnet, $sn). "/{$sn}";
+					if (!in_array($ip, $home_net))
+						$home_net[] = $ip;
+				}
 			}
 
 			// Add link-local address

--- a/config/suricata/suricata.inc
+++ b/config/suricata/suricata.inc
@@ -646,9 +646,10 @@ function suricata_rules_up_install_cron($should_install=true) {
 	if (suricata_cron_job_exists($command, TRUE, $suricata_rules_up_min, $suricata_rules_up_hr, $suricata_rules_up_mday, $suricata_rules_up_month, $suricata_rules_up_wday, "root"))
 		return;
 
-	// Else install the new or updated cron job
-	if ($should_install)
-		install_cron_job($command, $should_install, $suricata_rules_up_min, $suricata_rules_up_hr, $suricata_rules_up_mday, $suricata_rules_up_month, $suricata_rules_up_wday, "root");
+	// Else install the new or updated cron job by removing the
+	// existing job first, then installing the new or updated job.
+	install_cron_job("suricata_check_for_rule_updates.php", false);
+	install_cron_job($command, $should_install, $suricata_rules_up_min, $suricata_rules_up_hr, $suricata_rules_up_mday, $suricata_rules_up_month, $suricata_rules_up_wday, "root");
 }
 
 function suricata_loglimit_install_cron($should_install=true) {
@@ -664,7 +665,9 @@ function suricata_loglimit_install_cron($should_install=true) {
 	if ($should_install && suricata_cron_job_exists("/usr/local/pkg/suricata/suricata_check_cron_misc.inc", TRUE, "*/5"))
 		return;
 
-	// Else install the new or updated cron job
+	// Else install the new or updated cron job by removing the
+	// existing job first, then installing the new or updated job.
+	install_cron_job("suricata_check_cron_misc.inc", false);
 	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php -f /usr/local/pkg/suricata/suricata_check_cron_misc.inc", $should_install, "*/5");
 }
 
@@ -769,10 +772,10 @@ function suricata_rm_blocked_install_cron($should_install) {
 	if (suricata_cron_job_exists($command, TRUE, $suricata_rm_blocked_min, $suricata_rm_blocked_hr, $suricata_rm_blocked_mday, $suricata_rm_blocked_month, $suricata_rm_blocked_wday, "root"))
 		return;
 
-	// Else install the new or updated cron job
-	if ($should_install) {
-		install_cron_job($command, $should_install, $suricata_rm_blocked_min, $suricata_rm_blocked_hr, $suricata_rm_blocked_mday, $suricata_rm_blocked_month, $suricata_rm_blocked_wday, "root");
-	}
+	// Else install the new or updated cron job by removing the
+	// existing job first, then installing the new or updated job.
+	install_cron_job("{$suri_pf_table}", false);
+	install_cron_job($command, $should_install, $suricata_rm_blocked_min, $suricata_rm_blocked_hr, $suricata_rm_blocked_mday, $suricata_rm_blocked_month, $suricata_rm_blocked_wday, "root");
 }
 
 function sync_suricata_package_config() {

--- a/config/suricata/suricata.xml
+++ b/config/suricata/suricata.xml
@@ -42,7 +42,7 @@
 	<description>Suricata IDS/IPS Package</description>
 	<requirements>None</requirements>
 	<name>suricata</name>
-	<version>2.0.4 pkg v2.1.3</version>
+	<version>2.0.4 pkg v2.1.4</version>
 	<title>Services: Suricata IDS</title>
 	<include_file>/usr/local/pkg/suricata/suricata.inc</include_file>
 	<menu>

--- a/config/suricata/suricata_alerts.php
+++ b/config/suricata/suricata_alerts.php
@@ -424,20 +424,21 @@ if ($pconfig['arefresh'] == 'on')
 	echo "<meta http-equiv=\"refresh\" content=\"60;url=/suricata/suricata_alerts.php?instance={$instanceid}\" />\n";
 ?>
 
-<?php
-/* Display Alert message */
-if ($input_errors) {
-	print_input_errors($input_errors); // TODO: add checks
-}
-if ($savemsg) {
-	print_info_box($savemsg);
-}
-?>
 <form action="/suricata/suricata_alerts.php" method="post" id="formalert">
 <input type="hidden" name="sidid" id="sidid" value=""/>
 <input type="hidden" name="gen_id" id="gen_id" value=""/>
 <input type="hidden" name="ip" id="ip" value=""/>
 <input type="hidden" name="descr" id="descr" value=""/>
+
+<?php
+/* Display Alert message */
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
+if ($savemsg) {
+	print_info_box($savemsg);
+}
+?>
 
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <tbody>

--- a/config/suricata/suricata_barnyard.php
+++ b/config/suricata/suricata_barnyard.php
@@ -229,8 +229,10 @@ include_once("head.inc");
 ?>
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 
-<?php include("fbegin.inc"); 
+<?php include("fbegin.inc"); ?>
 
+<form action="suricata_barnyard.php" method="post" name="iform" id="iform">
+<?php
 	/* Display Alert message */
 	if ($input_errors) {
 		print_input_errors($input_errors);
@@ -239,10 +241,7 @@ include_once("head.inc");
 	if ($savemsg) {
 		print_info_box($savemsg);
 	}
-
 ?>
-
-<form action="suricata_barnyard.php" method="post" name="iform" id="iform">
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <tbody>
 <tr><td>

--- a/config/suricata/suricata_blocked.php
+++ b/config/suricata/suricata_blocked.php
@@ -163,18 +163,20 @@ include_once("fbegin.inc");
 /* refresh every 60 secs */
 if ($pconfig['brefresh'] == 'on')
 	echo "<meta http-equiv=\"refresh\" content=\"60;url=/suricata/suricata_blocked.php\" />\n";
+?>
 
+<form action="/suricata/suricata_blocked.php" method="post">
+<input type="hidden" name="ip" id="ip" value=""/>
+
+<?php
 /* Display Alert message */
 if ($input_errors) {
-	print_input_errors($input_errors); // TODO: add checks
+	print_input_errors($input_errors);
 }
 if ($savemsg) {
 	print_info_box($savemsg);
 }
 ?>
-
-<form action="/suricata/suricata_blocked.php" method="post">
-<input type="hidden" name="ip" id="ip" value=""/>
 
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <tbody>

--- a/config/suricata/suricata_define_vars.php
+++ b/config/suricata/suricata_define_vars.php
@@ -157,13 +157,7 @@ include_once("head.inc");
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 
 <?php 
-include("fbegin.inc"); 
-if($pfsense_stable == 'yes'){echo '<p class="pgtitle">' . $pgtitle . '</p>';}
-/* Display Alert message */
-if ($input_errors)
-	print_input_errors($input_errors); // TODO: add checks
-if ($savemsg)
-	print_info_box($savemsg);
+include("fbegin.inc");
 ?>
 
 <script type="text/javascript" src="/javascript/autosuggest.js">
@@ -171,6 +165,15 @@ if ($savemsg)
 <script type="text/javascript" src="/javascript/suggestions.js">
 </script>
 <form action="suricata_define_vars.php" method="post" name="iform" id="iform">
+
+<?php
+/* Display Alert message */
+if ($input_errors)
+	print_input_errors($input_errors);
+if ($savemsg)
+	print_info_box($savemsg);
+?>
+
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <tbody>
 <tr><td>

--- a/config/suricata/suricata_ip_list_mgmt.php
+++ b/config/suricata/suricata_ip_list_mgmt.php
@@ -170,6 +170,13 @@ include_once("head.inc");
 
 <?php
 include_once("fbegin.inc");
+?>
+
+<form action="/suricata/suricata_ip_list_mgmt.php" enctype="multipart/form-data" method="post" name="iform" id="iform">
+<input type="hidden" name="MAX_FILE_SIZE" value="100000000" />
+<input type="hidden" name="iplist_fname" id="iplist_fname" value=""/>
+
+<?php
 if ($input_errors) {
 	print_input_errors($input_errors);
 }
@@ -178,9 +185,6 @@ if ($savemsg)
 	print_info_box($savemsg);
 ?>
 
-<form action="/suricata/suricata_ip_list_mgmt.php" enctype="multipart/form-data" method="post" name="iform" id="iform">
-<input type="hidden" name="MAX_FILE_SIZE" value="100000000" />
-<input type="hidden" name="iplist_fname" id="iplist_fname" value=""/>
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <tbody>
 <tr><td>

--- a/config/suricata/suricata_ip_reputation.php
+++ b/config/suricata/suricata_ip_reputation.php
@@ -177,11 +177,6 @@ include_once("head.inc");
 
 <?php 
 include("fbegin.inc"); 
-/* Display Alert message */
-if ($input_errors)
-	print_input_errors($input_errors);
-if ($savemsg)
-	print_info_box($savemsg);
 ?>
 
 <form action="suricata_ip_reputation.php" method="post" name="iform" id="iform" >
@@ -193,7 +188,13 @@ if ($savemsg)
 <?php if (is_subsystem_dirty('suricata_iprep') && !$input_errors): ?><p>
 <?php print_info_box_np(gettext("A change has been made to IP List file assignments.") . "<br/>" . gettext("You must apply the change in order for it to take effect."));?>
 <?php endif; ?>
-
+<?php
+/* Display Alert message */
+if ($input_errors)
+	print_input_errors($input_errors);
+if ($savemsg)
+	print_info_box($savemsg);
+?>
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 	<tbody>
 	<tr>

--- a/config/suricata/suricata_passlist.php
+++ b/config/suricata/suricata_passlist.php
@@ -104,7 +104,11 @@ include_once("head.inc");
 
 <?php
 include_once("fbegin.inc");
+?>
 
+<form action="/suricata/suricata_passlist.php" method="post">
+<input type="hidden" name="list_id" id="list_id" value=""/>
+<?php
 /* Display Alert message */
 if ($input_errors) {
 	print_input_errors($input_errors);
@@ -113,9 +117,6 @@ if ($savemsg) {
 	print_info_box($savemsg);
 }
 ?>
-
-<form action="/suricata/suricata_passlist.php" method="post">
-<input type="hidden" name="list_id" id="list_id" value=""/>
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <tbody>
 <tr><td>

--- a/config/suricata/suricata_passlist_edit.php
+++ b/config/suricata/suricata_passlist_edit.php
@@ -199,10 +199,6 @@ include_once("head.inc");
 
 <?php
 include("fbegin.inc");
-if ($input_errors)
-	print_input_errors($input_errors);
-if ($savemsg)
-	print_info_box($savemsg);
 ?>
 <script type="text/javascript" src="/javascript/autosuggest.js">
 </script>
@@ -210,6 +206,14 @@ if ($savemsg)
 </script>
 <form action="suricata_passlist_edit.php" method="post" name="iform" id="iform">
 <input name="id" type="hidden" value="<?=$id;?>" />
+
+<?php
+if ($input_errors)
+	print_input_errors($input_errors);
+if ($savemsg)
+	print_info_box($savemsg);
+?>
+
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <tbody>
 <tr><td>

--- a/config/suricata/suricata_post_install.php
+++ b/config/suricata/suricata_post_install.php
@@ -281,8 +281,8 @@ if (empty($config['installedpackages']['suricata']['config'][0]['forcekeepsettin
 conf_mount_ro();
 
 // Update Suricata package version in configuration
-$config['installedpackages']['suricata']['config'][0]['suricata_config_ver'] = "2.1.2";
-write_config("Suricata pkg v2.1.2: post-install configuration saved.");
+$config['installedpackages']['suricata']['config'][0]['suricata_config_ver'] = "2.1.4";
+write_config("Suricata pkg v2.1.4: post-install configuration saved.");
 
 // Done with post-install, so clear flag
 unset($g['suricata_postinstall']);

--- a/config/suricata/suricata_post_install.php
+++ b/config/suricata/suricata_post_install.php
@@ -130,6 +130,29 @@ if ($config['installedpackages']['suricata']['config'][0]['et_iqrisk_enable'] ==
 	install_cron_job("/usr/bin/nice -n20 /usr/local/bin/php -f /usr/local/pkg/suricata/suricata_etiqrisk_update.php", TRUE, 0, "*/6", "*", "*", "*", "root");
 }
 
+/*********************************************************/
+/* START OF BUG FIX CODE                                 */
+/*                                                       */
+/* Remove any Suricata cron tasks that may have been     */
+/* left from a previous uninstall due to a bug that      */
+/* saved edited cron tasks as new ones while still       */
+/* leaving the original task.  Correct cron task         */
+/* entries will be recreated below if saved settings     */
+/* are detected.                                         */
+/*********************************************************/
+$cron_count = 0;
+$suri_pf_table = SURICATA_PF_TABLE;
+while (suricata_cron_job_exists($suri_pf_table, FALSE)) {
+	install_cron_job($suri_pf_table, false);
+	$cron_count++;
+}
+if ($cron_count > 0)
+	log_error(gettext("[Suricata] Removed {$cron_count} duplicate 'remove_blocked_hosts' cron task(s)."));
+
+/*********************************************************/
+/* END OF BUG FIX CODE                                   */
+/*********************************************************/
+
 // remake saved settings if previously flagged
 if ($config['installedpackages']['suricata']['config'][0]['forcekeepsettings'] == 'on') {
 	log_error(gettext("[Suricata] Saved settings detected... rebuilding installation with saved settings..."));

--- a/config/suricata/suricata_rules.php
+++ b/config/suricata/suricata_rules.php
@@ -436,15 +436,6 @@ $pgtitle = gettext("Suricata: Interface {$if_friendly} - Rules: {$currentruleset
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 <?php
 include("fbegin.inc");
-/* Display error or save messages if present */
-if ($input_errors) {
-        print_input_errors($input_errors); // TODO: add checks
-}
-
-if ($savemsg) {
-        print_info_box($savemsg);
-}
-
 ?>
 
 <form action='/suricata/suricata_rules.php' method='post' name='iform' id='iform'>
@@ -456,6 +447,16 @@ if ($savemsg) {
 <?php if (is_subsystem_dirty('suricata_rules')): ?><p>
 <?php print_info_box_np(gettext("A change has been made to a rule state.") . "<br/>" . gettext("Click APPLY when finished to send the changes to the running configuration."));?>
 <?php endif; ?>
+<?php
+/* Display error or save messages if present */
+if ($input_errors) {
+        print_input_errors($input_errors);
+}
+
+if ($savemsg) {
+        print_info_box($savemsg);
+}
+?>
 
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 	<tbody>

--- a/config/suricata/suricata_rulesets.php
+++ b/config/suricata/suricata_rulesets.php
@@ -260,20 +260,22 @@ include_once("head.inc");
 
 <?php
 include("fbegin.inc"); 
+?>
 
+<form action="suricata_rulesets.php" method="post" name="iform" id="iform">
+<input type="hidden" name="id" id="id" value="<?=$id;?>" />
+
+<?php
 /* Display message */
 if ($input_errors) {
-	print_input_errors($input_errors); // TODO: add checks
+	print_input_errors($input_errors);
 }
 
 if ($savemsg) {
 	print_info_box($savemsg);
 }
-
 ?>
 
-<form action="suricata_rulesets.php" method="post" name="iform" id="iform">
-<input type="hidden" name="id" id="id" value="<?=$id;?>" />
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <tbody>
 <tr><td>

--- a/config/suricata/suricata_suppress_edit.php
+++ b/config/suricata/suricata_suppress_edit.php
@@ -143,16 +143,14 @@ include_once("head.inc");
 
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 
-<?php
-include("fbegin.inc");
-if($pfsense_stable == 'yes'){echo '<p class="pgtitle">' . $pgtitle . '</p>';}
-
-if ($input_errors) print_input_errors($input_errors);
-if ($savemsg)
-	print_info_box($savemsg);
-
-?>
+<?php include("fbegin.inc"); ?>
 <form action="/suricata/suricata_suppress_edit.php" name="iform" id="iform" method="post">
+
+<?php
+if ($input_errors) print_input_errors($input_errors);
+if ($savemsg) print_info_box($savemsg);
+?>
+
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <tr><td>
 <?php

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1436,7 +1436,7 @@
 		<website>http://suricata-ids.org/</website>
 		<descr><![CDATA[High Performance Network IDS, IPS and Security Monitoring engine by OISF.]]></descr>
 		<category>Security</category>
-		<version>2.0.6 pkg v2.1.3</version>
+		<version>2.0.6 pkg v2.1.4</version>
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/suricata/suricata.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1894,7 +1894,7 @@
 		<website>http://suricata-ids.org/</website>
 		<descr><![CDATA[High Performance Network IDS, IPS and Security Monitoring engine by OISF.]]></descr>
 		<category>Security</category>
-		<version>2.0.4 pkg v2.1.3</version>
+		<version>2.0.4 pkg v2.1.4</version>
 		<status>Stable</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/suricata/suricata.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1881,7 +1881,7 @@
 		<website>http://suricata-ids.org/</website>
 		<descr><![CDATA[High Performance Network IDS, IPS and Security Monitoring engine by OISF.]]></descr>
 		<category>Security</category>
-		<version>2.0.4 pkg v2.1.3</version>
+		<version>2.0.4 pkg v2.1.4</version>
 		<status>Stable</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/suricata/suricata.xml</config_file>


### PR DESCRIPTION
Suricata 2.0.6 pkg v2.1.4
===================
This update for the Suricata package fixes three user-reported bugs.

Bug Fixes
-------------
1. On the INTERFACE SETTINGS tab, when EVE JSON output to syslog is enabled, then 'send alerts to system log' must also be auto-enabled in order for syslog output to be properly initialized.

2. Multiple cron task entries are generated when editing "rules update" and "remove blocked hosts" intervals.

3. In rare instances, a blank network and subnet string returned for an interface results in an invalid slash "/" character in a PASS LIST.