### PR TITLE
Validate widget_snort_display_lines

### DIFF
--- a/config/snort/snort_alerts.widget.php
+++ b/config/snort/snort_alerts.widget.php
@@ -46,7 +46,7 @@ $alertColClass = "listMRr";
 
 /* check if Snort widget alert display lines value is set */
 $snort_nentries = $config['widgets']['widget_snort_display_lines'];
-if (!isset($snort_nentries) || $snort_nentries < 0)
+if (!isset($snort_nentries) || $snort_nentries <= 0)
 	$snort_nentries = 5;
 
 /* array sorting of the alerts */
@@ -95,7 +95,11 @@ if (isset($_GET['getNewAlerts'])) {
 
 // See if saving new display line count value
 if(isset($_POST['widget_snort_display_lines'])) {
-	$config['widgets']['widget_snort_display_lines'] = $_POST['widget_snort_display_lines'];
+	if($_POST['widget_snort_display_lines'] == "") {
+		unset($config['widgets']['widget_snort_display_lines']);
+	} else {
+		$config['widgets']['widget_snort_display_lines'] = max(intval($_POST['widget_snort_display_lines']), 1);
+	}
 	write_config("Saved Snort Alerts Widget Displayed Lines Parameter via Dashboard");
 	header("Location: ../../index.php");
 }


### PR DESCRIPTION
Currently if you open the snort widget settings and just press "save" with a blank field, it sets the parameter to blank. Subsequently that causes problems trying to fetch the last "" number of alerts, and actually the little "tool" icon never reappears, so you cannot fix it from the dashboard.
1) Setting the number of entries to 0 seems silly, so limit it to a minimum of 1 alert.
2) If the user blanks the box, then unset widget_snort_display_lines to make sure things will always revert to the default.
3) Whatever else the user types in - "abc", "-999", "23xyz99" - try to interpret it as an int (with intval()), then do not let it be less than 1 (not negative or zero).
This forum entry made me touch it and "break" my widget also: https://forum.pfsense.org/index.php?topic=89161.0