### PR TITLE
vhost: Added ['custom_php_service_status_command']

### DIFF
--- a/config/vhosts/vhosts.inc
+++ b/config/vhosts/vhosts.inc
@@ -681,11 +681,11 @@ function vhosts_sync_package_php()
 					);
 
 					//add or update a service
-						$a_service   = &$config['installedpackages']['service'];
 						$ent['name'] = "vhosts-ssl-$x";
 						$ent['rcfile'] = "vhosts-".$ipaddress."-".$port."-ssl.sh";
 						$ent['executable'] = "vhosts-".$ipaddress."-".$port."-ssl";
 						$ent['description'] = "vHosts SSL, Host: $host, IP Address: ".$ipaddress.", port: ".$port." desc: ".$description;
+						$ent['custom_php_service_status_command'] = "\$vhost_output=''; exec('/bin/pgrep -anf '.".escapeshellarg($ent['executable']).", \$vhost_output, \$retval); \$rc=(intval(\$retval) == 0);";
 						$a_service   = $config['installedpackages']['service'];
 						$service_id = get_service_id ($a_service, 'name', "vhosts-ssl-$x");
 						if (is_int($service_id)) {


### PR DESCRIPTION
Added code to check if the process is running for any vhost lighthttpd configuration.
In this way it's possible to show the service status on each vhost.