### PR TITLE
APCd mail

### DIFF
--- a/config/apcupsd/apcupsd_mail.php
+++ b/config/apcupsd/apcupsd_mail.php
@@ -61,7 +61,7 @@ $mail = new PHPMailer();
 $mail->IsSMTP();
 $mail->Host = $config['notifications']['smtp']['ipaddress'];
 
-if ($config['notifications']['smtp']['ssl'] == "checked")
+if (isset($config['notifications']['smtp']['ssl']))
 	$mail->SMTPSecure =  "ssl";
 
 $mail->Port = empty($config['notifications']['smtp']['port']) ? 25 : $config['notifications']['smtp']['port'];

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1452,7 +1452,7 @@
 		<descr>Set of programs for controlling APC UPS.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.12_1 pkg v0.3.3</version>
+		<version>apcupsd-3.14.12_1 pkg v0.3.4</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1883,7 +1883,7 @@
 		<descr>Set of programs for controlling APC UPS.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.10_1 pkg v0.3.3</version>
+		<version>apcupsd-3.14.10_1 pkg v0.3.4</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1870,7 +1870,7 @@
 		<descr>Set of programs for controlling APC UPS.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.10_1 pkg v0.3.3</version>
+		<version>apcupsd-3.14.10_1 pkg v0.3.4</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>


### PR DESCRIPTION
In Pfsense version 2.2 the variable/key $config['notifications']['smtp']['ssl'] is set with an empty string value when the parameter 'Enable SMTP over SSL/TLS' is checked in the webgui (and the key not exists when the checkbox is off). The check in this file is for the value 'checked', but is not working and ever happening, thats why I modify this to get it work with Gmail.