### PR TITLE
Snort 2.9.7.2 pkg v3.2.4

### DIFF
--- a/config/snort/snort.xml
+++ b/config/snort/snort.xml
@@ -46,8 +46,8 @@
 	<requirements>None</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>Snort</name>
-	<version>2.9.7.0</version>
-	<title>Services:2.9.7.0 pkg v3.2.3</title>
+	<version>2.9.7.2</version>
+	<title>Services:2.9.7.2 pkg v3.2.4</title>
 	<include_file>/usr/local/pkg/snort/snort.inc</include_file>
 	<menu>
 		<name>Snort</name>

--- a/config/snort/snort_defs.inc
+++ b/config/snort/snort_defs.inc
@@ -50,7 +50,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 	if (!empty($snortver[0]))
 		define("SNORT_BIN_VERSION", $snortver[0]);
 	else
-		define("SNORT_BIN_VERSION", "2.9.7.0");
+		define("SNORT_BIN_VERSION", "2.9.7.2");
 }
 if (!defined("SNORT_SID_MODS_PATH"))
 	define('SNORT_SID_MODS_PATH', "{$g['vardb_path']}/snort/sidmods/");

--- a/config/snort/snort_generate_conf.php
+++ b/config/snort/snort_generate_conf.php
@@ -895,7 +895,7 @@ EOD;
 
 /* def AppID preprocessor */
 $appid_memcap = $snortcfg['sf_appid_mem_cap'] * 1024 * 1024;
-$appid_params = "app_detector_dir " . SNORT_APPID_ODP_PATH . ", \\\n\tmemcap {$appid_memcap}";
+$appid_params = "app_detector_dir " . rtrim(SNORT_APPID_ODP_PATH, '/') . ", \\\n\tmemcap {$appid_memcap}";
 if ($snortcfg['sf_appid_statslog'] == "on") {
 	$appid_params .= ", \\\n\tapp_stats_filename app-stats.log";
 	$appid_params .= ", \\\n\tapp_stats_period {$snortcfg['sf_appid_stats_period']}";

--- a/config/snort/snort_migrate_config.php
+++ b/config/snort/snort_migrate_config.php
@@ -533,7 +533,7 @@ unset($r);
 
 // Log a message if we changed anything
 if ($updated_cfg) {
-	$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.2.3";
+	$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.2.4";
 	log_error("[Snort] Settings successfully migrated to new configuration format...");
 }
 else

--- a/config/snort/snort_post_install.php
+++ b/config/snort/snort_post_install.php
@@ -263,8 +263,8 @@ if (stristr($config['widgets']['sequence'], "snort_alerts-container") === FALSE)
 	$config['widgets']['sequence'] .= ",{$snort_widget_container}";
 
 /* Update Snort package version in configuration */
-$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.2.3";
-write_config("Snort pkg v3.2.3: post-install configuration saved.");
+$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.2.4";
+write_config("Snort pkg v3.2.4: post-install configuration saved.");
 
 /* Done with post-install, so clear flag */
 unset($g['snort_postinstall']);

--- a/config/snort/snort_rulesets.php
+++ b/config/snort/snort_rulesets.php
@@ -531,7 +531,7 @@ if ($savemsg) {
 				sort($snortrules);
 				$i = count($emergingrules);
 				if ($i < count($snortsorules))
-					$i = count(snortsorules);
+					$i = count($snortsorules);
 				if ($i < count($snortrules))
 					$i = count($snortrules);
 

--- a/config/snort/snort_rulesets.php
+++ b/config/snort/snort_rulesets.php
@@ -452,7 +452,7 @@ if ($savemsg) {
 					<tr>
 						<td width="5%" class="listr" style="text-align: center;">
 						<img src="../themes/<?=$g['theme'];?>/images/icons/icon_advanced.gif" width="11" height="11" border="0" title="<?=gettext("Auto-managed by settings on SID Mgmt tab");?>" /></td>
-						<td colspan="5" class="listr"><a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=gettext("{$msg_community}");?></a></td>
+						<td colspan="5" class="listr"><a href='snort_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?=gettext("{$msg_community}");?></a></td>
 					</tr>
 				<?php else: ?>
 					<tr>
@@ -465,7 +465,7 @@ if ($savemsg) {
 			<tr>
 				<td width="5%" class="listr" style="text-align: center;">
 				<input type="checkbox" name="toenable[]" value="<?=$community_rules_file;?>" checked="checked"/></td>
-				<td colspan="5" class="listr"><a href='suricata_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext("{$msg_community}"); ?></a></td>
+				<td colspan="5" class="listr"><a href='snort_rules.php?id=<?=$id;?>&openruleset=<?=$community_rules_file;?>'><?php echo gettext("{$msg_community}"); ?></a></td>
 			</tr>
 			<?php else: ?>
 			<tr>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -353,14 +353,14 @@
 		<website>http://www.snort.org</website>
 		<descr>Snort is an open source network intrusion prevention and detection system (IDS/IPS). Combining the benefits of signature, protocol, and anomaly-based inspection.</descr>
 		<category>Security</category>
-		<depends_on_package_pbi>snort-2.9.7.0-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>snort-2.9.7.2-##ARCH##.pbi</depends_on_package_pbi>
 		<build_pbi>
 			<port>security/snort</port>
 			<ports_after>security/barnyard2</ports_after>
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET=PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;snort_UNSET=PULLEDPORK FILEINSPECT HA;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.7.0 pkg v3.2.3</version>
+		<version>2.9.7.2 pkg v3.2.4</version>
 		<required_version>2.2</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -486,14 +486,14 @@
 		<descr>Snort is an open source network intrusion prevention and detection system (IDS/IPS). Combining the benefits of signature, protocol, and anomaly-based inspection.</descr>
 		<category>Security</category>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
-		<depends_on_package_pbi>snort-2.9.7.0-i386.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>snort-2.9.7.2-i386.pbi</depends_on_package_pbi>
 		<build_pbi>
 			<port>security/snort</port>
 			<ports_after>security/barnyard2</ports_after>
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET=PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;snort_UNSET=PULLEDPORK FILEINSPECT HA;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.7.0 pkg v3.2.3</version>
+		<version>2.9.7.2 pkg v3.2.4</version>
 		<required_version>2.1</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -473,14 +473,14 @@
 		<descr>Snort is an open source network intrusion prevention and detection system (IDS/IPS). Combining the benefits of signature, protocol, and anomaly-based inspection.</descr>
 		<category>Security</category>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
-		<depends_on_package_pbi>snort-2.9.7.0-amd64.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>snort-2.9.7.2-amd64.pbi</depends_on_package_pbi>
 		<build_pbi>
 			<port>security/snort</port>
 			<ports_after>security/barnyard2</ports_after>
 		</build_pbi>
 		<build_options>barnyard2_UNSET=ODBC PGSQL PRELUDE;barnyard2_SET=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET=PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;snort_UNSET=PULLEDPORK FILEINSPECT HA;perl_SET=THREADS</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>2.9.7.0 pkg v3.2.3</version>
+		<version>2.9.7.2 pkg v3.2.4</version>
 		<required_version>2.1</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>


### PR DESCRIPTION
Snort 2.9.7.2 pkg v3.2.4 -- Update
==========================
This updates the Snort package to binary version 2.9.7.2 and the GUI package to version 3.2.4.  Release notes for Snort 2.9.7.2 can be found here: http://blog.snort.org/2015/03/snort-2972-has-been-released.html.  There are three minor bug fixes in the v3.2.4 GUI package update.

Bug Fixes
-------------
1. If you're on the CATEGORIES tab and have enabled "GPLv2 Community Rules (VRT certified)", the hyperlink assigned to it to take you to the ruleset is incorrect.

2. Redmine bug #4912 -- Typo in snort_rulesets.php.  Effect: Number of snort SO (shared object) rules always incorrectly counts as 1. There will be cases where not all snort SO rules are displayed, as $i is set by the other two rulesets.

3. Trailing backslash on OpenAppID detectors path needs to be removed in snort.conf file.

