### PR TITLE
General freeradius2 cleanup and fix for #4346

### DIFF
--- a/config/freeradius2/freeradius.inc
+++ b/config/freeradius2/freeradius.inc
@@ -76,6 +76,7 @@ if ($pfs_version == "2.2") {
 	}
 	
 function freeradius_deinstall_command() {
+	exec("killall -9 radiusd");
 	return;
 }
 

--- a/config/freeradius2/freeradius.inc
+++ b/config/freeradius2/freeradius.inc
@@ -76,7 +76,15 @@ if ($pfs_version == "2.2") {
 	}
 	
 function freeradius_deinstall_command() {
-	exec("killall -9 radiusd");
+	$pidFile = "/var/run/radiusd.pid";
+	$i = 0;
+
+	while (isvalidpid($pidFile) && $i < 3) {
+		$sig = ($i == 2 ? SIGKILL : SIGTERM);
+		sigkillbypid($pidFile, $sig);
+		sleep(1);
+		$i++;
+	}
 	return;
 }
 

--- a/config/freeradius2/freeradius.xml
+++ b/config/freeradius2/freeradius.xml
@@ -45,7 +45,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradius</name>
-	<version>1.6.12</version>
+	<version>1.6.13</version>
 	<title>FreeRADIUS: Users</title>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>
 	<menu>
@@ -472,6 +472,8 @@
 		freeradius_users_resync();
 	</custom_delete_php_command>
 	<custom_php_resync_config_command>
+		freeradius_settings_resync();
+		sleep(1);
 		freeradius_users_resync();
 	</custom_php_resync_config_command>
 	<custom_php_install_command>

--- a/config/freeradius2/freeradius_view_config.php
+++ b/config/freeradius2/freeradius_view_config.php
@@ -100,8 +100,8 @@ else{
 		display_top_tabs($tab_array);
 	?>
 			</td></tr>
-	 		<tr>
-	    		<td>
+			<tr>
+				<td>
 					<div id="mainarea">
 						<table class="tabcont" width="100%" border="0" cellpadding="8" cellspacing="0">
 						<tr><td></td></tr>
@@ -126,8 +126,8 @@ else{
 							</td>
 								</tr>
 								<tr>
-	     						<td class="tabcont" >
-	     						<div id="file_div"></div>
+								<td class="tabcont" >
+								<div id="file_div"></div>
 									
 								</td>
 							</tr>

--- a/config/freeradius2/freeradiusauthorizedmacs.xml
+++ b/config/freeradius2/freeradiusauthorizedmacs.xml
@@ -101,61 +101,6 @@
 			<url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
 		</tab>
 	</tabs>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradius.inc</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/www/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradius_view_config.php</item>
-	</additional_files_needed>	
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiusclients.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiussettings.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiuseapconf.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiussqlconf.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiusinterfaces.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiuscerts.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiussync.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiusmodulesldap.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiusauthorizedmacs.xml</item>
-	</additional_files_needed>
 	<adddeleteeditpagefields>
 		<columnitem>
 			<fielddescr>MAC Address</fielddescr>

--- a/config/freeradius2/freeradiusauthorizedmacs.xml
+++ b/config/freeradius2/freeradiusauthorizedmacs.xml
@@ -54,13 +54,6 @@
 		<section>Services</section>
 		<url>/pkg.php?xml=freeradiusauthorizedmacs.xml</url>
 	</menu>
-	<service>
-		<name>radiusd</name>
-		<rcfile>radiusd.sh</rcfile>
-		<executable>radiusd</executable>
-		<description><![CDATA[FreeRADIUS Server]]></description>
-	</service>
-
 	<tabs>
 		<tab>
 			<text>Users</text>

--- a/config/freeradius2/freeradiusauthorizedmacs.xml
+++ b/config/freeradius2/freeradiusauthorizedmacs.xml
@@ -45,7 +45,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiusauthorizedmacs</name>
-	<version>2.1.12</version>
+	<version>2.2.0</version>
 	<title>FreeRADIUS: MACs</title>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>
 	<menu>

--- a/config/freeradius2/freeradiuscerts.xml
+++ b/config/freeradius2/freeradiuscerts.xml
@@ -45,7 +45,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiuscerts</name>
-	<version>none</version>
+	<version>2.2.0</version>
 	<title>FreeRADIUS: Certificates</title>
 	<aftersaveredirect>pkg_edit.php?xml=freeradiuscerts.xml&amp;id=0</aftersaveredirect>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>

--- a/config/freeradius2/freeradiusclients.xml
+++ b/config/freeradius2/freeradiusclients.xml
@@ -45,7 +45,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiusclients</name>
-	<version>none</version>
+	<version>2.2.0</version>
 	<title>FreeRADIUS: Clients</title>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>
 	<tabs>

--- a/config/freeradius2/freeradiuseapconf.xml
+++ b/config/freeradius2/freeradiuseapconf.xml
@@ -46,7 +46,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiuseapconf</name>
-	<version>none</version>
+	<version>2.2.0</version>
 	<title>FreeRADIUS: EAP</title>
 	<aftersaveredirect>pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</aftersaveredirect>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>

--- a/config/freeradius2/freeradiusinterfaces.xml
+++ b/config/freeradius2/freeradiusinterfaces.xml
@@ -45,7 +45,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiusinterfaces</name>
-	<version>none</version>
+	<version>2.2.0</version>
 	<title>FreeRADIUS: Interfaces</title>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>
 	<tabs>

--- a/config/freeradius2/freeradiussync.xml
+++ b/config/freeradius2/freeradiussync.xml
@@ -56,12 +56,6 @@ POSSIBILITY OF SUCH DAMAGE.
 		<section>Services</section>
 		<url>/pkg.php?xml=freeradiussync.xml</url>
 	</menu>
-	<service>
-		<name>FreeRADIUS</name>
-		<rcfile>radiusd.sh</rcfile>
-		<executable>radiusd</executable>
-		<description><![CDATA[The FreeRADIUS daemon.]]></description>
-	</service>
 	<tabs>
 		<tab>
 			<text>Users</text>

--- a/config/open-vm-tools_2/open-vm-tools.inc
+++ b/config/open-vm-tools_2/open-vm-tools.inc
@@ -17,10 +17,13 @@ function open_vm_tools_install() {
 	unlink_if_exists("/boot/kernel/vmxnet.ko");
 
 	$pfs_version=substr(trim(file_get_contents("/etc/version")),0,3);
-	if ($pfs_version == "2.1" || $pfs_version == "2.2")
+	if ($pfs_version == "2.1") {
+		$openvmtools_path = "/usr/pbi/open-vm-tools-nox11-" . php_uname("m");
+	} else if ($pfs_version == "2.2") {
 		$openvmtools_path = "/usr/pbi/open-vm-tools-" . php_uname("m");
-	else
+	} else {
 		$openvmtools_path = "/usr/local";
+	}
 	
 	// won't copy this either for now, some sequences of loading/unloading of the module will kernel panic. 
 	//exec("cp $openvmtools_path/local/lib/vmware-tools/modules/drivers/vmmemctl.ko /boot/kernel/");

--- a/config/open-vm-tools_2/open-vm-tools.inc
+++ b/config/open-vm-tools_2/open-vm-tools.inc
@@ -20,7 +20,7 @@ function open_vm_tools_install() {
 	if ($pfs_version == "2.1") {
 		$openvmtools_path = "/usr/pbi/open-vm-tools-nox11-" . php_uname("m");
 	} else if ($pfs_version == "2.2") {
-		$openvmtools_path = "/usr/pbi/open-vm-tools-" . php_uname("m");
+		$openvmtools_path = "/usr/pbi/open-vm-tools-" . php_uname("m") . "/local";
 	} else {
 		$openvmtools_path = "/usr/local";
 	}
@@ -63,7 +63,7 @@ unset start_cmd
 stop_precmd="\${checkvm_cmd}"
 unset stop_cmd
 command="/usr/local/bin/vmtoolsd"
-command_args="-c {$openvmtools_path}/share/vmware-tools/tools.conf -p {$openvmtools_path}/local/lib/open-vm-tools/plugins/vmsvc"
+command_args="-c {$openvmtools_path}/share/vmware-tools/tools.conf -p {$openvmtools_path}/lib/open-vm-tools/plugins/vmsvc"
 pidfile="/var/run/\${name}.pid"
 
 load_rc_config \$name
@@ -131,10 +131,10 @@ EOF;
 	fclose($fd);
 	*/
 	
-	$fd = fopen("$openvmtools_path/local/share/vmware-tools/tools.conf", "w");
+	$fd = fopen("$openvmtools_path/share/vmware-tools/tools.conf", "w");
 	if (!$fd) {
-		log_error("Could not open $openvmtools_path/local/share/vmware-tools/tools.conf for writing");
-		die("Could not open $openvmtools_path/local/share/vmware-tools/tools.conf for writing");
+		log_error("Could not open $openvmtools_path/share/vmware-tools/tools.conf for writing");
+		die("Could not open $openvmtools_path/share/vmware-tools/tools.conf for writing");
 	}
 	fwrite($fd, $vmware_tools_conf);
 	fclose($fd);

--- a/config/openbgpd/openbgpd.inc
+++ b/config/openbgpd/openbgpd.inc
@@ -191,6 +191,46 @@ function openbgpd_install_conf() {
 	@chmod("{$bgpd_config_base}/bgpd.conf", 0600);
 	unset($conffile);
 
+	$carp_ip_status_check = "";
+	if (is_ipaddr($openbgpd_conf['carpstatusip'])) {
+
+		$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
+		switch ($pfs_version) {
+			case "2.0":
+			case "2.1":
+				/* Check for 2.1 and before */
+				$carpcheckinterface = trim(find_carp_interface($openbgpd_conf['carpstatusip']));
+				$carp_ip_status_check = <<<EOF
+
+CARP_STATUS=`/sbin/ifconfig {$carpcheckinterface} | /usr/bin/grep carp: | /usr/bin/awk '{print \$2;}'`
+if [ \${CARP_STATUS} != "MASTER" ]; then
+	exit;
+fi
+
+EOF;
+				break;
+			case "2.2":
+			default:
+				/* Check for 2.2 and later */
+				if (is_array($config['virtualip']['vip'])) {
+					foreach ($config['virtualip']['vip'] as $vip) {
+						if (($vip['mode'] == "carp") && ($vip['subnet'] == $openbgpd_conf['carpstatusip'])) {
+							$carpcheckinterface = escapeshellarg(get_real_interface($vip['interface']));
+							$vhid = escapeshellarg($vip['vhid']);
+							$carp_ip_status_check = <<<EOF
+
+CARP_STATUS=`/sbin/ifconfig {$carpcheckinterface} | /usr/bin/grep 'carp:' | /usr/bin/grep 'vhid {$vhid}' | /usr/bin/awk '{print \$2;}'`
+if [ \${CARP_STATUS} != "MASTER" ]; then
+	exit;
+fi
+EOF;
+						}
+					}
+				}
+				break;
+		}
+	}
+
 	// Create rc.d file
 	$rc_file_stop = <<<EOF
 killall -TERM bgpd
@@ -210,6 +250,7 @@ fi
 
 NUMBGPD=`ps auxw | grep -c '[b]gpd.*parent'`
 if [ \${NUMBGPD} -lt 1 ] ; then
+	{$carp_ip_status_check}
 	{$pkg_bin}/bgpd -f {$bgpd_config_base}/bgpd.conf
 else
 	{$pkg_bin}/bgpctl reload
@@ -225,13 +266,36 @@ EOF;
 
 	$_gb = exec("/sbin/sysctl net.inet.ip.ipsec_in_use=1");
 	// bgpd process running?  if so reload, else start.
+
+	// Kick off newly created rc.d script
+	if (is_ipaddr($openbgpd_conf['carpstatusip'])) {
+		$status = openbgpd_get_carp_status_by_ip($openbgpd_conf['carpstatusip']);
+		switch (strtoupper($status)) {
+			// Stop the service if the VIP is in BACKUP or INIT state.
+			case "BACKUP":
+			case "INIT":
+				exec("/usr/local/etc/rc.d/bgpd.sh stop");
+				break;
+			// Start the service if the VIP is MASTER state.
+			case "MASTER":
+			// Assume it's up if the status can't be determined.
+			default:
+				openbgpd_restart();
+				break;
+		}
+	} else {
+		openbgpd_restart();
+	}
+
+	conf_mount_ro();
+}
+
+function openbgpd_restart() {
 	if(is_openbgpd_running() == true) {
 		exec("{$pkg_bin}/bgpctl reload");
 	} else {
 		exec("{$pkg_bin}/bgpd -f {$bgpd_config_base}/bgpd.conf");
 	}
-
-	conf_mount_ro();
 }
 
 // get the raw openbgpd confi file for manual inspection/editing
@@ -360,6 +424,54 @@ function is_openbgpd_running() {
 		return true;
 	else
 		return false;
+}
+
+function openbgpd_get_carp_status_by_ip($ipaddr) {
+	$iface = trim(find_carp_interface($ipaddr));
+	if ($iface) {
+		$status = get_carp_interface_status($iface);
+		// If there is no status for that interface, return null.
+		if (!$status)
+			$status = null;
+	} else {
+		// If there is no VIP by that IP, return null.
+		$status = null;
+	}
+	return $status;
+}
+
+function openbgpd_plugin_carp($pluginparams) {
+	global $config;
+	require_once("service-utils.inc");
+	// Called when a CARP interface changes state
+	// $pluginparams['event'] either 'rc.carpmaster' or 'rc.carpbackup'
+	// $pluginparams['interface'] contains the affected interface
+
+	/* If there is no bgp config, then stop */
+	if(is_array($config['installedpackages']['openbgpd']['config'])) {
+		$openbgpd_conf = &$config['installedpackages']['openbgpd']['config'][0];
+	} else {
+		return null;
+	}
+	/* If there is no properly configured CARP status check IP, then stop */
+	if (!is_ipaddr($openbgpd_conf['carpstatusip'])) {
+		return null;
+	}
+	list($vhid, $iface) = explode("@", trim($pluginparams['interface']));
+	$friendly = convert_real_interface_to_friendly_interface_name($iface);
+	$carp_iface = "{$friendly}_vip${vhid}";
+
+	/* If this CARP transition is not from the IP address to check, then stop. */
+	if (get_interface_ip($carp_iface) != $openbgpd_conf['carpstatusip']) {
+		return null;
+	}
+
+	/* Start or stop the service as needed based on the CARP transition. */
+	if ($pluginparams['event'] == "rc.carpmaster") {
+		start_service("bgpd");
+	} elseif ($pluginparams['event'] == "rc.carpbackup") {
+		stop_service("bgpd");
+	}
 }
 
 ?>

--- a/config/openbgpd/openbgpd.xml
+++ b/config/openbgpd/openbgpd.xml
@@ -105,6 +105,11 @@
 			<url>/openbgpd_status.php</url>
 		</tab>
 	</tabs>
+	<plugins>
+		<item>
+			<type>plugin_carp</type>
+		</item>
+	</plugins>
 	<fields>
 		<field>
 			<fielddescr>Autonomous Systems (AS) Number</fielddescr>
@@ -143,8 +148,13 @@
 			<description>Set the router ID to the given IP address, which must be local to the machine.</description>
 			<type>input</type>
 		</field>
-
-
+		<field>
+			<fielddescr>CARP Status IP</fielddescr>
+			<fieldname>carpstatusip</fieldname>
+			<description>IP address used to determine the CARP status. When the VIP is in BACKUP status, bgpd will not be started. &lt;br/&gt;NOTE: On 2.1.x and before this requires changes to /etc/rc.carpmaster to start bgpd and /etc/rc.carpbackup to stop bgpd or it will not be fully effective. On pfSense 2.2.x and later, full support is automatic.</description>
+			<type>input</type>
+			<size>25</size>
+		</field>
 		<field>
 			<fielddescr>Networks</fielddescr>
 			<fieldname>network</fieldname>

--- a/config/syslog-ng/syslog-ng.inc
+++ b/config/syslog-ng/syslog-ng.inc
@@ -37,7 +37,11 @@ require_once('service-utils.inc');
 if(!function_exists("filter_configure")) 
 	require_once("filter.inc");
 
-define("SYSLOGNG_BASEDIR", "/usr/pbi/syslog-ng-" . php_uname("m") . "/");
+$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
+if ($pf_version == "2.1" || $pf_version == "2.2")
+	define("SYSLOGNG_BASEDIR", "/usr/pbi/syslog-ng-" . php_uname("m") . "/");
+else
+	define("SYSLOGNG_BASEDIR", "/usr/local/");
 
 function syslogng_get_real_interface_address($interface) {
 	$interface = convert_friendly_interface_to_real_interface_name($interface);

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -262,7 +262,7 @@
 			<ports_after>net/avahi-app devel/dbus</ports_after>
 		</build_pbi>
 		<depends_on_package_pbi>avahi-0.6.31-##ARCH##.pbi</depends_on_package_pbi>
-		<version>v1.09</version>
+		<version>1.09</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/avahi/avahi.xml</config_file>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -49,6 +49,7 @@
 		<maintainer>marcellocoutinho@gmail.com robreg@zsurob.hu</maintainer>
 		<configurationfile>asterisk.xml</configurationfile>
 		<after_install_info>Please visit the Asterisk tab on status menu.</after_install_info>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>bind</name>
@@ -69,6 +70,7 @@
 			<port>dns/bind99</port>
 		</build_pbi>
 		<build_options>bind_UNSET_FORCE=IDN REPLACE_BASE FIXED_RRSET GSSAPI LARGE_FILE;bind_SET_FORCE=IPV6 LINKS SSL THREADS XML DLZ_FILESYSTEM FILTER_AAAA SIGCHASE RRL</build_options>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>Filer</name>
@@ -82,6 +84,7 @@
 		<required_version>2.2</required_version>
 		<maintainer>bscholer@cshl.edu</maintainer>
 		<configurationfile>filer.xml</configurationfile>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>Strikeback</name>
@@ -216,6 +219,7 @@
 		</build_pbi>
 		<build_options>apache24_UNSET_FORCE=MPM_PREFORK;apache24_SET_FORCE=MPM_EVENT SLOTMEM_SHM MOST_ENABLED_MODULES MPM_SHARED SESSION_ENABLED_MODULES PROXY_ENABLED_MODULES SESSION_ENABLED_MODULES;mod_security_SET_FORCE=MLOGC</build_options>
 		<after_install_info>Please visit the ProxyServer settings tab and set the service up so that it may be started.</after_install_info>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>Proxy Server with mod_security</name>
@@ -328,6 +332,7 @@
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<configurationfile>tftp.xml</configurationfile>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>PHPService</name>
@@ -421,6 +426,7 @@
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<configurationfile>olsrd.xml</configurationfile>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>routed</name>
@@ -454,6 +460,7 @@
 			<facilityname>spamd</facilityname>
 			<logfilename>spamd.log</logfilename>
 		</logging>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>Postfix Forwarder</name>
@@ -476,6 +483,7 @@
 			<port>mail/postfix</port>
 		</build_pbi>
 		<build_options>postfix_SET_FORCE=PCRE SASL2 SPF TLS</build_options>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>Dansguardian</name>
@@ -523,6 +531,7 @@
 			<ports_after>shells/bash mail/pyzor mail/dcc-dccd security/clamav mail/spamassassin</ports_after>
 		</build_pbi>
 		<build_options>mailscanner_UNSET_FORCE=BDC CLAMAVMODULE;mailscanner_SET_FORCE=SPAMASSASSIN CLAMAV;spamassassin_SET_FORCE=DCC</build_options>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>siproxd</name>
@@ -602,6 +611,7 @@
 		</build_pbi>
 		<build_options>sarg_UNSET_FORCE=PHP</build_options>
 		<after_install_info>Please visit sarg settings on Status Menu to configure sarg.</after_install_info>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>Ipguard-dev</name>
@@ -624,6 +634,7 @@
 			<port>security/ipguard</port>
 		</build_pbi>
 		<after_install_info>Please visit ipguard settings on the Firewall Menu to configure.</after_install_info>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>Varnish3</name>
@@ -647,6 +658,7 @@
 			<ports_after>lang/gcc</ports_after>
 		</build_pbi>
 		<build_options>gcc_UNSET_FORCE=JAVA</build_options>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>vnstat2</name>
@@ -667,6 +679,7 @@
 		<config_file>https://packages.pfsense.org/packages/config/vnstat2/vnstat2.xml</config_file>
 		<configurationfile>vnstat2.xml</configurationfile>
 		<after_install_info></after_install_info>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>dns-server</name>
@@ -687,6 +700,7 @@
 			<port>dns/djbdns</port>
 		</build_pbi>
 		<build_options>ucspi-tcp_SET_FORCE=IPV6;djbdns_SET_FORCE=SRV;djbdns_UNSET_FORCE=DUMPCACHE IGNOREIP JUMBO PERSISTENT_MMAP</build_options>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>Open-VM-Tools</name>
@@ -774,6 +788,7 @@
 		<build_pbi>
 			<port>net-im/imspector</port>
 		</build_pbi>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>nut</name>
@@ -792,6 +807,7 @@
 			<port>sysutils/nut</port>
 		</build_pbi>
 		<pkginfolink>https://doc.pfsense.org/index.php/Nut_package</pkginfolink>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>diag_new_states</name>
@@ -804,6 +820,7 @@
 		<status>BETA</status>
 		<config_file>https://packages.pfsense.org/packages/config/diag_states_pt/diag_new_states.xml</config_file>
 		<configurationfile>https://packages.pfsense.org/packages/config/diag_states_pt/diag_new_states.xml</configurationfile>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>darkstat</name>
@@ -858,6 +875,7 @@
 		<build_pbi>
 			<port>net/widentd</port>
 		</build_pbi>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>freeradius2</name>
@@ -904,6 +922,7 @@
 			<port>net-mgmt/bandwidthd</port>
 		</build_pbi>
 		<build_options>libgd_UNSET_FORCE=FONTCONFIG XPM</build_options>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>stunnel</name>
@@ -923,6 +942,7 @@
 			<port>security/stunnel</port>
 		</build_pbi>
 		<build_options>stunnel_SET_FORCE=PTHREAD LIBWRAP;stunnel_UNSET_FORCE=FORK UCONTEXT IPV6</build_options>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>iperf</name>
@@ -958,6 +978,7 @@
 		<build_pbi>
 			<port>benchmarks/netio</port>
 		</build_pbi>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>mtr-nox11</name>
@@ -1452,7 +1473,6 @@
 		<maintainer>laleger@gmail.com</maintainer>
 		<config_file>https://packages.pfsense.org/packages/config/syslog-ng/syslog-ng.xml</config_file>
 		<configurationfile>syslog-ng.xml</configurationfile>
-		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>Zabbix Agent LTS</name>
@@ -1624,7 +1644,6 @@
 		<pkginfolink></pkginfolink>
 		<required_version>2.2</required_version>
 		<configurationfile>ladvd.xml</configurationfile>
-		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>suricata</name>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -2,7 +2,7 @@
 <!-- pfSense packages -->
 <pfsensepkgs>
 <copy_packages_to_host_ssh_port>22</copy_packages_to_host_ssh_port>
-<copy_packages_to_host_ssh>packagecopy@files.pfsense.org</copy_packages_to_host_ssh>
+<copy_packages_to_host_ssh>packagecopy@files.atx.pfsense.org</copy_packages_to_host_ssh>
 <copy_packages_to_folder_ssh>/usr/local/www/files/packages/10/All/</copy_packages_to_folder_ssh>
 <depends_on_package_base_url>https://files.pfsense.org/packages/10/All/</depends_on_package_base_url>
 <packages>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -553,7 +553,7 @@
 		<build_pbi>
 			<port>net/openbgpd</port>
 		</build_pbi>
-		<version>0.9.3_2</version>
+		<version>0.9.3_3</version>
 		<status>STABLE</status>
 		<pkginfolink>https://doc.pfsense.org/index.php/OpenBGPD_package</pkginfolink>
 		<required_version>2.2</required_version>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -886,7 +886,7 @@
 					On pfSense docs there is a how-to which could help you on porting users.]]></descr>
 		<pkginfolink>https://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
 		<category>System</category>
-		<version>1.6.12</version>
+		<version>1.6.13</version>
 		<status>RC1</status>
 		<required_version>2.2</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1462,10 +1462,12 @@
 		<website>http://www.balabit.com/network-security/syslog-ng/</website>
 		<descr>Syslog-ng syslog server. This service is not intended to replace the default pfSense syslog server but rather acts as an independent syslog server.</descr>
 		<category>Services</category>
-		<version>3.6.2_3 pkg.v.1.0.6</version>
+		<version>1.0.6</version>
 		<status>ALPHA</status>
 		<required_version>2.2</required_version>
 		<depends_on_package_pbi>syslog-ng-3.6.2_3-##ARCH##.pbi</depends_on_package_pbi>
+		<port_category>sysutils</port_category>
+		<run_depends>sbin/syslog-ng:sysutils/syslog-ng</run_depends>
 		<build_pbi>
 			<ports_before>sysutils/logrotate</ports_before>
 			<port>sysutils/syslog-ng</port>
@@ -1638,6 +1640,8 @@
 		<status>BETA</status>
 		<depends_on_package_pbi>ladvd-1.0.4_1-##ARCH##.pbi</depends_on_package_pbi>
 		<config_file>https://packages.pfsense.org/packages/config/ladvd/ladvd.xml</config_file>
+		<port_category>net</port_category>
+		<run_depends>sbin/ladvd:net/ladvd</run_depends>
 		<build_pbi>
 			<port>net/ladvd</port>
 		</build_pbi>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -886,7 +886,7 @@
 					On pfSense docs there is a how-to which could help you on porting users.]]></descr>
 		<pkginfolink>https://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
 		<category>System</category>
-		<version>1.6.13</version>
+		<version>1.6.14</version>
 		<status>RC1</status>
 		<required_version>2.2</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1319,7 +1319,7 @@
 		<name>mailreport</name>
 		<descr>Allows you to setup periodic e-mail reports containing command output, log file contents, and RRD graphs.</descr>
 		<category>Network Management</category>
-		<version>2.3</version>
+		<version>2.3_1</version>
 		<status>Stable</status>
 		<port_category>mail</port_category>
 		<required_version>2.2</required_version>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1041,7 +1041,7 @@
 					On pfSense docs there is a how-to which could help you on porting users.]]></descr>
 		<pkginfolink>https://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
 		<category>System</category>
-		<version>1.6.13</version>
+		<version>1.6.14</version>
 		<status>RC1</status>
 		<required_version>2.1</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1610,7 +1610,7 @@
 		<name>mailreport</name>
 		<descr>Allows you to setup periodic e-mail reports containing command output, log file contents, and RRD graphs.</descr>
 		<category>Network Management</category>
-		<version>2.3</version>
+		<version>2.3_1</version>
 		<status>Stable</status>
 		<required_version>2.0</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/mailreport/mailreport.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1041,7 +1041,7 @@
 					On pfSense docs there is a how-to which could help you on porting users.]]></descr>
 		<pkginfolink>https://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
 		<category>System</category>
-		<version>1.6.12</version>
+		<version>1.6.13</version>
 		<status>RC1</status>
 		<required_version>2.1</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -651,7 +651,7 @@
 		<build_pbi>
 			<port>net/openbgpd</port>
 		</build_pbi>
-		<version>0.9.2</version>
+		<version>0.9.2_1</version>
 		<status>STABLE</status>
 		<pkginfolink>https://doc.pfsense.org/index.php/OpenBGPD_package</pkginfolink>
 		<required_version>1.3</required_version>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1028,7 +1028,7 @@
 					On pfSense docs there is a how-to which could help you on porting users.]]></descr>
 		<pkginfolink>https://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
 		<category>System</category>
-		<version>1.6.13</version>
+		<version>1.6.14</version>
 		<status>RC1</status>
 		<required_version>2.1</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -638,7 +638,7 @@
 		<build_pbi>
 			<port>net/openbgpd</port>
 		</build_pbi>
-		<version>0.9.2</version>
+		<version>0.9.2_1</version>
 		<status>STABLE</status>
 		<pkginfolink>https://doc.pfsense.org/index.php/OpenBGPD_package</pkginfolink>
 		<required_version>1.3</required_version>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1028,7 +1028,7 @@
 					On pfSense docs there is a how-to which could help you on porting users.]]></descr>
 		<pkginfolink>https://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
 		<category>System</category>
-		<version>1.6.12</version>
+		<version>1.6.13</version>
 		<status>RC1</status>
 		<required_version>2.1</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1597,7 +1597,7 @@
 		<name>mailreport</name>
 		<descr>Allows you to setup periodic e-mail reports containing command output, log file contents, and RRD graphs.</descr>
 		<category>Network Management</category>
-		<version>2.3</version>
+		<version>2.3_1</version>
 		<status>Stable</status>
 		<required_version>2.0</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/mailreport/mailreport.xml</config_file>


### PR DESCRIPTION
Removed <service> and <additional_files_needed> from files other than freeradius.xml, since that is the main package config file where these things need to be defined.

Kill radiusd processes during deinstall. RC script fails to stop radiusd process because it calls script from freeradius package and that package is uninstalled before RC script is called. #4346