### PR TITLE
Update sqstat.class.php

### DIFF
--- a/config/lightsquid/sqstat.class.php
+++ b/config/lightsquid/sqstat.class.php
@@ -427,7 +427,6 @@ class squidstat{
             else
             # i use ip2long() to make ip sorting work correctly
             if ($resolveip) {
-				echo $ip;
                 $hostname = gethostbyaddr($ip);
                 if ($hostname == $ip)
                      $ip = ip2long($ip); # resolve failed. use (ip2long) key

--- a/config/lightsquid/sqstat.class.php
+++ b/config/lightsquid/sqstat.class.php
@@ -202,8 +202,12 @@ class squidstat{
 				}
 				if ($connection) {
 					# username field is avaible in Squid 2.6 stable
+					# peer changed to remote in Squid 3.2 or later
+					# me changed to local in Squid 3.2 or later
 					if(substr($v,0,9)  == "username ")  $parsed["con"][$connection]["username"]   = substr($v, 9);
+					if(substr($v,0,7)  == "remote:")    $parsed["con"][$connection]["peer"]       = substr($v, 8);
 					if(substr($v,0,5)  == "peer:")      $parsed["con"][$connection]["peer"]       = substr($v, 6);
+					if(substr($v,0,6)  == "local:")     $parsed["con"][$connection]["me"]         = substr($v, 7);
 					if(substr($v,0,3)  == "me:")        $parsed["con"][$connection]["me"]         = substr($v, 4);
 					if(substr($v,0,4)  == "uri ")       $parsed["con"][$connection]["uri"]        = substr($v, 4);
 					if(substr($v,0,10) == "delay_pool") $parsed["con"][$connection]["delay_pool"] = substr($v, 11);
@@ -423,6 +427,7 @@ class squidstat{
             else
             # i use ip2long() to make ip sorting work correctly
             if ($resolveip) {
+				echo $ip;
                 $hostname = gethostbyaddr($ip);
                 if ($hostname == $ip)
                      $ip = ip2long($ip); # resolve failed. use (ip2long) key

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -511,7 +511,7 @@
 		<descr>High performance web proxy report (LightSquid). Proxy realtime stat (SQStat). Requires squid HTTP proxy.</descr>
 		<website>http://lightsquid.sf.net/</website>
 		<category>Network Report</category>
-		<version>1.8.2 pkg v.2.35</version>
+		<version>1.8.2 pkg v.2.36</version>
 		<maintainer>dv_serg@mail.ru</maintainer>
 		<depends_on_package_pbi>lightsquid-1.8_2-##ARCH##.pbi</depends_on_package_pbi>
 		<build_pbi>


### PR DESCRIPTION
Fix erro in Squid 3.2 or later
Field "peer:" is changed to "remote:" and field "me:" changed to "local:"
Cause:
Warning: gethostbyaddr(): Address is not a valid IPv4 or IPv6 address in /usr/local/www/sqstat/sqstat.class.php on line 426

Fix Bug #3936