### PR TITLE
vhost: Corrected PHP bin-path for  SSL configuration

### DIFF
--- a/config/vhosts/vhosts.inc
+++ b/config/vhosts/vhosts.inc
@@ -659,7 +659,7 @@ function vhosts_sync_package_php()
 					$tmp .= "				\"PHP_FCGI_MAX_REQUESTS\" => \"500\",\n";
 					$tmp .= "				\"PHP_FCGI_CHILDREN\" => \"1\"\n";
 					$tmp .= "			),\n";
-					$tmp .= "			\"bin-path\" => \"/usr/local/php5/php-cgi\"\n";
+					$tmp .= "			\"bin-path\" => \"/usr/local/bin/php\"\n";
 					$tmp .= "		)\n";
 					$tmp .= "	)\n";
 					$tmp .= ")\n";


### PR DESCRIPTION
"bin-path" should be "/usr/local/bin/php"
(same as 7232161e99d60256c1a4ee94ef800f6d4f39764 )