### PR TITLE
haproxy-1_5, haproxy-devel, pkg v0.22 fix SNI handling inspect-delay 5s instead if 5ms, show 'not' in acls when set

### DIFF
--- a/config/haproxy-devel/pkg/haproxy.inc
+++ b/config/haproxy-devel/pkg/haproxy.inc
@@ -1302,7 +1302,7 @@ function haproxy_writeconf($configpath) {
 			}
 			
 			if ($inspectdelay > 0)
-				fwrite ($fd, "\ttcp-request inspect-delay\t" . $inspectdelay . "\n");
+				fwrite ($fd, "\ttcp-request inspect-delay\t" . $inspectdelay . "s\n");
 				
 			// Write acl's first, so they may be used by advanced text options written by user.
 			fwrite ($fd, $config_acls);
@@ -1897,9 +1897,9 @@ function get_frontend_acls($frontend) {
 			// Filter out acls for different modes
 			if ($acl['mode'] != '' && $acl['mode'] != strtolower($mainfrontend['type']))
 				continue;
-			$not = $entry['not'] == "yes" ? "not " : "";
+			$not = $entry['not'] == "yes" ? "not: " : "";
 			$acl_item = array();
-			$acl_item['descr'] = $acl['name'] . " " . (isset($acl['novalue']) ? "" : $entry['value']);
+			$acl_item['descr'] = $acl['name'] . " " . (isset($acl['novalue']) ? "" : $not . $entry['value']);
 			$acl_item['ref'] = $entry;
 			
 			$result[] = $acl_item;

--- a/config/haproxy1_5/pkg/haproxy.inc
+++ b/config/haproxy1_5/pkg/haproxy.inc
@@ -1302,7 +1302,7 @@ function haproxy_writeconf($configpath) {
 			}
 			
 			if ($inspectdelay > 0)
-				fwrite ($fd, "\ttcp-request inspect-delay\t" . $inspectdelay . "\n");
+				fwrite ($fd, "\ttcp-request inspect-delay\t" . $inspectdelay . "s\n");
 				
 			// Write acl's first, so they may be used by advanced text options written by user.
 			fwrite ($fd, $config_acls);
@@ -1897,9 +1897,9 @@ function get_frontend_acls($frontend) {
 			// Filter out acls for different modes
 			if ($acl['mode'] != '' && $acl['mode'] != strtolower($mainfrontend['type']))
 				continue;
-			$not = $entry['not'] == "yes" ? "not " : "";
+			$not = $entry['not'] == "yes" ? "not: " : "";
 			$acl_item = array();
-			$acl_item['descr'] = $acl['name'] . " " . (isset($acl['novalue']) ? "" : $entry['value']);
+			$acl_item['descr'] = $acl['name'] . " " . (isset($acl['novalue']) ? "" : $not . $entry['value']);
 			$acl_item['ref'] = $entry;
 			
 			$result[] = $acl_item;

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -137,7 +137,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.9 pkg v 0.21</version>
+		<version>1.5.9 pkg v 0.22</version>
 		<status>Release</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy1_5/haproxy.xml</config_file>
@@ -158,7 +158,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.9 pkg v 0.21</version>
+		<version>1.5.9 pkg v 0.22</version>
 		<status>Release</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -166,7 +166,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.21</version>
+		<version>1.5.3 pkg v 0.22</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy1_5/haproxy.xml</config_file>
@@ -190,7 +190,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.21</version>
+		<version>1.5.3 pkg v 0.22</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -153,7 +153,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.21</version>
+		<version>1.5.3 pkg v 0.22</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy1_5/haproxy.xml</config_file>
@@ -177,7 +177,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.21</version>
+		<version>1.5.3 pkg v 0.22</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>


### PR DESCRIPTION
haproxy-1_5, haproxy-devel, pkg v0.22 fix SNI handling inspect-delay 5s instead if 5ms, show 'not' in acls when set