### PR TITLE
Zabbix - New Packages

### DIFF
--- a/config/zabbix-lts/zabbix-agent-lts.xml
+++ b/config/zabbix-lts/zabbix-agent-lts.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packagegui>
+<copyright>
+	<![CDATA[
+/* $Id$ */
+/* ========================================================================== */
+/*
+    zabbix-agent-lts.xml
+    part of the Zabbix package for pfSense
+    Copyright (C) 2013 Danilo G. Baio
+    Copyright (C) 2013 Marcello Coutinho
+	
+    All rights reserved.            
+			                                                                  */
+/* ========================================================================== */
+/*
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+                                                                              */
+/* ========================================================================== */
+	]]>
+	</copyright>
+	<name>zabbixagentlts</name>
+	<title>Services: Zabbix Agent LTS</title>
+	<category>Monitoring</category>
+	<version>0.8.3</version>
+	<include_file>/usr/local/pkg/zabbix-lts.inc</include_file>
+	<addedit_string>Zabbix Agent LTS has been created/modified.</addedit_string>
+	<delete_string>Zabbix Agent LTS has been deleted.</delete_string>
+	<restart_command>/usr/local/etc/rc.d/zabbix_agentd_lts.sh restart</restart_command>
+	<additional_files_needed>
+		<item>https://packages.pfsense.org/packages/config/zabbix-lts/zabbix-lts.inc</item>
+		<prefix>/usr/local/pkg/</prefix>
+		<chmod>0755</chmod>
+	</additional_files_needed>
+	<menu>
+		<name>Zabbix Agent LTS</name>
+		<tooltiptext>Setup Zabbix Agent specific settings</tooltiptext>
+		<section>Services</section>
+		<url>/pkg_edit.php?xml=zabbix-agent-lts.xml&amp;id=0</url>
+	</menu>
+	<service>
+		<name>zabbix_agentd_lts</name>
+		<rcfile>zabbix_agentd_lts.sh</rcfile>
+		<executable>zabbix_agentd</executable>
+		<description>Zabbix Agent LTS host monitor daemon</description>
+	</service>
+	<tabs>
+		<tab>
+			<text>Agent</text>
+			<url>/pkg_edit.php?xml=zabbix-agent-lts.xml&amp;id=0</url>
+			<active />
+		</tab>
+	</tabs>
+	<fields>
+		<field>
+			<name>Zabbix Agent LTS Settings</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Enable</fielddescr>
+			<fieldname>agentenabled</fieldname>
+			<description>Enable Zabbix Agent LTS service</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Server</fielddescr>
+			<fieldname>server</fieldname>
+			<description>List of comma delimited IP addresses (or hostnames) of ZABBIX servers</description>
+			<type>input</type>
+			<size>60</size>
+		</field>
+		<field>
+			<fielddescr>Server Active</fielddescr>
+			<fieldname>serveractive</fieldname>
+			<description>List of comma delimited IP:port (or hostname:port) pairs of Zabbix servers for active checks</description>
+			<type>input</type>
+			<size>60</size>
+		</field>
+		<field>
+			<fielddescr>Hostname</fielddescr>
+			<fieldname>hostname</fieldname>
+			<description>Unique hostname. Required for active checks and must match hostname as configured on the Zabbix server (case sensitive).</description>
+			<type>input</type>
+			<size>60</size>
+		</field>
+		<field>
+			<fielddescr>Listen IP</fielddescr>
+			<fieldname>listenip</fieldname>
+			<default_value>0.0.0.0</default_value>
+			<type>input</type>
+			<size>60</size>
+			<description>Listen IP for connections from the server (default 0.0.0.0 for all interfaces)</description>
+		</field>
+		<field>
+			<fielddescr>Listen Port</fielddescr>
+			<fieldname>listenport</fieldname>
+			<default_value>10050</default_value>
+			<type>input</type>
+			<size>5</size>
+			<description>Listen port for connections from the server (default 10050)</description>
+		</field>
+		<field>
+			<fielddescr>Refresh Active Checks</fielddescr>
+			<fieldname>refreshactchecks</fieldname>
+			<default_value>120</default_value>
+			<type>input</type>
+			<size>5</size>
+			<description>The agent will refresh list of active checks once per 120 (default) seconds.</description>
+		</field>
+		<field>
+			<fielddescr>Timeout</fielddescr>
+			<fieldname>timeout</fieldname>
+			<default_value>3</default_value>
+			<type>input</type>
+			<size>5</size>
+			<description>Timeout (default 3). Do not spend more that Timeout seconds on getting requested value (1-30). The agent does not kill timeouted User Parameters processes!</description>
+		</field>
+		<field>
+			<fielddescr>Buffer Send</fielddescr>
+			<fieldname>buffersend</fieldname>
+			<default_value>5</default_value>
+			<type>input</type>
+			<size>5</size>
+			<description>Buffer Send (default 5). Do not keep data longer than N seconds in buffer (1-3600).</description>
+		</field>
+		<field>
+			<fielddescr>Buffer Size</fielddescr>
+			<fieldname>buffersize</fieldname>
+			<default_value>100</default_value>
+			<type>input</type>
+			<size>5</size>
+			<description>Buffer Size (default 100). Maximum number of values in a memory buffer (2-65535). The agent will send all collected data to Zabbix server or proxy if the buffer is full.</description>
+		</field>
+		<field>
+			<fielddescr>Start Agents</fielddescr>
+			<fieldname>startagents</fieldname>
+			<default_value>3</default_value>
+			<type>input</type>
+			<size>5</size>
+			<description>Start Agents (default 3). Number of pre-forked instances of zabbix_agentd that process passive checks (0-100).If set to 0, disables passive checks and the agent will not listen on any TCP port.</description>
+		</field>
+		<field>
+			<fielddescr>User Parameters</fielddescr>
+			<fieldname>userparams</fieldname>
+			<encoding>base64</encoding>
+			<type>textarea</type>
+			<rows>5</rows>
+			<cols>50</cols>
+			<description>User-defined parameter to monitor. There can be several user-defined parameters. Value has form, example: UserParameter=users,who|wc -l</description>
+		</field>
+	</fields>
+	<custom_php_install_command>sync_package_zabbix_lts();</custom_php_install_command>
+	<custom_php_command_before_form></custom_php_command_before_form>
+	<custom_php_after_head_command></custom_php_after_head_command>
+	<custom_php_after_form_command></custom_php_after_form_command>
+	<custom_php_validation_command>validate_input_zabbix_lts($_POST, $input_errors);</custom_php_validation_command>
+	<custom_add_php_command></custom_add_php_command>
+	<custom_php_resync_config_command>sync_package_zabbix_lts();</custom_php_resync_config_command>
+	<custom_php_deinstall_command>php_deinstall_zabbix_agent_lts();</custom_php_deinstall_command>
+</packagegui>

--- a/config/zabbix-lts/zabbix-lts.inc
+++ b/config/zabbix-lts/zabbix-lts.inc
@@ -47,7 +47,7 @@ function php_deinstall_zabbix_agent_lts(){
 
    conf_mount_rw();
 
-   define('ZABBIX_AGENT_BASE', '/usr/pbi/zabbix-agent-lts-' . php_uname("m"));
+   define('ZABBIX_AGENT_BASE', '/usr/pbi/zabbix22-agent-' . php_uname("m"));
 
    exec("/usr/bin/killall zabbix_agentd");
    unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/rc.d/zabbix_agentd_lts.sh");
@@ -70,7 +70,7 @@ function php_deinstall_zabbix_proxy_lts(){
 
    conf_mount_rw();
 
-   define('ZABBIX_PROXY_BASE', '/usr/pbi/zabbix-proxy-lts-' . php_uname("m"));
+   define('ZABBIX_PROXY_BASE', '/usr/pbi/zabbix22-proxy-' . php_uname("m"));
 
    exec("/usr/bin/killall zabbix_proxy");
    unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/rc.d/zabbix_proxy_lts.sh");
@@ -170,8 +170,8 @@ function sync_package_zabbix_lts(){
 
 	conf_mount_rw();
 
-	define('ZABBIX_AGENT_BASE', '/usr/pbi/zabbix-agent-lts-' . php_uname("m"));
-	define('ZABBIX_PROXY_BASE', '/usr/pbi/zabbix-proxy-lts-' . php_uname("m"));
+	define('ZABBIX_AGENT_BASE', '/usr/pbi/zabbix22-agent-' . php_uname("m"));
+	define('ZABBIX_PROXY_BASE', '/usr/pbi/zabbix22-proxy-' . php_uname("m"));
 
 	#check zabbix proxy config
 	if (is_array($config['installedpackages']['zabbixproxylts'])){

--- a/config/zabbix-lts/zabbix-lts.inc
+++ b/config/zabbix-lts/zabbix-lts.inc
@@ -1,0 +1,360 @@
+<?php
+/* $Id$ */
+/* ========================================================================== */
+/*
+    zabbix-lts.inc
+    part of the Zabbix package for pfSense
+    Copyright (C) 2013 Danilo G. Baio
+    Copyright (C) 2013 Marcello Coutinho
+
+    All rights reserved.            
+			                                                                  */
+/* ========================================================================== */
+/*
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+                                                                              */
+/* ========================================================================== */
+require_once("util.inc");
+require_once("functions.inc");
+require_once("pkg-utils.inc");
+require_once("globals.inc");
+
+function php_install_zabbix_lts(){
+	sync_package_zabbix_lts();	
+}
+
+function php_deinstall_zabbix_agent_lts(){
+   global $config, $g;
+
+   conf_mount_rw();
+
+   define('ZABBIX_AGENT_BASE', '/usr/pbi/zabbix-agent-lts-' . php_uname("m"));
+
+   exec("/usr/bin/killall zabbix_agentd");
+   unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/rc.d/zabbix_agentd_lts.sh");
+   unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/zabbix22/zabbix_agentd.conf");
+   unlink_if_exists("/var/log/zabbix-lts/zabbix_agentd_lts.log");
+   unlink_if_exists("/var/run/zabbix-lts/zabbix_agentd_lts.pid");
+
+   if (!is_array($config['installedpackages']['zabbixproxylts'])){
+      if (is_dir("/var/log/zabbix-lts"))
+         exec("/bin/rm -r /var/log/zabbix-lts/");
+      if (is_dir("/var/run/zabbix-lts"))
+         exec("/bin/rm -r /var/run/zabbix-lts/");
+   }
+
+   conf_mount_ro();
+}
+
+function php_deinstall_zabbix_proxy_lts(){
+   global $config, $g;
+
+   conf_mount_rw();
+
+   define('ZABBIX_PROXY_BASE', '/usr/pbi/zabbix-proxy-lts-' . php_uname("m"));
+
+   exec("/usr/bin/killall zabbix_proxy");
+   unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/rc.d/zabbix_proxy_lts.sh");
+   unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/zabbix22/zabbix_proxy.conf");
+   unlink_if_exists("/var/log/zabbix-lts/zabbix_proxy_lts.log");
+   unlink_if_exists("/var/run/zabbix-lts/zabbix_proxy_lts.pid");
+
+   if (!is_array($config['installedpackages']['zabbixagentlts'])){
+      if (is_dir("/var/log/zabbix-lts"))
+         exec("/bin/rm -r /var/log/zabbix-lts/");
+      if (is_dir("/var/run/zabbix-lts"))
+         exec("/bin/rm -r /var/run/zabbix-lts/");
+   }
+
+   if (is_dir("/var/db/zabbix-lts"))
+      exec("/bin/rm -r /var/db/zabbix-lts/");
+
+   conf_mount_ro();
+}
+
+function validate_input_zabbix_lts($post, &$input_errors){
+
+	if  (isset($post['proxyenabled'])){
+		if (!is_numericint($post['serverport'])) {
+      		$input_errors[]='Server Port is not numeric.'.$ServerPort;
+   			}
+	
+		if (!is_numericint($post['configfrequency'])) {
+			$input_errors[]='Config Frequency is not numeric.';
+			}
+		}
+	if  (isset($post['agentenabled'])){
+		if (!preg_match("/\w+/", $post['server'])) {
+			$input_errors[]='Server field is required.';
+			}
+		
+		if (!preg_match("/\w+/", $post['hostname'])) {
+			$input_errors[]='Hostname field is required.';
+			}
+	
+		if ($post['listenip'] != '') {
+			if (!is_ipaddr_configured($post['listenip']) && !preg_match("/(127.0.0.1|0.0.0.0)/",$post['listenip'])) {
+				$input_errors[]='Listen IP is not a configured IP address.';
+			}
+		}
+
+		if ($post['listenport'] != '') {
+			if (!preg_match("/^\d+$/", $post['listenport'])) {
+				$input_errors[]='Listen Port is not numeric.';
+			}	
+		}
+
+		if ($post['refreshactchecks'] != '') {
+			if (!preg_match("/^\d+$/", $post['refreshactchecks'])) {
+				$input_errors[]='Refresh Active Checks is not numeric.';
+			} elseif ( $post['refreshactchecks'] < 60 || $post['refreshactchecks'] > 3600 ) {
+				$input_errors[]='You must enter a valid value for \'Refresh Active Checks\'';
+			}
+		}
+
+		if ($post['timeout'] != '') {
+			if (!is_numericint($post['timeout'])) {
+				$input_errors[]='Timeout is not numeric.';
+			} elseif ( $post['timeout'] < 1 || $post['timeout'] > 30 ) {
+				$input_errors[]='You must enter a valid value for \'Timeout\'';
+			}
+		}
+	
+		if ($post['buffersend'] != '') {
+			if (!is_numericint($post['buffersend'])) {
+				$input_errors[]='Buffer Send is not numeric.';
+			} elseif ( $post['buffersend'] < 1 || $post['buffersend'] > 3600 ) {
+				$input_errors[]='You must enter a valid value for \'Buffer Send\'';
+			}
+		}
+		
+		if ($post['buffersize'] != '') {
+			if (!is_numericint($post['buffersize'])) {
+				$input_errors[]='Bufer Size is not numeric.';
+			} elseif ( $post['buffersize'] < 2 || $post['buffersize'] > 65535 ) {
+				$input_errors[]='You must enter a valid value for \'Buffer Size\'';
+			}
+		}
+		
+		if ($post['startagents'] != '') {
+			if (!is_numericint($post['startagents'])) {
+				$input_errors[]='Start Agents is not numeric.';
+			} elseif ( $post['startagents'] < 0 || $post['startagents'] > 100 ) {
+				$input_errors[]='You must enter a valid value for \'Start Agents\'';
+			}
+		}
+	}	
+}
+
+function sync_package_zabbix_lts(){
+	global $config, $g;
+
+	conf_mount_rw();
+
+	define('ZABBIX_AGENT_BASE', '/usr/pbi/zabbix-agent-lts-' . php_uname("m"));
+	define('ZABBIX_PROXY_BASE', '/usr/pbi/zabbix-proxy-lts-' . php_uname("m"));
+
+	#check zabbix proxy config
+	if (is_array($config['installedpackages']['zabbixproxylts'])){
+		$zbproxy_config = $config['installedpackages']['zabbixproxylts']['config'][0];
+		if ($zbproxy_config['proxyenabled']=="on"){
+			$Mode=(is_numericint($zbproxy_config['proxymode'])?$zbproxy_config['proxymode'] : 0);
+			$AdvancedParams=base64_decode($zbproxy_config['advancedparams']);
+		
+			$zbproxy_conf_file = <<< EOF
+Server={$zbproxy_config['server']}
+ServerPort={$zbproxy_config['serverport']}
+Hostname={$zbproxy_config['hostname']}
+PidFile=/var/run/zabbix-lts/zabbix_proxy_lts.pid
+DBName=/var/db/zabbix-lts/proxy.db
+LogFile=/var/log/zabbix-lts/zabbix_proxy_lts.log
+ConfigFrequency={$zbproxy_config['configfrequency']}
+FpingLocation=/usr/local/sbin/fping
+#there's currently no fping6 (IPv6) dependency in the package, but if there was, the binary would likely also be in /usr/local/sbin
+Fping6Location=/usr/local/sbin/fping6
+ProxyMode={$Mode}
+{$AdvancedParams}
+
+EOF;
+			file_put_contents(ZABBIX_PROXY_BASE . "/etc/zabbix22/zabbix_proxy.conf", strtr($zbproxy_conf_file, array("\r" => "")));
+		}
+	}
+	/* check zabbix agent settings*/
+	if (is_array($config['installedpackages']['zabbixagentlts'])){
+		$zbagent_config = $config['installedpackages']['zabbixagent']['config'][0];
+		if ($zbagent_config['agentenabled']=="on"){
+			$RefreshActChecks=(preg_match("/(\d+)/",$zbagent_config['refreshactchecks'],$matches)? $matches[1] : "120");
+			$BufferSend=(preg_match("/(\d+)/",$zbagent_config['buffersend'],$matches)? $matches[1]  : "5"  );
+			$BufferSize=(preg_match("/(\d+)/",$zbagent_config['buffersize'],$matches)? $matches[1]  : "100");
+			$StartAgents=(preg_match("/(\d+)/",$zbagent_config['startagents'],$matches)? $matches[1] :"3" );
+			$UserParams=base64_decode($zbagent_config['userparams']);
+			$ListenIp=($zbagent_config['listenip'] != ''? $zbagent_config['listenip'] : "0.0.0.0");
+			$ListenPort=($zbagent_config['listenport'] != ''? $zbagent_config['listenport'] : "10050");
+			$TimeOut=($zbagent_config['timeout'] != ''? $zbagent_config['timeout'] : "3");
+	
+			$zbagent_conf_file = <<< EOF
+Server={$zbagent_config['server']}
+ServerActive={$zbagent_config['serveractive']}
+Hostname={$zbagent_config['hostname']}
+ListenIP={$ListenIp}
+ListenPort={$ListenPort}
+RefreshActiveChecks={$RefreshActChecks}
+DebugLevel=3
+PidFile=/var/run/zabbix-lts/zabbix_agentd_lts.pid
+LogFile=/var/log/zabbix-lts/zabbix_agentd_lts.log
+LogFileSize=1
+Timeout={$TimeOut}
+BufferSend={$BufferSend}
+BufferSize={$BufferSize}
+StartAgents={$StartAgents}
+{$UserParams}
+
+EOF;
+		file_put_contents(ZABBIX_AGENT_BASE . "/etc/zabbix22/zabbix_agentd.conf",  strtr($zbagent_conf_file, array("\r" => "")));
+		}
+	}
+	$want_sysctls = array(
+		'kern.ipc.shmall' => '2097152',
+		'kern.ipc.shmmax' => '2147483648',
+		'kern.ipc.semmsl' => '250'
+	);
+	$sysctls = array();
+	#check sysctl file values
+	$sc_file="";
+	if (file_exists("/etc/sysctl.conf")) {
+		$sc = file("/etc/sysctl.conf");
+		foreach ($sc as $line) {
+			list($sysk, $sysv) = explode("=", $line, 2);
+			if (preg_match("/\w/",$line) && !array_key_exists($sysk, $want_sysctls))
+				$sc_file.=$line;
+			}
+	}
+	foreach ($want_sysctls as $ws=> $wv) {
+		$sc_file .= "{$ws}={$wv}\n";
+		exec("/sbin/sysctl {$ws}={$wv}");
+	}
+	file_put_contents("/etc/sysctl.conf", $sc_file);
+
+	#check bootloader values
+	$lt_file="";
+	$want_tunables = array(
+		'kern.ipc.semopm' => '100',
+		'kern.ipc.semmni' => '128',
+		'kern.ipc.semmns' => '32000',
+		'kern.ipc.shmmni' => '4096'
+	);
+	$tunables = array();
+	if (file_exists("/boot/loader.conf")) {
+		$lt = file("/boot/loader.conf");
+		foreach ($lt as $line) {
+			list($tunable, $val) = explode("=", $line, 2);
+			if (preg_match("/\w/",$line) && !array_key_exists($tunable, $want_tunables))
+				$lt_file.=$line;
+		}
+	}
+	foreach ($want_tunables as $wt => $wv) {
+		$lt_file.= "{$wt}={$wv}\n";
+	}
+	file_put_contents("/boot/loader.conf", $lt_file);
+
+	/*check startup script files*/
+	/* create a few directories and ensure the sample files are in place */
+	if (!is_dir(ZABBIX_PROXY_BASE . "/etc/zabbix22"))
+		exec("/bin/mkdir -p " . ZABBIX_PROXY_BASE . "/etc/zabbix22");
+
+	$dir_checks  = <<< EOF
+if [ ! -d /var/log/zabbix-lts ]
+ then
+ /bin/mkdir -p /var/log/zabbix-lts
+ /usr/sbin/chmod 755 /var/log/zabbix-lts
+ fi
+/usr/sbin/chown -R zabbix:zabbix /var/log/zabbix-lts
+
+if [ ! -d /var/run/zabbix-lts ]
+ then
+ /bin/mkdir -p /var/run/zabbix-lts
+ /usr/sbin/chmod 755 /var/run/zabbix-lts
+ fi
+/usr/sbin/chown -R zabbix:zabbix /var/run/zabbix-lts
+
+if [ ! -d /var/db/zabbix-lts ]
+ then
+ /bin/mkdir -p /var/db/zabbix-lts
+ /usr/sbin/chmod 755 /var/db/zabbix-lts
+ fi
+/usr/sbin/chown -R zabbix:zabbix /var/db/zabbix-lts
+
+EOF;
+ 
+	$zproxy_rcfile="/usr/local/etc/rc.d/zabbix_proxy_lts.sh";
+	if (is_array($zbproxy_config) && $zbproxy_config['proxyenabled']=="on"){
+		$zproxy_start= strtr($dir_checks, array("\r" => "")). "\necho \"Starting Zabbix Proxy LTS\"...\n";
+		/* start zabbix proxy */
+		$zproxy_start .= ZABBIX_PROXY_BASE . "/sbin/zabbix_proxy\n";
+	
+		$zproxy_stop  = "echo \"Stopping Zabbix Proxy LTS\"\n";
+		$zproxy_stop .= "/usr/bin/killall zabbix_proxy\n";
+		$zproxy_stop .= "/bin/sleep 5\n";
+
+		/* write out rc.d start/stop file */
+		write_rcfile(array(
+			"file" => "zabbix_proxy_lts.sh",
+			"start" => $zproxy_start,
+			"stop" => $zproxy_stop
+			)
+		);
+		mwexec("{$zproxy_rcfile} restart");
+	}else{
+		if (file_exists($zproxy_rcfile)){
+		mwexec("{$zproxy_rcfile} stop");
+		unlink($zproxy_rcfile);
+		}
+	}
+	
+	$zagent_rcfile="/usr/local/etc/rc.d/zabbix_agentd_lts.sh";
+	if (is_array($zbagent_config) && $zbagent_config['agentenabled']=="on"){
+		$zagent_start .= strtr($dir_checks, array("\r" => "")). "\necho \"Starting Zabbix Agent LTS...\"\n";
+		$zagent_start .= ZABBIX_AGENT_BASE . "/sbin/zabbix_agentd\n";
+	
+		$zagent_stop  = "echo \"Stopping Zabbix Agent LTS...\"\n";
+		$zagent_stop .= "/usr/bin/killall zabbix_agentd\n";
+		$zagent_stop .= "/bin/sleep 5\n";
+	
+		/* write out rc.d start/stop file */
+		write_rcfile(array(
+						"file" => "zabbix_agentd_lts.sh",
+						"start" => "$zagent_start",
+						"stop" => "$zagent_stop"
+				)
+		);
+		mwexec("{$zagent_rcfile} restart");	
+	}else{
+		if (file_exists($zagent_rcfile)){
+		mwexec("{$zagent_rcfile} stop");
+		unlink($zagent_rcfile);
+		}
+	}
+		
+	conf_mount_ro();
+}
+
+?>

--- a/config/zabbix-lts/zabbix-proxy-lts.xml
+++ b/config/zabbix-lts/zabbix-proxy-lts.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packagegui>
+<copyright>
+	<![CDATA[
+/* $Id$ */
+/* ========================================================================== */
+/*
+    zabbix-proxy-lts.xml
+    part of the Zabbix package for pfSense
+    Copyright (C) 2013 Danilo G. Baio
+    Copyright (C) 2013 Marcello Coutinho
+
+    All rights reserved.            
+			                                                                  */
+/* ========================================================================== */
+/*
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+                                                                              */
+/* ========================================================================== */
+	]]>
+	</copyright>
+	<name>zabbixproxylts</name>
+	<title>Services: Zabbix Proxy LTS</title>
+	<category>Monitoring</category>
+	<version>0.8.3</version>
+	<include_file>/usr/local/pkg/zabbix-lts.inc</include_file>
+	<addedit_string>Zabbix Proxy has been created/modified.</addedit_string>
+	<delete_string>Zabbix Proxy has been deleted.</delete_string>
+	<restart_command>/usr/local/etc/rc.d/zabbix_proxy_lts.sh restart</restart_command>
+	<additional_files_needed>
+		<item>https://packages.pfsense.org/packages/config/zabbix-lts/zabbix-lts.inc</item>
+		<prefix>/usr/local/pkg/</prefix>
+		<chmod>0755</chmod>
+	</additional_files_needed>
+	<menu>
+		<name>Zabbix Proxy LTS</name>
+		<tooltiptext>Setup Zabbix Proxy LTS specific settings</tooltiptext>
+		<section>Services</section>
+		<url>/pkg_edit.php?xml=zabbix-proxy-lts.xml&amp;id=0</url>
+	</menu>
+	<service>
+		<name>zabbix_proxy_lts</name>
+		<rcfile>zabbix_proxy_lts.sh</rcfile>
+		<executable>zabbix_proxy</executable>
+		<description>Zabbix Proxy LTS collection daemon</description>
+	</service>
+	<tabs>
+		<tab>
+			<text>Proxy</text>
+			<url>/pkg_edit.php?xml=zabbix-proxy-lts.xml&amp;id=0</url>
+			<active />
+		</tab>
+	</tabs>
+	<fields>
+		<field>
+			<name>Zabbix Proxy LTS Settings</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Enable</fielddescr>
+			<fieldname>proxyenabled</fieldname>
+			<description>Enable Zabbix Proxy LTS service</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Server</fielddescr>
+			<fieldname>server</fieldname>
+			<description>List of comma delimited IP addresses (or hostnames) of ZABBIX servers</description>
+			<default_value>127.0.0.1</default_value>
+			<type>input</type>
+			<size>60</size>
+			<required>true</required>
+		</field>
+		<field>
+         <fielddescr>Server Port</fielddescr>
+         <fieldname>serverport</fieldname>
+         <description>Port of Zabbix trapper on Zabbix server. default value 10051</description>
+         <default_value>10051</default_value>
+         <type>input</type>
+         <size>6</size>
+         <required>true</required>
+		</field>
+		<field>
+			<fielddescr>Hostname</fielddescr>
+			<fieldname>hostname</fieldname>
+			<description>Unique, case-sensitive proxy name. Make sure the proxy name is known to the server</description>
+			<default_value>localhost</default_value>
+			<type>input</type>
+			<size>50</size>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Proxy Mode</fielddescr>
+			<fieldname>proxymode</fieldname>
+			<description>Select Zabbix proxy mode (Active is default)</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>Active</name><value>0</value></option>
+				<option><name>Passive</name><value>1</value></option>
+			</options>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Config Frequency</fielddescr>
+			<fieldname>configfrequency</fieldname>
+			<description>How often the proxy retrieves configuration data from the Zabbix server in seconds. Ignored if the proxy runs in passive mode.</description>
+			<default_value>3600</default_value>
+			<type>input</type>
+			<size>10</size>
+			<required>true</required>
+		</field>
+		<field>
+			<fielddescr>Advanced Parameters</fielddescr>
+			<fieldname>advancedparams</fieldname>
+			<encoding>base64</encoding>
+			<type>textarea</type>
+			<rows>5</rows>
+			<cols>50</cols>
+			<description>Advanced parameters. There are some rarely used parameters that sometimes need to be defined. Value has form, example: StartDiscoverers=10</description>
+		</field>
+	</fields>
+	<custom_php_install_command>sync_package_zabbix_lts();</custom_php_install_command>
+	<custom_php_command_before_form></custom_php_command_before_form>
+	<custom_php_after_head_command></custom_php_after_head_command>
+	<custom_php_after_form_command></custom_php_after_form_command>
+	<custom_php_validation_command>validate_input_zabbix_lts($_POST, $input_errors);</custom_php_validation_command>
+	<custom_add_php_command></custom_add_php_command>
+	<custom_php_resync_config_command>sync_package_zabbix_lts();</custom_php_resync_config_command>
+	<custom_php_deinstall_command>php_deinstall_zabbix_proxy_lts();</custom_php_deinstall_command>
+</packagegui>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1304,7 +1304,10 @@
 	</package>
 	<package>
 		<name>Zabbix Agent LTS</name>
-		<descr>Monitoring agent.</descr>
+		<descr>LTS (Long Term Support) release of Zabbix Monitoring agent. Zabbix LTS releases are supported for 
+		Zabbix customers during five (5) years i.e. 3 years of Full Support (general, critical and security issues) 
+		and 2 additional years of Limited Support (critical and security issues only). Zabbix LTS version release 
+		will result in change of the first version number. More info in http://www.zabbix.com/life_cycle_and_release_policy.php </descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/zabbix-lts/zabbix-agent-lts.xml</config_file>
 		<version>zabbix-agent-lts-2.2.7 pkg v0.8.3</version>
@@ -1320,7 +1323,10 @@
 	</package>
 	<package>
 		<name>Zabbix Proxy LTS</name>
-		<descr>Monitoring agent proxy.</descr>
+		<descr>LTS (Long Term Support) release of Zabbix agent proxy. Zabbix LTS releases are supported for 
+		Zabbix customers during five (5) years i.e. 3 years of Full Support (general, critical and security issues) 
+		and 2 additional years of Limited Support (critical and security issues only). Zabbix LTS version release 
+		will result in change of the first version number. More info in http://www.zabbix.com/life_cycle_and_release_policy.php </descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/zabbix-lts/zabbix-proxy-lts.xml</config_file>
 		<version>zabbix-proxy-lts-2.2.7 pkg v0.8.3</version>
@@ -1337,7 +1343,11 @@
 	</package>
 	<package>
 		<name>Zabbix-2 Agent</name>
-		<descr>Monitoring agent.</descr>
+		<descr>Standard release of Zabbix Monitoring agent. Standard Zabbix releases are supported for 
+		Zabbix customers during six (6) months of Full Support (general, critical and security issues) until 
+		the next Zabbix stable release, plus one (1) additional month of Limited Support (critical and security 
+		issues only). Zabbix Standard version release will result in change of the second version number.
+		More info in http://www.zabbix.com/life_cycle_and_release_policy.php </descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/zabbix2/zabbix2-agent.xml</config_file>
 		<version>zabbix24-agent-2.4.3 pkg v0.8.3</version>
@@ -1353,7 +1363,11 @@
 	</package>
 	<package>
 		<name>Zabbix-2 Proxy</name>
-		<descr>Monitoring agent proxy.</descr>
+		<descr>Standard release of Zabbix agent proxy. Standard Zabbix releases are supported for 
+		Zabbix customers during six (6) months of Full Support (general, critical and security issues) until 
+		the next Zabbix stable release, plus one (1) additional month of Limited Support (critical and security 
+		issues only). Zabbix Standard version release will result in change of the second version number.
+		More info in http://www.zabbix.com/life_cycle_and_release_policy.php </descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/zabbix2/zabbix2-proxy.xml</config_file>
 		<version>zabbix24-proxy-2.4.3 pkg v0.8.3</version>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1303,40 +1303,40 @@
 		<configurationfile>syslog-ng.xml</configurationfile>
 	</package>
 	<package>
-		<name>Zabbix-2.2 Agent</name>
+		<name>Zabbix Agent LTS</name>
 		<descr>Monitoring agent.</descr>
 		<category>Services</category>
-		<config_file>https://packages.pfsense.org/packages/config/zabbix2/zabbix2-agent.xml</config_file>
-		<version>zabbix22-agent-2.2.7 pkg v0.8.3</version>
+		<config_file>https://packages.pfsense.org/packages/config/zabbix-lts/zabbix-agent-lts.xml</config_file>
+		<version>zabbix-agent-lts-2.2.7 pkg v0.8.3</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
-		<configurationfile>zabbix2-agent.xml</configurationfile>
+		<configurationfile>zabbix-agent-lts.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
 		<build_pbi>
-			<custom_name>zabbix22-agent</custom_name>
+			<custom_name>zabbix-agent-lts</custom_name>
 			<port>net-mgmt/zabbix22-agent</port>
 		</build_pbi>
-		<depends_on_package_pbi>zabbix22-agent-2.2.7-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>zabbix-agent-lts-2.2.7-##ARCH##.pbi</depends_on_package_pbi>
 	</package>
 	<package>
-		<name>Zabbix-2.2 Proxy</name>
+		<name>Zabbix Proxy LTS</name>
 		<descr>Monitoring agent proxy.</descr>
 		<category>Services</category>
-		<config_file>https://packages.pfsense.org/packages/config/zabbix2/zabbix2-proxy.xml</config_file>
-		<version>zabbix22-proxy-2.2.7 pkg v0.8.3</version>
+		<config_file>https://packages.pfsense.org/packages/config/zabbix-lts/zabbix-proxy-lts.xml</config_file>
+		<version>zabbix-proxy-lts-2.2.7 pkg v0.8.3</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
-		<configurationfile>zabbix2-proxy.xml</configurationfile>
+		<configurationfile>zabbix-proxy-lts.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
 		<build_pbi>
-			<custom_name>zabbix22-proxy</custom_name>
+			<custom_name>zabbix-proxy-lts</custom_name>
 			<port>net-mgmt/zabbix22-proxy</port>
 		</build_pbi>
 		<build_options>OPTIONS_SET+= SQLITE IPV6;OPTIONS_UNSET+= MYSQL JABBER GSSAPI</build_options>
-		<depends_on_package_pbi>zabbix22-proxy-2.2.7-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>zabbix-proxy-lts-2.2.7-##ARCH##.pbi</depends_on_package_pbi>
 	</package>
 	<package>
-		<name>Zabbix-2.4 Agent</name>
+		<name>Zabbix-2 Agent</name>
 		<descr>Monitoring agent.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/zabbix2/zabbix2-agent.xml</config_file>
@@ -1352,7 +1352,7 @@
 		<depends_on_package_pbi>zabbix24-agent-2.4.3-##ARCH##.pbi</depends_on_package_pbi>
 	</package>
 	<package>
-		<name>Zabbix-2.4 Proxy</name>
+		<name>Zabbix-2 Proxy</name>
 		<descr>Monitoring agent proxy.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/zabbix2/zabbix2-proxy.xml</config_file>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1319,7 +1319,7 @@
 			<custom_name>zabbix-agent-lts</custom_name>
 			<port>net-mgmt/zabbix22-agent</port>
 		</build_pbi>
-		<depends_on_package_pbi>zabbix-agent-lts-2.2.7-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>zabbix22-agent-2.2.7-##ARCH##.pbi</depends_on_package_pbi>
 	</package>
 	<package>
 		<name>Zabbix Proxy LTS</name>
@@ -1339,7 +1339,7 @@
 			<port>net-mgmt/zabbix22-proxy</port>
 		</build_pbi>
 		<build_options>OPTIONS_SET+= SQLITE IPV6;OPTIONS_UNSET+= MYSQL JABBER GSSAPI</build_options>
-		<depends_on_package_pbi>zabbix-proxy-lts-2.2.7-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>zabbix22-proxy-2.2.7-##ARCH##.pbi</depends_on_package_pbi>
 	</package>
 	<package>
 		<name>Zabbix-2 Agent</name>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1316,7 +1316,7 @@
 		<configurationfile>zabbix-agent-lts.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
 		<build_pbi>
-			<custom_name>zabbix-agent-lts</custom_name>
+			<custom_name>zabbix22-agent</custom_name>
 			<port>net-mgmt/zabbix22-agent</port>
 		</build_pbi>
 		<depends_on_package_pbi>zabbix22-agent-2.2.7-##ARCH##.pbi</depends_on_package_pbi>
@@ -1335,7 +1335,7 @@
 		<configurationfile>zabbix-proxy-lts.xml</configurationfile>
 		<maintainer>dbaio@bsd.com.br</maintainer>
 		<build_pbi>
-			<custom_name>zabbix-proxy-lts</custom_name>
+			<custom_name>zabbix22-proxy</custom_name>
 			<port>net-mgmt/zabbix22-proxy</port>
 		</build_pbi>
 		<build_options>OPTIONS_SET+= SQLITE IPV6;OPTIONS_UNSET+= MYSQL JABBER GSSAPI</build_options>


### PR DESCRIPTION
The ideia is keep the packages as they were before and create new ones "Zabbix Agent LTS" and "Zabbix Proxy LTS" with another path of config files.

Proposed:
- Rename packages back.
- Alter package description informing the difference between standard releases and LTS releases.
- Create structure for new packages (LTS) and take out lines of code for keeping compatibility with earlier pfSense versions.