### PR TITLE
Update squid.inc

### DIFF
--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -1361,9 +1361,9 @@ icap_client_username_header X-Authenticated-User
 icap_preview_enable on
 icap_preview_size 1024
 
-icap_service service_avi_req reqmod_precache icap://[::1]:1344/squid_clamav bypass=off
+icap_service service_avi_req reqmod_precache icap://localhost:1344/squid_clamav bypass=off
 adaptation_access service_avi_req allow all
-icap_service service_avi_resp respmod_precache icap://[::1]:1344/squid_clamav bypass=on
+icap_service service_avi_resp respmod_precache icap://localhost:1344/squid_clamav bypass=on
 adaptation_access service_avi_resp allow all
 
 EOF;

--- a/config/squid3/34/squid.xml
+++ b/config/squid3/34/squid.xml
@@ -46,7 +46,7 @@
     <requirements>Describe your package requirements here</requirements>
     <faq>Currently there are no FAQ items provided.</faq>
 	<name>squid</name>
-	<version>3.4.10_2 pkg 0.2.6</version>
+	<version>3.4.10_2 pkg 0.2.7</version>
 	<title>Proxy server: General settings</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<menu>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -914,7 +914,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>3.4.10_2 pkg 0.2.6</version>
+		<version>3.4.10_2 pkg 0.2.7</version>
 		<status>beta</status>
 		<required_version>2.2</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>


### PR DESCRIPTION
Change squid_clamav icap_service from ipv6 to ipv4 for default configuration (or add a choice). 
IPV6 could be disabled for some reason.
Regards