### PR TITLE
Fix IPv6 Reverse Zone configuration. Bug#4553

### DIFF
--- a/config/bind/bind.inc
+++ b/config/bind/bind.inc
@@ -318,6 +318,7 @@ EOD;
 			$zoneipslave = $zone['slaveip'];
 			$zoneforwarders=$zone['forwarders'];
 			$zonereverso = $zone['reverso'];
+			$zonereversv6o = $zone['reversv6o'];
 			
 			if (!(is_dir(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview")))
             	mkdir(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview",0755,true);
@@ -337,7 +338,10 @@ EOD;
 
 				if ($zoneview == $viewname){
 					if($zonereverso == "on")
-				 		$bind_conf .= "\tzone \"$zonename.in-addr.arpa\" {\n";
+						if($zonereversv6o == "on")
+					 		$bind_conf .= "\tzone \"$zonename.ip6.arpa\" {\n";
+						else
+							$bind_conf .= "\tzone \"$zonename.in-addr.arpa\" {\n";
 				  	else
 						$bind_conf .= "\tzone \"$zonename\" {\n";
         		
@@ -394,7 +398,8 @@ EOD;
 						$zoneminimum = ($zone['minimum']?$zone['minimum']:"3600");
 						$zonenameserver = $zone['nameserver'];
 						$zoneipns = $zone['ipns'];
-						$zonereverso = $zone['reverso'];
+						$zonereverso = $zone['reverso'];		
+						$zonereversv6o = $zone['reversv6o'];
 						if($zone['allowupdate'] == '')
 							$zoneallowupdate = "none";
 						else
@@ -409,7 +414,10 @@ EOD;
 							$zoneallowtransfer = str_replace(',','; ',$zone['allowtransfer']);
 						$zone_conf = "\$TTL {$zonetll}\n;\n";
 						if($zonereverso == "on")
-							$zone_conf .= "\$ORIGIN {$zonename}.in-addr.arpa.\n\n";
+							if($zonereversv6o == "on")
+								$zone_conf .= "\$ORIGIN {$zonename}.ip6.arpa.\n\n";
+							else
+								$zone_conf .= "\$ORIGIN {$zonename}.in-addr.arpa.\n\n";
 						else
 							$zone_conf .= "\$ORIGIN {$zonename}.\n\n";
 						$zone_conf .= ";\tDatabase file {$zonename}.DB for {$zonename} zone.\n";

--- a/config/bind/bind_zones.xml
+++ b/config/bind/bind_zones.xml
@@ -165,6 +165,12 @@
 			<fieldname>reverso</fieldname>
 			<description>Enable if this is a reverse zone.</description>
 			<type>checkbox</type>
+		</field>		
+		<field>
+			<fielddescr>IPV6 Reverse Zone</fielddescr>
+			<fieldname>reversv6o</fieldname>
+			<description>Enable if this is a IPV6 reverse zone. Evaluated only if Reverse Zone is also selected.</description>
+			<type>checkbox</type>
 		</field>
 		<field>
 			<fielddescr>Custom Option</fielddescr>


### PR DESCRIPTION
This fix was written by cuteredstorm 19 Nov 2013.
https://github.com/cuteredstorm/pfsense-packages/commit/2b4e8084a92c8e9936f1b2fdca8272d29217c20a

But it was never been included into BIND package of pfsense. If you fix this manually you loose all your updates after BIND package upgrade from pfsense GUI.
So, i decided to commit this fix once again.