### PR TITLE
Respect SMTP notifications disable in mail reports

### DIFF
--- a/config/mailreport/mail_reports.inc
+++ b/config/mailreport/mail_reports.inc
@@ -185,12 +185,18 @@ function set_mail_report_cron_jobs($a_mailreports) {
 	}
 }
 
-include('phpmailer/PHPMailerAutoload.php');
+include('phpmailer/class.phpmailer.php');
 
 function mail_report_send($headertext, $cmdtext, $logtext, $attachments) {
 	global $config, $g;
 
+	if (isset($config['notifications']['smtp']['disable']))
+		return;
+
 	if (empty($config['notifications']['smtp']['ipaddress']))
+		return;
+
+	if (empty($config['notifications']['smtp']['notifyemailaddress']))
 		return;
 
 	$mail = new PHPMailer();


### PR DESCRIPTION
At the moment, mail reports package sends email even if "Disable SMTP Notifications" is checked.
Add the equivalent checks in mail_reports.inc mail_report_send() as are in notices.inc notify_via_smtp() and send_smtp_message()
That will make it respect the System:Advanced:Notifications settings in the same way.