### PR TITLE
apcupsd - improve status page

### DIFF
--- a/config/apcupsd/apcupsd.inc
+++ b/config/apcupsd/apcupsd.inc
@@ -224,5 +224,45 @@ EOF;
 
 }
 
+function check_nis_running_apcupsd(){
+   global $config, $g;
+
+   if (is_array($config['installedpackages']['apcupsd'])){
+      $apcupsd_config = $config['installedpackages']['apcupsd']['config'][0];
+
+      if ($apcupsd_config['apcupsdenabled']=="on" && $apcupsd_config['netserver']=="on" )
+         return(true);
+   }
+
+   return(false);
+}
+
+
+function check_nis_ip_apcupsd(){
+   global $config, $g;
+
+   if (is_array($config['installedpackages']['apcupsd'])){
+      $apcupsd_config = $config['installedpackages']['apcupsd']['config'][0];
+
+      if ($apcupsd_config['apcupsdenabled']=="on" && $apcupsd_config['netserver']=="on" )
+         return($apcupsd_config['nisip']);
+   }
+
+   return(false);
+}
+
+function check_nis_port_apcupsd(){
+   global $config, $g;
+
+   if (is_array($config['installedpackages']['apcupsd'])){
+      $apcupsd_config = $config['installedpackages']['apcupsd']['config'][0];
+
+      if ($apcupsd_config['apcupsdenabled']=="on" && $apcupsd_config['netserver']=="on" )
+         return($apcupsd_config['nisport']);
+   }
+
+   return(false);
+}
+
 ?>
 

--- a/config/apcupsd/apcupsd.xml
+++ b/config/apcupsd/apcupsd.xml
@@ -40,7 +40,7 @@
 	<name>Apcupsd</name>
 	<title>Services: Apcupsd (General)</title>
 	<category>Monitoring</category>
-	<version>0.3.3</version>
+	<version>0.3.4</version>
 	<include_file>/usr/local/pkg/apcupsd.inc</include_file>
 	<addedit_string>Apcupsd has been created/modified.</addedit_string>
 	<delete_string>Apcupsd has been deleted.</delete_string>

--- a/config/apcupsd/apcupsd_status.php
+++ b/config/apcupsd/apcupsd_status.php
@@ -107,7 +107,7 @@ pre {
 				<td width="14%" valign="top" class="vncellreq">Host:</td>
 				<td width="86%" class="vtable">
 					<input name="strapcaccess" type="text" class="formfld unknown" id="strapcaccess" size="22" value="<? echo "{$strapcaccess}"; ?>">
-               <br/>
+					<br/>
 					<span class="vexpl">
      Default: <b>localhost</b><br/>
      apcaccess uses apcupsd's inbuilt Network Information Server (NIS) to obtain the current status information <br/>
@@ -120,46 +120,46 @@ pre {
 					<?php else: ?>
 						<input type="Submit" value="Execute" class="formbtn"/>
 					<?php endif; ?>
-               </span>
-            </td>
+					</span>
+				</td>
 			</tr>
 		</form>
 			<tr><td colspan="2">
 <?php
-   $nis_server = check_nis_running_apcupsd();
+	$nis_server = check_nis_running_apcupsd();
 
-   if ($pf_version >= 2.2){
-      if($strapcaccess) {
+	if ($pf_version >= 2.2){
+		if($strapcaccess) {
 			echo "Running: apcaccess -h {$strapcaccess} <br/>";
 			puts("<pre>");
 			putenv("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
-         $ph = popen("apcaccess -h {$strapcaccess} 2>&1", "r" );
-         while ($line = fgets($ph)) echo htmlspecialchars($line);
-         pclose($ph);
-         puts("</pre>");
+			$ph = popen("apcaccess -h {$strapcaccess} 2>&1", "r" );
+			while ($line = fgets($ph)) echo htmlspecialchars($line);
+			pclose($ph);
+			puts("</pre>");
 		}elseif($nis_server){
-         $nisip=(check_nis_ip_apcupsd() != ''? check_nis_ip_apcupsd() : "0.0.0.0");
-         $nisport=(check_nis_port_apcupsd() != ''? check_nis_port_apcupsd() : "3551");
+			$nisip=(check_nis_ip_apcupsd() != ''? check_nis_ip_apcupsd() : "0.0.0.0");
+			$nisport=(check_nis_port_apcupsd() != ''? check_nis_port_apcupsd() : "3551");
 			echo "Running: apcaccess -h {$nisip}:{$nisport} <br/>";
 			puts("<pre>");
 			putenv("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
-         $ph = popen("apcaccess -h localhost 2>&1", "r" );
+			$ph = popen("apcaccess -h localhost 2>&1", "r" );
 			while ($line = fgets($ph)) echo htmlspecialchars($line);
-         pclose($ph);
-         puts("</pre>");
+			pclose($ph);
+			puts("</pre>");
 		}else
-         echo "Not running Network Information Server (NIS). In order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br/>";
+			echo "Not running Network Information Server (NIS). In order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br/>";
    }else{
-      echo "pfSense version prior to 2.2 runs APCupsd 3.14.10 and apcaccess doesn't accept host parameter. <br/>";
-      if ($nis_server){
-         puts("<pre>");
-         putenv("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
-         $ph = popen("apcaccess 2>&1", "r" );
-         while ($line = fgets($ph)) echo htmlspecialchars($line);
-         pclose($ph);
-         puts("</pre>");
-      }else
-         echo "Not Network Information Server (NIS). In order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br/>";
+		echo "pfSense version prior to 2.2 runs APCupsd 3.14.10 and apcaccess doesn't accept host parameter. <br/>";
+		if ($nis_server){
+			puts("<pre>");
+			putenv("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
+			$ph = popen("apcaccess 2>&1", "r" );
+			while ($line = fgets($ph)) echo htmlspecialchars($line);
+			pclose($ph);
+			puts("</pre>");
+		}else
+			echo "Not Network Information Server (NIS). In order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br/>";
    }
 
 ?>

--- a/config/apcupsd/apcupsd_status.php
+++ b/config/apcupsd/apcupsd_status.php
@@ -28,7 +28,7 @@
 */
 
 require("guiconfig.inc");
-require_once("/usr/local/pkg/apcupsd.inc");
+require_once("apcupsd.inc");
 
 $pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 if ($pf_version < 2.0)

--- a/config/apcupsd/apcupsd_status.php
+++ b/config/apcupsd/apcupsd_status.php
@@ -148,7 +148,7 @@ pre {
 			pclose($ph);
 			puts("</pre>");
 		}else
-			echo "Not running Network Information Server (NIS). In order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br/>";
+			echo "Network Information Server (NIS) not running, in order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br/>";
    }else{
 		echo "pfSense version prior to 2.2 runs APCupsd 3.14.10 and apcaccess doesn't accept host parameter. <br/>";
 		if ($nis_server){
@@ -159,7 +159,7 @@ pre {
 			pclose($ph);
 			puts("</pre>");
 		}else
-			echo "Not Network Information Server (NIS). In order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br/>";
+			echo "Network Information Server (NIS) not running, in order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br/>";
    }
 
 ?>

--- a/config/apcupsd/apcupsd_status.php
+++ b/config/apcupsd/apcupsd_status.php
@@ -28,6 +28,7 @@
 */
 
 require("guiconfig.inc");
+require_once("/usr/local/pkg/apcupsd.inc");
 
 $pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 if ($pf_version < 2.0)
@@ -37,6 +38,9 @@ $pgtitle = "Services: Apcupsd (Status)";
 include("head.inc");
 
 function puts( $arg ) { echo "$arg\n"; }	
+
+if (isset($_GET['strapcaccess']))
+   $strapcaccess = trim($_GET['strapcaccess']);
 
 ?>
 
@@ -98,14 +102,66 @@ pre {
 
 <div id="mainarea" style="padding-top: 0px; padding-bottom: 0px; ">
 	<table class="tabcont" width="100%" border="0" cellspacing="0" cellpadding="6">
-		<tr><td>
+		<form name="frm_apcupsd_status" method="GET">
+			<tr>
+				<td width="14%" valign="top" class="vncellreq">Host:</td>
+				<td width="86%" class="vtable">
+					<input name="strapcaccess" type="text" class="formfld unknown" id="strapcaccess" size="22" value="<? echo "{$strapcaccess}"; ?>">
+               <br/>
+					<span class="vexpl">
+     Default: <b>localhost</b><br/>
+     apcaccess uses apcupsd's inbuilt Network Information Server (NIS) to obtain the current status information <br/>
+     from the UPS on the local or remote computer. It is therefore necessary to have the following configuration directives: <br/>
+     NETSERVER on<br/>
+     NISPORT 3551<br/>
+					<br/>
+					<?php if ($pf_version < 2.2): ?>
+						<input type="Submit" value="Execute" class="formbtn" disabled/>
+					<?php else: ?>
+						<input type="Submit" value="Execute" class="formbtn"/>
+					<?php endif; ?>
+               </span>
+            </td>
+			</tr>
+		</form>
+			<tr><td colspan="2">
 <?php
-   puts("<pre>");
-   putenv("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
-   $ph = popen('apcaccess 2>&1', "r" );
-   while ($line = fgets($ph)) echo htmlspecialchars($line);
-   pclose($ph);
-   puts("</pre>");
+   $nis_server = check_nis_running_apcupsd();
+
+   if ($pf_version >= 2.2){
+      if($strapcaccess) {
+			echo "Running: apcaccess -h {$strapcaccess} <br/>";
+			puts("<pre>");
+			putenv("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
+         $ph = popen("apcaccess -h {$strapcaccess} 2>&1", "r" );
+         while ($line = fgets($ph)) echo htmlspecialchars($line);
+         pclose($ph);
+         puts("</pre>");
+		}elseif($nis_server){
+         $nisip=(check_nis_ip_apcupsd() != ''? check_nis_ip_apcupsd() : "0.0.0.0");
+         $nisport=(check_nis_port_apcupsd() != ''? check_nis_port_apcupsd() : "3551");
+			echo "Running: apcaccess -h {$nisip}:{$nisport} <br/>";
+			puts("<pre>");
+			putenv("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
+         $ph = popen("apcaccess -h localhost 2>&1", "r" );
+			while ($line = fgets($ph)) echo htmlspecialchars($line);
+         pclose($ph);
+         puts("</pre>");
+		}else
+         echo "Not running Network Information Server (NIS). In order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br/>";
+   }else{
+      echo "pfSense version prior to 2.2 runs APCupsd 3.14.10 and apcaccess doesn't accept host parameter. <br/>";
+      if ($nis_server){
+         puts("<pre>");
+         putenv("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
+         $ph = popen("apcaccess 2>&1", "r" );
+         while ($line = fgets($ph)) echo htmlspecialchars($line);
+         pclose($ph);
+         puts("</pre>");
+      }else
+         echo "Not Network Information Server (NIS). In order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br/>";
+   }
+
 ?>
 		</td></tr>
 	</table>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1452,7 +1452,7 @@
 		<descr>Set of programs for controlling APC UPS.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.12_1 pkg v0.3.3</version>
+		<version>apcupsd-3.14.12_1 pkg v0.3.4</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1883,7 +1883,7 @@
 		<descr>Set of programs for controlling APC UPS.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.10_1 pkg v0.3.3</version>
+		<version>apcupsd-3.14.10_1 pkg v0.3.4</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1870,7 +1870,7 @@
 		<descr>Set of programs for controlling APC UPS.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.10_1 pkg v0.3.3</version>
+		<version>apcupsd-3.14.10_1 pkg v0.3.4</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>


### PR DESCRIPTION
There are some issues with APCupsd status page by misunderstandings.

- add an option for chose host parameter on apcaccess command.
This options is enabled only on pfSense >= 2.2 (APCupsd 3.4.12)
- add a verification if NIS server is running (apcaccess needs to connect on a NIS server, localhost or remote).
- bump version