### PR TITLE
apcupsd - add another way to send email notifications

### DIFF
--- a/config/apcupsd/apcupsd.inc
+++ b/config/apcupsd/apcupsd.inc
@@ -123,8 +123,8 @@ function validate_input_apcupsd($post,&$input_errors){
 
 			if (empty($post['smtpport'])) {
 					$input_errors[]='SMTP Port cannot be empty if SMTP builtin is enabled.';
-			}elseif(!is_numericint($post['smtpport'])){
-					$input_errors[]='SMTP Port is not numeric.';
+			}elseif(!is_port($post['smtpport'])){
+					$input_errors[]='SMTP Port is not a valid port.';
 			}
 
 			if (empty($post['smtpfrom'])) {

--- a/config/apcupsd/apcupsd.inc
+++ b/config/apcupsd/apcupsd.inc
@@ -259,10 +259,12 @@ function apccontrol_scripts_install($emailnotification){
 				}
 			}
 
+			$pfSense_hostname = gethostname();
+
 			$apccontrol_script_file=<<<EOF
 #!/bin/sh
 
-HOSTNAME=`hostname`
+HOSTNAME="{$pfSense_hostname}"
 MSG="{$apcstatus["{$apccontrol_script}"]}"
 #
 (

--- a/config/apcupsd/apcupsd.inc
+++ b/config/apcupsd/apcupsd.inc
@@ -115,6 +115,28 @@ function validate_input_apcupsd($post,&$input_errors){
 			}	
 		}
 
+		if ($post['emailnotification'] == 'smtpbuiltin') {
+
+			if (empty($post['smtphost'])) {
+					$input_errors[]='SMTP Host cannot be empty if SMTP builtin is enabled.';
+			}
+
+			if (empty($post['smtpport'])) {
+					$input_errors[]='SMTP Port cannot be empty if SMTP builtin is enabled.';
+			}elseif(!is_numericint($post['smtpport'])){
+					$input_errors[]='SMTP Port is not numeric.';
+			}
+
+			if (empty($post['smtpfrom'])) {
+					$input_errors[]='From field cannot be empty if SMTP builtin is enabled.';
+			}
+
+			if (empty($post['smtpto'])) {
+					$input_errors[]='To field cannot be empty if SMTP builtin is enabled..';
+			}
+
+		}
+
 	} // apcupsdenabled
 }
 
@@ -154,6 +176,7 @@ function sync_package_apcupsd(){
 			$upsclass=$apcupsd_config['upsclass'];
 			$upsmode=$apcupsd_config['upsmode'];
 			$lockfile=($apcupsd_config['lockfile'] != ''? $apcupsd_config['lockfile'] : "/var/tmp");
+			$emailnotification=$apcupsd_config['emailnotification'];
 	
 			include("/usr/local/pkg/apcupsd.conf.php");
 			file_put_contents(APCUPSD_BASE . "/etc/apcupsd/apcupsd.conf", $apcupsdconf, LOCK_EX);
@@ -193,10 +216,12 @@ function sync_package_apcupsd(){
 		}
 	}
 
+	apccontrol_scripts_install($emailnotification);
 	conf_mount_ro();
 }
 
-function apccontrol_scripts_install(){
+function apccontrol_scripts_install($emailnotification){
+	global $config, $g;
 
 	// check pfsense version
 	$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
@@ -207,10 +232,50 @@ function apccontrol_scripts_install(){
 		define('APCUPSD_BASE', '/usr/local');
 	}
 
+	$apcstatus[commfailure] = "\$HOSTNAME - Communications with UPS \$1 lost";
+	$apcstatus[commok] = "\$HOSTNAME - Communications with UPS \$1 restored";
+	$apcstatus[onbattery] = "\$HOSTNAME - Power failure. Running on UPS \$1 batteries";
+	$apcstatus[offbattery] = "\$HOSTNAME - UPS \$1 Power has returned...";
+	$apcstatus[changeme] = "\$HOSTNAME - Emergency! UPS batteries have failed. Change them NOW";
+
 	$apccontrol_scripts = array("offbattery","onbattery","commfailure","commok","changeme");
 	foreach($apccontrol_scripts as $apccontrol_script) {
 
-		$apccontrol_script_file=<<<EOF
+		if ($emailnotification == "smtpbuiltin"){
+
+			if (is_array($config['installedpackages']['apcupsd'])){
+				$apcupsd_config = $config['installedpackages']['apcupsd']['config'][0];
+				if ($apcupsd_config['apcupsdenabled']=="on"){
+					$smtphost=($apcupsd_config['smtphost'] != ''? $apcupsd_config['smtphost'] : "0.0.0.0");
+					$smtpport=($apcupsd_config['smtpport'] != ''? $apcupsd_config['smtpport'] : "25");
+					$smtpfrom=$apcupsd_config['smtpfrom'];
+					$smtpto=$apcupsd_config['smtpto'];
+					$smtpcc=$apcupsd_config['smtpcc'];
+					if(empty($smtpcc)){
+						$smtpcc_cmd = "";
+					}else{
+						$smtpcc_cmd = "-c {$smtpcc}";
+					}
+				}
+			}
+
+			$apccontrol_script_file=<<<EOF
+#!/bin/sh
+
+HOSTNAME=`hostname`
+MSG="{$apcstatus["{$apccontrol_script}"]}"
+#
+(
+   echo " "
+   echo "\$MSG"
+   echo " "
+   /usr/local/sbin/apcaccess status
+) | /usr/local/sbin/smtp -s "\$MSG" -h {$smtphost}:{$smtpport} -f {$smtpfrom} {$smtpcc_cmd} {$smtpto}
+exit 0
+
+EOF;
+		}else{
+			$apccontrol_script_file=<<<EOF
 #!/bin/sh
 
 /usr/local/bin/php -f /usr/local/pkg/apcupsd_mail.php {$apccontrol_script} > /dev/null
@@ -218,6 +283,7 @@ function apccontrol_scripts_install(){
 exit 0
 
 EOF;
+		}
 
 		file_put_contents(APCUPSD_BASE . "/etc/apcupsd/" . $apccontrol_script, $apccontrol_script_file, LOCK_EX);
 	}

--- a/config/apcupsd/apcupsd.inc
+++ b/config/apcupsd/apcupsd.inc
@@ -232,11 +232,11 @@ function apccontrol_scripts_install($emailnotification){
 		define('APCUPSD_BASE', '/usr/local');
 	}
 
-	$apcstatus[commfailure] = "\$HOSTNAME - Communications with UPS \$1 lost";
-	$apcstatus[commok] = "\$HOSTNAME - Communications with UPS \$1 restored";
-	$apcstatus[onbattery] = "\$HOSTNAME - Power failure. Running on UPS \$1 batteries";
-	$apcstatus[offbattery] = "\$HOSTNAME - UPS \$1 Power has returned...";
-	$apcstatus[changeme] = "\$HOSTNAME - Emergency! UPS batteries have failed. Change them NOW";
+	$apcstatus['commfailure'] = "\$HOSTNAME - Communications with UPS \$1 lost";
+	$apcstatus['commok'] = "\$HOSTNAME - Communications with UPS \$1 restored";
+	$apcstatus['onbattery'] = "\$HOSTNAME - Power failure. Running on UPS \$1 batteries";
+	$apcstatus['offbattery'] = "\$HOSTNAME - UPS \$1 Power has returned...";
+	$apcstatus['changeme'] = "\$HOSTNAME - Emergency! UPS batteries have failed. Change them NOW";
 
 	$apccontrol_scripts = array("offbattery","onbattery","commfailure","commok","changeme");
 	foreach($apccontrol_scripts as $apccontrol_script) {

--- a/config/apcupsd/apcupsd.xml
+++ b/config/apcupsd/apcupsd.xml
@@ -346,6 +346,8 @@ UPSTYPE   DEVICE           Description <br>
 <strong>phpMailer</strong>	- In order to receive e-mail notifications through phpMailer, you need 
 to configure SMTP Email Notifications on Advanced/Notifications section, and also, 
 install mailreport package.<br>
+This feature is currently broken on pfSense 2.2, for more info see pfSense forum: 
+<a href="https://forum.pfsense.org/index.php?topic=89901.0">APCupsd package status for pfSense.</a><br>
 <br>
 <strong>SMTP built-in</strong> - A simple SMTP mail client for apcupsd. 
 It does not have smtp authentication of any kind.

--- a/config/apcupsd/apcupsd.xml
+++ b/config/apcupsd/apcupsd.xml
@@ -40,7 +40,7 @@
 	<name>Apcupsd</name>
 	<title>Services: Apcupsd (General)</title>
 	<category>Monitoring</category>
-	<version>0.3.4</version>
+	<version>0.3.5</version>
 	<include_file>/usr/local/pkg/apcupsd.inc</include_file>
 	<addedit_string>Apcupsd has been created/modified.</addedit_string>
 	<delete_string>Apcupsd has been deleted.</delete_string>

--- a/config/apcupsd/apcupsd.xml
+++ b/config/apcupsd/apcupsd.xml
@@ -339,11 +339,63 @@ UPSTYPE   DEVICE           Description <br>
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fieldname>notification_info</fieldname>
-			<type>info</type>
-			<description>In order to receive e-mail notifications, you need to configure 
-			SMTP Email Notifications on Advanced/Notifications section, and also, 
-			install mailreport package.</description>
+			<fielddescr>E-mail notification</fielddescr>
+			<fieldname>emailnotification</fieldname>
+			<description><![CDATA[Choose how APCUpsd will send email notifications.<br>
+<br>
+<strong>phpMailer</strong>	- In order to receive e-mail notifications through phpMailer, you need 
+to configure SMTP Email Notifications on Advanced/Notifications section, and also, 
+install mailreport package.<br>
+<br>
+<strong>SMTP built-in</strong> - A simple SMTP mail client for apcupsd. 
+It does not have smtp authentication of any kind.
+<br>
+			]]></description>
+			<type>select</type>
+			<default_value>phpmailer</default_value>
+			<options>
+				<option><name>phpMailer</name><value>phpmailer</value></option>
+				<option><name>SMTP built-in</name><value>smtpbuiltin</value></option>
+			</options>
+		</field>
+		<field>
+			<name>SMTP built-in</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>SMTP Host</fielddescr>
+			<fieldname>smtphost</fieldname>
+			<description></description>
+         <type>input</type>
+         <size>20</size>
+		</field>
+		<field>
+			<fielddescr>SMTP Port</fielddescr>
+			<fieldname>smtpport</fieldname>
+			<description></description>
+         <type>input</type>
+         <size>5</size>
+		</field>
+		<field>
+			<fielddescr>From</fielddescr>
+			<fieldname>smtpfrom</fieldname>
+			<description></description>
+         <type>input</type>
+         <size>20</size>
+		</field>
+		<field>
+			<fielddescr>To</fielddescr>
+			<fieldname>smtpto</fieldname>
+			<description></description>
+         <type>input</type>
+         <size>20</size>
+		</field>
+		<field>
+			<fielddescr>Cc</fielddescr>
+			<fieldname>smtpcc</fieldname>
+			<description></description>
+         <type>input</type>
+         <size>20</size>
 		</field>
 	</fields>
 	<custom_php_install_command>php_install_apcupsd();</custom_php_install_command>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1452,7 +1452,7 @@
 		<descr>Set of programs for controlling APC UPS.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.12_1 pkg v0.3.4</version>
+		<version>apcupsd-3.14.12_1 pkg v0.3.5</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1883,7 +1883,7 @@
 		<descr>Set of programs for controlling APC UPS.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.10_1 pkg v0.3.4</version>
+		<version>apcupsd-3.14.10_1 pkg v0.3.5</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1870,7 +1870,7 @@
 		<descr>Set of programs for controlling APC UPS.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.10_1 pkg v0.3.4</version>
+		<version>apcupsd-3.14.10_1 pkg v0.3.5</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>


### PR DESCRIPTION
Add another way to send email notifications.
The user can choose between phpMailer or a simple SMTP mail client packaged with APCUpsd.
Bump version.