### PR TITLE
Apcupsd - Bug 4650 - Support TLS email notifications and update email no...

### DIFF
--- a/config/apcupsd/apcupsd_mail.php
+++ b/config/apcupsd/apcupsd_mail.php
@@ -61,8 +61,11 @@ $mail = new PHPMailer();
 $mail->IsSMTP();
 $mail->Host = $config['notifications']['smtp']['ipaddress'];
 
-if ($config['notifications']['smtp']['ssl'] == "checked")
-	$mail->SMTPSecure =  "ssl";
+if ((isset($config['notifications']['smtp']['ssl']) && $config['notifications']['smtp']['ssl'] != "unchecked") || $config['notifications']['smtp']['ssl'] == "checked")
+	$mail->SMTPSecure = "ssl";
+
+if ((isset($config['notifications']['smtp']['tls']) && $config['notifications']['smtp']['tls'] != "unchecked") || $config['notifications']['smtp']['tls'] == "checked")
+	$mail->SMTPSecure = "tls";
 
 $mail->Port = empty($config['notifications']['smtp']['port']) ? 25 : $config['notifications']['smtp']['port'];
 

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1452,7 +1452,7 @@
 		<descr>Set of programs for controlling APC UPS.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.12_1 pkg v0.3.4</version>
+		<version>apcupsd-3.14.12_1 pkg v0.3.5</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1883,7 +1883,7 @@
 		<descr>Set of programs for controlling APC UPS.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.10_1 pkg v0.3.4</version>
+		<version>apcupsd-3.14.10_1 pkg v0.3.5</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1870,7 +1870,7 @@
 		<descr>Set of programs for controlling APC UPS.</descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.10_1 pkg v0.3.4</version>
+		<version>apcupsd-3.14.10_1 pkg v0.3.5</version>
 		<status>BETA</status>
 		<required_version>2.0</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>


### PR DESCRIPTION
Apcupsd - Fix #4650 - Support TLS email notifications and update email notification flag tests

Bump package number to 0.3.5