### PR TITLE
Update apcupsd_mail.php

### DIFF
--- a/config/apcupsd/apcupsd_mail.php
+++ b/config/apcupsd/apcupsd_mail.php
@@ -61,7 +61,7 @@ $mail = new PHPMailer();
 $mail->IsSMTP();
 $mail->Host = $config['notifications']['smtp']['ipaddress'];
 
-if ($config['notifications']['smtp']['ssl'] == "checked")
+if (isset($config['notifications']['smtp']['ssl']))
 	$mail->SMTPSecure =  "ssl";
 
 $mail->Port = empty($config['notifications']['smtp']['port']) ? 25 : $config['notifications']['smtp']['port'];


### PR DESCRIPTION
In Pfsense version 2.2 the variable/key $config['notifications']['smtp']['ssl'] is set with an empty string value when the parameter 'Enable SMTP over SSL/TLS' is checked in the webgui (and the key not exists when the checkbox is off). The check in this file is for the value 'checked', but is not working and ever happening, thats why I modify this to get it work with Gmail.