### PR TITLE
haproxy 1.5, bump version on 2.2 to 1.5.11, move advanced frontend settings below forwardfor

### DIFF
--- a/config/haproxy-devel/pkg/haproxy.inc
+++ b/config/haproxy-devel/pkg/haproxy.inc
@@ -1087,16 +1087,6 @@ function haproxy_writeconf($configpath) {
 				fwrite ($fd, "\tbind /tmp/haproxy_chroot/{$bind['name']}.socket name unixsocket accept-proxy {$ssl_info} {$advanced_bind}\n");
 			}
 
-			// Advanced pass thru
-			if($bind['advanced']) {
-				$advanced	= explode("\n", base64_decode($bind['advanced']));
-				foreach($advanced as $adv_line) {
-					if ($adv_line != "") {
-						fwrite($fd, "\t" . str_replace("\r", "", $adv_line) . "\n");
-					}
-				}
-			}
-
 			// https is an alias for tcp for clarity purposes
 			if($bind['type'] == "https") {
 				$backend_type = "tcp";
@@ -1142,6 +1132,16 @@ function haproxy_writeconf($configpath) {
 			
 			fwrite ($fd, "\ttimeout client\t\t" . $bind['client_timeout'] . "\n");
 
+			
+			// Advanced pass thru
+			if($bind['advanced']) {
+				$advanced	= explode("\n", base64_decode($bind['advanced']));
+				foreach($advanced as $adv_line) {
+					if ($adv_line != "") {
+						fwrite($fd, "\t" . str_replace("\r", "", $adv_line) . "\n");
+					}
+				}
+			}
 	
 			// Combine the rest of the frontend configs
 			$default_backend = "";

--- a/config/haproxy1_5/pkg/haproxy.inc
+++ b/config/haproxy1_5/pkg/haproxy.inc
@@ -1087,16 +1087,6 @@ function haproxy_writeconf($configpath) {
 				fwrite ($fd, "\tbind /tmp/haproxy_chroot/{$bind['name']}.socket name unixsocket accept-proxy {$ssl_info} {$advanced_bind}\n");
 			}
 
-			// Advanced pass thru
-			if($bind['advanced']) {
-				$advanced	= explode("\n", base64_decode($bind['advanced']));
-				foreach($advanced as $adv_line) {
-					if ($adv_line != "") {
-						fwrite($fd, "\t" . str_replace("\r", "", $adv_line) . "\n");
-					}
-				}
-			}
-
 			// https is an alias for tcp for clarity purposes
 			if($bind['type'] == "https") {
 				$backend_type = "tcp";
@@ -1142,6 +1132,16 @@ function haproxy_writeconf($configpath) {
 			
 			fwrite ($fd, "\ttimeout client\t\t" . $bind['client_timeout'] . "\n");
 
+			
+			// Advanced pass thru
+			if($bind['advanced']) {
+				$advanced	= explode("\n", base64_decode($bind['advanced']));
+				foreach($advanced as $adv_line) {
+					if ($adv_line != "") {
+						fwrite($fd, "\t" . str_replace("\r", "", $adv_line) . "\n");
+					}
+				}
+			}
 	
 			// Combine the rest of the frontend configs
 			$default_backend = "";

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -137,12 +137,12 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.9 pkg v 0.22</version>
+		<version>1.5.11 pkg v 0.23</version>
 		<status>Release</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy1_5/haproxy.xml</config_file>
 		<configurationfile>haproxy.xml</configurationfile>
-		<depends_on_package_pbi>haproxy-devel-1.5.9-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>haproxy-devel-1.5.11-##ARCH##.pbi</depends_on_package_pbi>
 		<build_pbi>
 			<ports_before>security/openssl</ports_before>
 			<custom_name>haproxy-devel</custom_name>
@@ -158,12 +158,12 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.9 pkg v 0.22</version>
+		<version>1.5.11 pkg v 0.23</version>
 		<status>Release</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>
 		<configurationfile>haproxy.xml</configurationfile>
-		<depends_on_package_pbi>haproxy-devel-1.5.9-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>haproxy-devel-1.5.11-##ARCH##.pbi</depends_on_package_pbi>
 		<build_pbi>
 			<ports_before>security/openssl</ports_before>
 			<custom_name>haproxy-devel</custom_name>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -166,7 +166,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.22</version>
+		<version>1.5.3 pkg v 0.23</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy1_5/haproxy.xml</config_file>
@@ -190,7 +190,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.22</version>
+		<version>1.5.3 pkg v 0.23</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -153,7 +153,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.22</version>
+		<version>1.5.3 pkg v 0.23</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy1_5/haproxy.xml</config_file>
@@ -177,7 +177,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.22</version>
+		<version>1.5.3 pkg v 0.23</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>


### PR DESCRIPTION
haproxy 1.5, bump version on 2.2 to 1.5.11, move advanced frontend settings below forwardfor to avoid a (possible) warning