### PR TITLE
BIND package code clean up

### DIFF
--- a/config/bind/bind.inc
+++ b/config/bind/bind.inc
@@ -36,107 +36,124 @@ require_once('util.inc');
 require_once('pfsense-utils.inc');
 require_once('pkg-utils.inc');
 require_once('service-utils.inc');
-if(!function_exists("filter_configure")) 
+if (!function_exists("filter_configure")) {
 	require_once("filter.inc");
-
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version > 2.0)
-	define('BIND_LOCALBASE', '/usr/pbi/bind-' . php_uname("m"));
-else
-	define('BIND_LOCALBASE','/usr/local');
-
-define('CHROOT_LOCALBASE','/cf/named');
-
-function bind_zone_validate($post, &$input_errors){
-	if (key_exists("mail",$_POST))
-		$_POST['mail']=preg_replace("/@/",".",$post['mail']);
-		
-	switch ($_POST['type']){
-		case 'slave':
-			if( $_POST['slaveip'] == "")
-				$input_errors[] = 'The field \'Master Zone IP\' is required for slave zones.';
-		break;
-		case 'forward':
-			if( $_POST['forwarders'] == "")
-			$input_errors[] = 'The field \'Forwarders\' is required for forward zones.';
-		break;
-		case 'redirect':
-			$_POST['tll']=300;
-			$_POST['refresh']=0;
-			$_POST['serial']=0;
-			$_POST['retry']=0;
-			$_POST['expire']=0;
-			$_POST['minimum']=0;
-			if($_POST['mail']=='')
-				$input_errors[] = "The field 'Mail Admin Zone' is required for {$_POST['type']} zones.";
-			
-		default:
-			if($_POST['nameserver']=='')
-				$input_errors[] = "The field 'Name server' is required for {$_POST['type']} zones.";
-			for ($i=0;$i < count($_POST);$i++){
-				if (key_exists("hostname$i",$_POST)){
-					if ($_POST['reverso']=="on"){
-						$_POST["hostvalue$i"]="";
-						if (!preg_match("/(PTR|NS)/",$_POST["hosttype$i"]))
-							$input_errors[] = 'On reverse zones, valid record types are NS or PTR';
-						}
-					if (preg_match("/(MX|NS)/",$_POST["hosttype$i"]))
-						$_POST["hostname$i"]="";
-					if (!preg_match("/(MX|NS)/",$_POST["hosttype$i"]) && $_POST["hostname$i"]=="")
-						$input_errors[] = 'Record cannot be empty for '.$_POST["hosttype$i"].' type ';
-					if ($_POST["hosttype$i"]=="MX" && $_POST["hostvalue$i"]=="")
-						$_POST["hostvalue$i"]="10";
-					if ($_POST["hosttype$i"]!="MX" && $_POST["hostvalue$i"]!="")
-						$_POST["hostvalue$i"]="";
-					if ($_POST["hostdst$i"]=="")
-						$input_errors[] = 'Alias or IP address cannot be empty.';
-				}
-			}
-		}
 }
 
-function bind_sync(){
+$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+if ($pf_version > 2.0) {
+	define('BIND_LOCALBASE', '/usr/pbi/bind-'.php_uname("m"));
+} else {
+	define('BIND_LOCALBASE', '/usr/local');
+}
+
+define('CHROOT_LOCALBASE', '/cf/named');
+
+function bind_zone_validate($post, &$input_errors)
+{
+	if (array_key_exists("mail", $_POST)) {
+		$_POST['mail'] = preg_replace("/@/", ".", $post['mail']);
+	}
+
+	switch ($_POST['type']) {
+		case 'slave':
+			if ($_POST['slaveip'] == "") {
+				$input_errors[] = 'The field \'Master Zone IP\' is required for slave zones.';
+			}
+			break;
+		case 'forward':
+			if ($_POST['forwarders'] == "") {
+				$input_errors[] = 'The field \'Forwarders\' is required for forward zones.';
+			}
+			break;
+		case 'redirect':
+			$_POST['tll'] = 300;
+			$_POST['refresh'] = 0;
+			$_POST['serial'] = 0;
+			$_POST['retry'] = 0;
+			$_POST['expire'] = 0;
+			$_POST['minimum'] = 0;
+			if ($_POST['mail'] == '') {
+				$input_errors[] = "The field 'Mail Admin Zone' is required for {$_POST['type']} zones.";
+			}
+		default:
+			if ($_POST['nameserver'] == '') {
+				$input_errors[] = "The field 'Name server' is required for {$_POST['type']} zones.";
+			}
+			for ($i = 0; $i < count($_POST); $i++) {
+				if (array_key_exists("hostname$i", $_POST)) {
+					if ($_POST['reverso'] == "on") {
+						$_POST["hostvalue$i"] = "";
+						if (!preg_match("/(PTR|NS)/", $_POST["hosttype$i"])) {
+							$input_errors[] = 'On reverse zones, valid record types are NS or PTR';
+						}
+					}
+					if (preg_match("/(MX|NS)/", $_POST["hosttype$i"])) {
+						$_POST["hostname$i"] = "";
+					}
+					if (!preg_match("/(MX|NS)/", $_POST["hosttype$i"]) && $_POST["hostname$i"] == "") {
+						$input_errors[] = 'Record cannot be empty for '.$_POST["hosttype$i"].' type ';
+					}
+					if ($_POST["hosttype$i"] == "MX" && $_POST["hostvalue$i"] == "") {
+						$_POST["hostvalue$i"] = "10";
+					}
+					if ($_POST["hosttype$i"] != "MX" && $_POST["hostvalue$i"] != "") {
+						$_POST["hostvalue$i"] = "";
+					}
+					if ($_POST["hostdst$i"] == "") {
+						$input_errors[] = 'Alias or IP address cannot be empty.';
+					}
+				}
+			}
+			break;
+	}
+}
+
+function bind_sync()
+{
 	global $config;
 	conf_mount_rw();
 	//create rndc
-	$rndc_confgen="/usr/local/sbin/rndc-confgen";
-	if (!file_exists(BIND_LOCALBASE."/etc/rndc-confgen.pfsense") && file_exists($rndc_confgen)){
-		exec("$rndc_confgen ",$rndc_conf);
-		foreach($rndc_conf as $line)
-			$confgen_file.="$line\n";
-		file_put_contents(BIND_LOCALBASE."/etc/rndc-confgen.pfsense",$confgen_file);
+	$rndc_confgen = "/usr/local/sbin/rndc-confgen";
+	if (!file_exists(BIND_LOCALBASE."/etc/rndc-confgen.pfsense") && file_exists($rndc_confgen)) {
+		exec("$rndc_confgen ", $rndc_conf);
+		foreach ($rndc_conf as $line) {
+			$confgen_file .= "$line\n";
 		}
-	if (file_exists(BIND_LOCALBASE."/etc/rndc-confgen.pfsense")){
-		$rndc_conf=file(BIND_LOCALBASE."/etc/rndc-confgen.pfsense");
-		$confgen="rndc.conf";
-		$rndc_bindconf="";
-		foreach ($rndc_conf as $line){
-			if ($confgen =="rndc.conf"){
-				if (!preg_match ("/^#/",$line))
-					$rndc_file.=$line;
+		file_put_contents(BIND_LOCALBASE."/etc/rndc-confgen.pfsense", $confgen_file);
+	}
+	if (file_exists(BIND_LOCALBASE."/etc/rndc-confgen.pfsense")) {
+		$rndc_conf = file(BIND_LOCALBASE."/etc/rndc-confgen.pfsense");
+		$confgen = "rndc.conf";
+		$rndc_bindconf = "";
+		foreach ($rndc_conf as $line) {
+			if ($confgen == "rndc.conf") {
+				if (!preg_match("/^#/", $line)) {
+					$rndc_file .= $line;
 				}
-			else{
-				if (!preg_match ("/named.conf/",$line))
-					$rndc_bindconf.=preg_replace('/#/',"",$line);
+			} else {
+				if (!preg_match("/named.conf/", $line)) {
+					$rndc_bindconf .= preg_replace('/#/', "", $line);
 				}
-			if (preg_match("/named.conf/",$line)){
-				$confgen="named.conf";
-				file_put_contents(BIND_LOCALBASE."/etc/rndc.conf",$rndc_file);
-				}
+			}
+			if (preg_match("/named.conf/", $line)) {
+				$confgen = "named.conf";
+				file_put_contents(BIND_LOCALBASE."/etc/rndc.conf", $rndc_file);
+			}
 		}
 	}
-	 
-	$bind = $config["installedpackages"]["bind"]["config"][0];
+
+	$bind = $config['installedpackages']['bind']['config'][0];
 	$bind_enable = $bind['enable_bind'];
 	$bind_forwarder = $bind['bind_forwarder'];
 	$forwarder_ips = $bind['bind_forwarder_ips'];
-	$ram_limit = ($bind['bind_ram_limit']?$bind['bind_ram_limit']:"256M");
+	$ram_limit = ($bind['bind_ram_limit'] ? $bind['bind_ram_limit'] : "256M");
 	$hide_version = $bind['bind_hide_version'];
 	$bind_notify = $bind['bind_notify'];
 	$custom_options = base64_decode($bind['bind_custom_options']);
 	$bind_logging = $bind['bind_logging'];
-	$bind_conf ="#Bind pfsense configuration\n";
-	$bind_conf .="#Do not edit this file!!!\n\n";
+	$bind_conf = "#Bind pfsense configuration\n";
+	$bind_conf .= "#Do not edit this file!!!\n\n";
 	$bind_conf .= "$rndc_bindconf\n";
 	$bind_conf .= <<<EOD
 
@@ -145,280 +162,310 @@ options {
 	pid-file "/var/run/named/pid";
 	statistics-file "/var/log/named.stats";
 	max-cache-size {$ram_limit};
-	
+
 EOD;
 	// check response rate limit option
 	//https://kb.isc.org/article/AA-01000/0/A-Quick-Introduction-to-Response-Rate-Limiting.html
 	//http://ss.vix.su/~vjs/rl-arm.html
-	if ($bind['rate_enabled']=="on"){
-		$rate_limit=($bind['rate_limit']?$bind['rate_limit']:"15");
-		$log_only=($bind['log_only']=="no"?"no":"yes");
+	if ($bind['rate_enabled'] == "on") {
+		$rate_limit = ($bind['rate_limit'] ? $bind['rate_limit'] : "15");
+		$log_only = ($bind['log_only'] == "no" ? "no" : "yes");
 		$bind_conf .= <<<EOD
-		rate-limit {
-			responses-per-second {$rate_limit};
-			log-only {$log_only};
-    		};
-    	
+	rate-limit {
+		responses-per-second { $rate_limit };
+		log-only { $log_only };
+	};
+
 EOD;
 	}
 	//check ips to listen on
-	if (preg_match("/All/",$bind['listenon'])){
-		$bind_listenonv6="any;";
-		$bind_listenon="any;";
-		}
-	else{
-		$bind_listenonv6="";
-		$bind_listenon ="";
-		foreach (explode(',',$bind['listenon']) as $listenon){
-			if (is_ipaddrv6($listenon))
+	if (preg_match("/All/", $bind['listenon'])) {
+		$bind_listenonv6 = "any;";
+		$bind_listenon = "any;";
+	} else {
+		$bind_listenonv6 = "";
+		$bind_listenon = "";
+		foreach (explode(',', $bind['listenon']) as $listenon) {
+			if (is_ipaddrv6($listenon)) {
 				$bind_listenonv6 .= $listenon."; ";
-			elseif (is_ipaddr($listenon))
+			} elseif (is_ipaddr($listenon)) {
 				$bind_listenon .= $listenon."; ";
-			else{
-				$listenon=(pfSense_get_interface_addresses(convert_friendly_interface_to_real_interface_name($listenon)));
-				if (is_ipaddr($listenon['ipaddr']))
+			} else {
+				$listenon = (pfSense_get_interface_addresses(convert_friendly_interface_to_real_interface_name($listenon)));
+				if (is_ipaddr($listenon['ipaddr'])) {
 					$bind_listenon .= $listenon['ipaddr']."; ";
-				if(is_ipaddrv6($listenon['ipaddr6']))
+				}
+				if (is_ipaddrv6($listenon['ipaddr6'])) {
 					$bind_listenonv6 .= $listenon['ipaddr6']."; ";
-			}	
-		}
-	}
-	$bind_listenonv6=($bind_listenonv6==""?"none;":$bind_listenonv6);
-	$bind_listenon=($bind_listenon==""?"none;":$bind_listenon);
-	//print "<PRE>$bind_listenonv6 $bind_listenon";
-	if (key_exists("ipv6allow",$config['system'])){
-		$bind_conf .="\t\tlisten-on-v6 { $bind_listenonv6 };\n";
-		}
-	$bind_conf .="\t\tlisten-on { $bind_listenon };\n";
-
-	#forwarder config
-	if ($bind_forwarder == on)
-		$bind_conf .="\t\tforwarders { $forwarder_ips };\n";
-	if ($bind_notify == on)
-		$bind_conf .="\t\tnotify yes;\n"; 
-	if ($hide_version == on)
-		$bind_conf .="\t\tversion none;\n";
-
-	$bind_conf .= preg_replace("/^/m","\t\t",$custom_options); 
-	$bind_conf .= "\n\t};\n\n";
-	
-	if ($bind_logging == on){
-		//check if bind is included on syslog
-		$syslog_files=array("/etc/inc/system.inc","/var/etc/syslog.conf");
-		$restart_syslog=0;
-		foreach ($syslog_files as $syslog_file){
-			$syslog_file_data=file_get_contents($syslog_file);
-			if ( !preg_match("/dnsmasq,named,filterdns/",$syslog_file_data) || !preg_match("/'dnsmasq','named','filterdns'/",$syslog_file_data) ) {
-				$syslog_file_data=preg_replace("/dnsmasq,filterdns/","dnsmasq,named,filterdns",$syslog_file_data);
-				$syslog_file_data=preg_replace("/'dnsmasq','filterdns'/","'dnsmasq','named','filterdns'",$syslog_file_data);
-				file_put_contents($syslog_file,$syslog_file_data);
-				$restart_syslog++;
 				}
 			}
-		if ($restart_syslog > 0){
-			system("/usr/bin/killall -HUP syslogd");
 		}
-		$log_categories=explode(",",$bind['log_options']);
-		$log_severity=($bind['log_severity']?$bind['log_severity']:'default');
-		if (sizeof($log_categories) > 0 && $log_categories[0]!=""){
-			$bind_conf .= <<<EOD
-			
-		logging {
-			channel custom {
-				syslog daemon;
-				print-time no;
-				print-severity yes;
-				print-category yes;
-				severity {$log_severity};
-				};
+	}
+	$bind_listenonv6 = ($bind_listenonv6 == "" ? "none;" : $bind_listenonv6);
+	$bind_listenon = ($bind_listenon == "" ? "none;" : $bind_listenon);
+	// print "<PRE>$bind_listenonv6 $bind_listenon";
+	if (array_key_exists("ipv6allow", $config['system'])) {
+		$bind_conf .= "\t\tlisten-on-v6 { $bind_listenonv6 };\n";
+	}
+	$bind_conf .= "\tlisten-on { $bind_listenon };\n";
 
-EOD;
-		foreach ($log_categories as $category)
-			$bind_conf .="\t\t\tcategory $category\t{custom;};\n";
-		$bind_conf .="\t\t};\n\n";				
-				}
-		 }
-	else {
-		$bind_conf .="\t\tlogging { category default { null; }; };\n\n";				
+	// forwarder config
+	if ($bind_forwarder == 'on') {
+		$bind_conf .= "\t\tforwarders { $forwarder_ips };\n";
+	}
+	if ($bind_notify == 'on') {
+		$bind_conf .= "\t\tnotify yes;\n";
+	}
+	if ($hide_version == 'on') {
+		$bind_conf .= "\t\tversion none;\n";
 	}
 
-	#Config Zone domain
-	if(!is_array($config["installedpackages"]["bindacls"]) || !is_array($config["installedpackages"]["bindacls"]["config"])){
-		$config["installedpackages"]["bindacls"]["config"][] =
-			array("name"=>"none","description"=>"BIND Built-in ACL","row"=>array("value"=>"","description"=>""));
-		$config["installedpackages"]["bindacls"]["config"][] =
-			array("name"=>"any","description"=>"BIND Built-in ACL","row"=>array("value"=>"","description"=>""));
-		$config["installedpackages"]["bindacls"]["config"][] =
-			array("name"=>"localhost","description"=>"BIND Built-in ACL","row"=>array("value"=>"","description"=>""));
-		$config["installedpackages"]["bindacls"]["config"][] =
-			array("name"=>"localnets","description"=>"BIND Built-in ACL","row"=>array("value"=>"","description"=>""));
-		write_config("Create BIND Built-in ACLs");
+	$bind_conf .= preg_replace("/^/m", "\t", $custom_options);
+	$bind_conf .= "\n\t};\n\n";
+
+	if ($bind_logging == 'on') {
+		//check if bind is included on syslog
+		$syslog_files = array("/etc/inc/system.inc", "/var/etc/syslog.conf");
+		$restart_syslog = 0;
+		foreach ($syslog_files as $syslog_file) {
+			$syslog_file_data = file_get_contents($syslog_file);
+			if (!preg_match("/dnsmasq,named,filterdns/", $syslog_file_data) || !preg_match("/'dnsmasq','named','filterdns'/", $syslog_file_data)) {
+				$syslog_file_data = preg_replace("/dnsmasq,filterdns/", "dnsmasq,named,filterdns", $syslog_file_data);
+				$syslog_file_data = preg_replace("/'dnsmasq','filterdns'/", "'dnsmasq','named','filterdns'", $syslog_file_data);
+				file_put_contents($syslog_file, $syslog_file_data);
+				$restart_syslog++;
+			}
 		}
-	$bindacls = $config["installedpackages"]["bindacls"]["config"];
-	for ($i=0; $i<sizeof($bindacls); $i++)
-	{
+		if ($restart_syslog > 0) {
+			system("/usr/bin/killall -HUP syslogd");
+		}
+		$log_categories = explode(",", $bind['log_options']);
+		$log_severity = ($bind['log_severity'] ? $bind['log_severity'] : 'default');
+		if (sizeof($log_categories) > 0 && $log_categories[0] != "") {
+			$bind_conf .= <<<EOD
+
+logging {
+	channel custom {
+		syslog daemon;
+		print-time no;
+		print-severity yes;
+		print-category yes;
+		severity {$log_severity};
+		};
+
+EOD;
+			foreach ($log_categories as $category) {
+				$bind_conf .= "\t\t\tcategory $category\t{custom;};\n";
+			}
+			$bind_conf .= "\t\t};\n\n";
+		}
+	} else {
+		$bind_conf .= "\t\tlogging { category default { null; }; };\n\n";
+	}
+
+	// Config Zone domain
+
+	// Add ACLS
+	if (!is_array($config['installedpackages']['bindacls']) || !is_array($config['installedpackages']['bindacls']['config'])) {
+		$config['installedpackages']['bindacls']['config'][] =
+			array("name" => "none", "description" => "BIND Built-in ACL", "row" => array("value" => "", "description" => ""));
+		$config['installedpackages']['bindacls']['config'][] =
+			array("name" => "any", "description" => "BIND Built-in ACL", "row" => array("value" => "", "description" => ""));
+		$config['installedpackages']['bindacls']['config'][] =
+			array("name" => "localhost", "description" => "BIND Built-in ACL", "row" => array("value" => "", "description" => ""));
+		$config['installedpackages']['bindacls']['config'][] =
+			array("name" => "localnets", "description" => "BIND Built-in ACL", "row" => array("value" => "", "description" => ""));
+		write_config("Create BIND Built-in ACLs");
+	}
+	$bindacls = $config['installedpackages']['bindacls']['config'];
+	for ($i = 0; $i < sizeof($bindacls); $i++) {
 		$aclname = $bindacls[$i]['name'];
 		$aclhost = $bindacls[$i]['row'];
-		if($aclname != "none" && $aclname != "any" && $aclname != "localhost" && $aclname != "localnets"){
-			$bind_conf .= "acl \"$aclname\" {\n";	
-			for ($u=0; $u<sizeof($aclhost); $u++)
-			{
+		if ($aclname != "none" && $aclname != "any" && $aclname != "localhost" && $aclname != "localnets") {
+			$bind_conf .= "acl \"$aclname\" {\n";
+			for ($u = 0; $u < sizeof($aclhost); $u++) {
 				$aclhostvalue = $aclhost[$u]['value'];
 				$bind_conf .= "\t$aclhostvalue;\n";
 			}
 			$bind_conf .= "};\n\n";
-		}	
+		}
 	}
- 
-	if(is_array($config["installedpackages"]["bindviews"]))
-		$bindview = $config["installedpackages"]["bindviews"]["config"];
-	else
-		$bindview =array();
-		
-	for ($i=0; $i<sizeof($bindview); $i++) 
-	{
-		$views = $config["installedpackages"]["bindviews"]["config"][$i];
-		$viewname = $views['name'];
-		$viewrecursion = $views['recursion']; 
-		if($views['match-clients'] == '')
-			$viewmatchclients = "none";
-		else
-			$viewmatchclients = str_replace(',','; ',$views['match-clients']); 	
-		if($views['allow-recursion'] == '')
-			$viewallowrecursion = "none";
-		else
-			$viewallowrecursion = str_replace(',','; ',$views['allow-recursion']); 	
-		$viewcustomoptions = base64_decode($views['bind_custom_options']);
-		
-		$bind_conf .= "view \"$viewname\" { \n\n"; 
-		$bind_conf .= "\trecursion $viewrecursion;\n"; 
-		$bind_conf .= "\tmatch-clients { $viewmatchclients;};\n"; 
-		$bind_conf .= "\tallow-recursion { $viewallowrecursion;};\n"; 
-		$bind_conf .= "\t$viewcustomoptions\n\n"; 
-			
-		if(is_array($config["installedpackages"]["bindzone"])) 
-			$bindzone = $config["installedpackages"]["bindzone"]["config"];
-		else
-			$bindzone =array();
 
-		$write_config=0;
-		for ($x=0; $x<sizeof($bindzone); $x++)
-		{
+	// Add Views
+	if (is_array($config['installedpackages']['bindviews'])) {
+		$bindview = $config['installedpackages']['bindviews']['config'];
+	} else {
+		$bindview = array();
+	}
+
+	for ($i = 0; $i < sizeof($bindview); $i++) {
+		$views = $config['installedpackages']['bindviews']['config'][$i];
+		$viewname = $views['name'];
+		$viewrecursion = $views['recursion'];
+		if ($views['match-clients'] == '') {
+			$viewmatchclients = "none";
+		} else {
+			$viewmatchclients = str_replace(',', '; ', $views['match-clients']);
+		}
+		if ($views['allow-recursion'] == '') {
+			$viewallowrecursion = "none";
+		} else {
+			$viewallowrecursion = str_replace(',', '; ', $views['allow-recursion']);
+		}
+		$viewcustomoptions = base64_decode($views['bind_custom_options']);
+
+		$bind_conf .= "view \"$viewname\" { \n\n";
+		$bind_conf .= "\trecursion $viewrecursion;\n";
+		$bind_conf .= "\tmatch-clients { $viewmatchclients; };\n";
+		$bind_conf .= "\tallow-recursion { $viewallowrecursion; };\n";
+		$bind_conf .= "\t$viewcustomoptions\n\n";
+
+		if (is_array($config['installedpackages']['bindzone'])) {
+			$bindzone = $config['installedpackages']['bindzone']['config'];
+		} else {
+			$bindzone = array();
+		}
+
+		// Add Zones in View
+		$write_config = 0;
+		for ($x = 0; $x < sizeof($bindzone); $x++) {
 			$zone = $bindzone[$x];
-			if ($zone['disabled']=="on"){
+			if ($zone['disabled'] == "on") {
 				continue;
-				}
+			}
 			$zonename = $zone['name'];
-			if ($zonename=="."){
-				$custom_root_zone[$i]=true;
+			if ($zonename == ".") {
+				$custom_root_zone[$i] = true;
 			}
 			$zonetype = $zone['type'];
 			$zoneview = $zone['view'];
 			$zonecustom = base64_decode($zone['custom']);
 			$zoneipslave = $zone['slaveip'];
-			$zoneforwarders=$zone['forwarders'];
+			$zoneforwarders = $zone['forwarders'];
 			$zonereverso = $zone['reverso'];
-			
-			if (!(is_dir(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview")))
-            	mkdir(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview",0755,true);
-            					
-			if($zone['allowupdate'] == '')
-				$zoneallowupdate = "none";
-			else
-				$zoneallowupdate = str_replace(',','; ',$zone['allowupdate']); 	
-			if($zone['allowquery'] == '')
-				$zoneallowquery = "none";
-			else
-				$zoneallowquery = str_replace(',','; ',$zone['allowquery']); 	
-			if($zone['allowtransfer'] == '')
-				$zoneallowtransfer = "none";
-			else
-				$zoneallowtransfer = str_replace(',','; ',$zone['allowtransfer']); 	
 
-				if ($zoneview == $viewname){
-					if($zonereverso == "on")
-				 		$bind_conf .= "\tzone \"$zonename.in-addr.arpa\" {\n";
-				  	else
-						$bind_conf .= "\tzone \"$zonename\" {\n";
-        		
-					$bind_conf .= "\t\ttype $zonetype;\n";
-					if ($zonetype != "forward")
-        				$bind_conf .= "\t\tfile \"/etc/namedb/$zonetype/$zoneview/$zonename.DB\";\n";
-        			switch ($zonetype){
-        				case "slave":
-        				$bind_conf .= "\t\tmasters { $zoneipslave; };\n";
-        				$bind_conf .= "\t\tallow-transfer { $zoneallowtransfer;};\n";
-        				$bind_conf .= "\t\tnotify no;\n";
-        				break;
-        				case "forward":
-        				$bind_conf .= "\t\tforward only;\n";
-        				$bind_conf .= "\t\tforwarders { $zoneforwarders; };\n";
-        				break;
-        				case "redirect":
-							$bind_conf .= "\t\t# While using redirect zones,NXDOMAIN Redirection will not override DNSSEC\n";
-							$bind_conf .= "\t\t# If the client has requested DNSSEC records (DO=1) and the NXDOMAIN response is signed then no substitution will occur\n";
-							$bind_conf .= "\t\t# https://kb.isc.org/article/AA-00376/192/BIND-9.9-redirect-zones-for-NXDOMAIN-redirection.html\n";
-        				break;
-        				default:
-						$bind_conf .= "\t\tallow-update { $zoneallowupdate;};\n"; 
-						$bind_conf .= "\t\tallow-query { $zoneallowquery;};\n"; 
-						$bind_conf .= "\t\tallow-transfer { $zoneallowtransfer;};\n";
-	        			if ($zone['dnssec']=="on"){
-	        				//https://kb.isc.org/article/AA-00626/
-	        				$bind_conf .="\n\t\t# look for dnssec keys here:\n";
-	        				$bind_conf .="\t\tkey-directory \"/etc/namedb/keys\";\n\n";
-	        				$bind_conf .="\t\t# publish and activate dnssec keys:\n";
-	        				$bind_conf .="\t\tauto-dnssec maintain;\n\n";
-	        				$bind_conf .="\t\t# use inline signing:\n";
-	        				$bind_conf .="\t\tinline-signing yes;\n\n";
-	        				}
-	        			}
-				 	if ($zonecustom != '')
-        				$bind_conf .= "\t\t$zonecustom\n";
-        				
-					$bind_conf .= "\t};\n\n";
-        
-					switch($zonetype){
-					  case "redirect":
-					  case "master":
-					  	//check/update slave dir permission
-						chown(CHROOT_LOCALBASE."/etc/namedb/$zonetype","bind");
-						chown(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview","bind");
-						$zonetll = ($zone['tll']?$zone['tll']:"43200");
-						$zonemail = ($zone['mail']?$zone['mail']:"zonemaster.{$zonename}");
-						$zonemail = preg_replace("/@/",".",$zonemail);				
+			// Ensure zone view folder exists
+			if (!(is_dir(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview"))) {
+				mkdir(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview", 0755, true);
+			}
+
+			if ($zone['allowupdate'] == '') {
+				$zoneallowupdate = "none";
+			} else {
+				$zoneallowupdate = str_replace(',', '; ', $zone['allowupdate']);
+			}
+			if ($zone['allowquery'] == '') {
+				$zoneallowquery = "none";
+			} else {
+				$zoneallowquery = str_replace(',', '; ', $zone['allowquery']);
+			}
+			if ($zone['allowtransfer'] == '') {
+				$zoneallowtransfer = "none";
+			} else {
+				$zoneallowtransfer = str_replace(',', '; ', $zone['allowtransfer']);
+			}
+
+			if ($zoneview == $viewname) {
+				// Add zone name
+				if ($zonereverso == "on") {
+					$bind_conf .= "\tzone \"$zonename.in-addr.arpa\" {\n";
+				} else {
+					$bind_conf .= "\tzone \"$zonename\" {\n";
+				}
+
+				// Add zone file (if not forwarder)
+				$bind_conf .= "\t\ttype $zonetype;\n";
+				if ($zonetype != "forward") {
+					$bind_conf .= "\t\tfile \"/etc/namedb/$zonetype/$zoneview/$zonename.DB\";\n";
+				}
+
+				// Add zone statements
+				switch ($zonetype) {
+					case 'slave':
+						$bind_conf .= "\t\tmasters { $zoneipslave; };\n";
+						$bind_conf .= "\t\tallow-transfer { $zoneallowtransfer; };\n";
+						$bind_conf .= "\t\tnotify no;\n";
+						break;
+					case 'forward':
+						$bind_conf .= "\t\tforward only;\n";
+						$bind_conf .= "\t\tforwarders { $zoneforwarders; };\n";
+						break;
+					case 'redirect':
+						$bind_conf .= "\t\t# While using redirect zones,NXDOMAIN Redirection will not override DNSSEC\n";
+						$bind_conf .= "\t\t# If the client has requested DNSSEC records (DO=1) and the NXDOMAIN response is signed then no substitution will occur\n";
+						$bind_conf .= "\t\t# https://kb.isc.org/article/AA-00376/192/BIND-9.9-redirect-zones-for-NXDOMAIN-redirection.html\n";
+						break;
+					default:
+						$bind_conf .= "\t\tallow-update { $zoneallowupdate; };\n";
+						$bind_conf .= "\t\tallow-query { $zoneallowquery; };\n";
+						$bind_conf .= "\t\tallow-transfer { $zoneallowtransfer; };\n";
+						if ($zone['dnssec'] == "on") {
+							//https://kb.isc.org/article/AA-00626/
+							$bind_conf .= "\n\t\t# look for dnssec keys here:\n";
+							$bind_conf .= "\t\tkey-directory \"/etc/namedb/keys\";\n\n";
+							$bind_conf .= "\t\t# publish and activate dnssec keys:\n";
+							$bind_conf .= "\t\tauto-dnssec maintain;\n\n";
+							$bind_conf .= "\t\t# use inline signing:\n";
+							$bind_conf .= "\t\tinline-signing yes;\n\n";
+						}
+						break;
+				}
+
+				// Add custom zone statements
+				if ($zonecustom != '') {
+					$bind_conf .= "\t\t$zonecustom\n";
+				}
+
+				$bind_conf .= "\t};\n\n";
+
+				// Create zone config DB file
+				switch ($zonetype) {
+					case 'master':
+					case 'redirect':
+						// check/update slave dir permission
+						chown(CHROOT_LOCALBASE."/etc/namedb/$zonetype", "bind");
+						chown(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview", "bind");
+						$zonetll = ($zone['tll'] ? $zone['tll'] : "43200");
+						$zonemail = ($zone['mail'] ? $zone['mail'] : "zonemaster.{$zonename}");
+						$zonemail = preg_replace("/@/", ".", $zonemail);
 						$zoneserial = $zone['serial'];
-						$zonerefresh = ($zone['refresh']?$zone['refresh']:"3600");		
-						$zoneretry = ($zone['retry']?$zone['retry']:"600");
-						$zoneexpire = ($zone['expire']?$zone['expire']:"86400");
-						$zoneminimum = ($zone['minimum']?$zone['minimum']:"3600");
+						$zonerefresh = ($zone['refresh'] ? $zone['refresh'] : "3600");
+						$zoneretry = ($zone['retry'] ? $zone['retry'] : "600");
+						$zoneexpire = ($zone['expire'] ? $zone['expire'] : "86400");
+						$zoneminimum = ($zone['minimum'] ? $zone['minimum'] : "3600");
 						$zonenameserver = $zone['nameserver'];
 						$zoneipns = $zone['ipns'];
 						$zonereverso = $zone['reverso'];
-						if($zone['allowupdate'] == '')
+						if ($zone['allowupdate'] == '') {
 							$zoneallowupdate = "none";
-						else
-							$zoneallowupdate = str_replace(',','; ',$zone['allowupdate']);
-						if($zone['allowquery'] == '')
+						} else {
+							$zoneallowupdate = str_replace(',', '; ', $zone['allowupdate']);
+						}
+						if ($zone['allowquery'] == '') {
 							$zoneallowquery = "none";
-						else
-							$zoneallowquery = str_replace(',','; ',$zone['allowquery']);
-						if($zone['allowtransfer'] == '')
+						} else {
+							$zoneallowquery = str_replace(',', '; ', $zone['allowquery']);
+						}
+						if ($zone['allowtransfer'] == '') {
 							$zoneallowtransfer = "none";
-						else
-							$zoneallowtransfer = str_replace(',','; ',$zone['allowtransfer']);
+						} else {
+							$zoneallowtransfer = str_replace(',', '; ', $zone['allowtransfer']);
+						}
+
 						$zone_conf = "\$TTL {$zonetll}\n;\n";
-						if($zonereverso == "on")
+						if ($zonereverso == "on") {
 							$zone_conf .= "\$ORIGIN {$zonename}.in-addr.arpa.\n\n";
-						else
+						} else {
 							$zone_conf .= "\$ORIGIN {$zonename}.\n\n";
+						}
 						$zone_conf .= ";\tDatabase file {$zonename}.DB for {$zonename} zone.\n";
 						$zone_conf .= ";\tDo not edit this file!!!\n";
 						$zone_conf .= ";\tZone version {$zoneserial}\n;\n";
-					 	if($zonereverso == "on" || $zonetype =="redirect")
+						if ($zonereverso == "on" || $zonetype == "redirect") {
 							$zone_conf .= "@\t IN  SOA $zonenameserver. \t $zonemail. (\n";
-						else
+						} else {
 							$zone_conf .= "$zonename.\t IN  SOA $zonenameserver. \t $zonemail. (\n";
+						}
 
 						$zone_conf .= "\t\t$zoneserial ; serial\n";
 						$zone_conf .= "\t\t$zonerefresh ; refresh\n";
@@ -427,30 +474,31 @@ EOD;
 						$zone_conf .= "\t\t$zoneminimum ; default_ttl\n\t\t)\n\n";
 						$zone_conf .= ";\n; Zone Records\n;\n";
 
-					 	if($zonereverso == "on")
+						if ($zonereverso == "on") {
 							$zone_conf .= "\t IN NS \t$zonenameserver.\n";
-						else{
+						} else {
 							$zone_conf .= "@ \t IN NS \t$zonenameserver.\n";
-							if ($zoneipns !="")
+							if ($zoneipns != "") {
 								$zone_conf .= "@ \t IN A \t$zoneipns\n";
+							}
 						}
-						for ($y=0; $y<sizeof($zone['row']); $y++)
-						{
-							$hostname = (preg_match("/(MX|NS)/",$zone['row'][$y]['hosttype'])?"@":$zone['row'][$y]['hostname']);
+						for ($y = 0; $y < sizeof($zone['row']); $y++) {
+							$hostname = (preg_match("/(MX|NS)/", $zone['row'][$y]['hosttype']) ? "@" : $zone['row'][$y]['hostname']);
 							$hosttype = $zone['row'][$y]['hosttype'];
 							$hostdst = $zone['row'][$y]['hostdst'];
-							if (preg_match("/[a-zA-Z]/",$hostdst) && !preg_match("/(TXT|SPF|AAAA)/",$hosttype))
+							if (preg_match("/[a-zA-Z]/", $hostdst) && !preg_match("/(TXT|SPF|AAAA)/", $hosttype)) {
 								$hostdst .= ".";
+							}
 							$hostvalue = $zone['row'][$y]['hostvalue'];
-							
+
 							$zone_conf .= "$hostname \t IN $hosttype $hostvalue \t$hostdst\n";
 						}
 
-						# Register DHCP static mappings
-						if (($zone[regdhcpstatic] == 'on') && is_array($config['dhcpd'])) {
-							$zoneparts = array_reverse(explode('.',$zonename));
+						// Register DHCP static mappings
+						if (($zone['regdhcpstatic'] == 'on') && is_array($config['dhcpd'])) {
+							$zoneparts = array_reverse(explode('.', $zonename));
 							foreach ($config['dhcpd'] as $dhcpif => $dhcpifconf) {
-								if (!isset($dhcpifconf['enable']) || !is_array($dhcpifconf['staticmap']))  {
+								if (!isset($dhcpifconf['enable']) || !is_array($dhcpifconf['staticmap'])) {
 									continue;
 								}
 								foreach ($dhcpifconf['staticmap'] as $host) {
@@ -463,20 +511,20 @@ EOD;
 									} else {
 										continue;
 									}
-									if (!is_hostname($host['hostname']) || !is_ipaddr($host['ipaddr']))  {
+									if (!is_hostname($host['hostname']) || !is_ipaddr($host['ipaddr'])) {
 										continue;
 									}
 									if ($zonereverso == "on") {
-										$parts = explode('.',$host['ipaddr']);
-										$intersect = array_intersect_assoc($parts,$zoneparts);
+										$parts = explode('.', $host['ipaddr']);
+										$intersect = array_intersect_assoc($parts, $zoneparts);
 										if (count($zoneparts) == count($intersect)) {
-											$diff = array_diff_assoc($parts,$zoneparts);
-											$shortaddr = implode('.',array_reverse($diff));
+											$diff = array_diff_assoc($parts, $zoneparts);
+											$shortaddr = implode('.', array_reverse($diff));
 											$zone_conf .= "{$shortaddr}\tIN PTR\t{$host['hostname']}.{$domain}.\n";
 										}
 									} else {
-										$parts = array_reverse(explode('.',$domain));
-										$diff = array_diff_assoc($parts,$zoneparts);
+										$parts = array_reverse(explode('.', $domain));
+										$diff = array_diff_assoc($parts, $zoneparts);
 										if (count($diff) == 0) {
 											$zone_conf .= "{$host['hostname']}\tIN A\t{$host['ipaddr']}\n";
 										}
@@ -485,173 +533,184 @@ EOD;
 							}
 						}
 
-						if ($zone['customzonerecords']!=""){
+						// Add custom zone records
+						if ($zone['customzonerecords'] != "") {
 							$zone_conf .= "\n\n;\n;custom zone records\n;\n".base64_decode($zone['customzonerecords'])."\n";
 						}
+
+						// Save zone configuration DB file
 						file_put_contents(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview/$zonename.DB", $zone_conf);
-						$config["installedpackages"]["bindzone"]["config"][$x][resultconfig]=base64_encode($zone_conf);
+
+						$config['installedpackages']['bindzone']['config'][$x]['resultconfig'] = base64_encode($zone_conf);
 						$write_config++;
 						//check dnssec keys creation for master zones
-        				if($zone['dnssec']=="on"){
-	        				$zone_found=0;
-	        				foreach (glob(CHROOT_LOCALBASE."/etc/namedb/keys/*{$zonename}*key",GLOB_NOSORT) as $filename){
+						if ($zone['dnssec'] == "on") {
+							$zone_found = 0;
+							foreach (glob(CHROOT_LOCALBASE."/etc/namedb/keys/*{$zonename}*key", GLOB_NOSORT) as $filename) {
 								$zone_found++;
-	        					}
-							if ($zone_found==0){
-								$key_restored=0;
-								if(is_array($config['installedpackages']['dnsseckeys']) && is_array($config['installedpackages']['dnsseckeys']['config'])){
-									foreach ($config['installedpackages']['dnsseckeys']['config']as $filer)
-										if (preg_match ("/K$zonename\.+/",$filer['fullfile'])){
-											file_put_contents($filer['fullfile'],base64_decode($filer['filedata']),LOCK_EX);
-											chmod($filer['fullfile'],0700);
-											chown($filer['fullfile'],"bind");
+							}
+							if ($zone_found == 0) {
+								$key_restored = 0;
+								if (is_array($config['installedpackages']['dnsseckeys']) && is_array($config['installedpackages']['dnsseckeys']['config'])) {
+									foreach ($config['installedpackages']['dnsseckeys']['config'] as $filer) {
+										if (preg_match("/K$zonename\.+/", $filer['fullfile'])) {
+											file_put_contents($filer['fullfile'], base64_decode($filer['filedata']), LOCK_EX);
+											chmod($filer['fullfile'], 0700);
+											chown($filer['fullfile'], "bind");
 											$key_restored++;
-											}
 										}
-								if ($key_restored > 0){
-									log_error("[bind] {$key_restored} DNSSEC keys restored from XML backup for {$zonename} zone.");
 									}
-								$dnssec_bin="/usr/local/sbin/dnssec-keygen";
-								if (file_exists($dnssec_bin) && $key_restored==0){
-									exec("{$dnssec_bin} -K ".CHROOT_LOCALBASE."/etc/namedb/keys {$zonename}",$kout);
-									exec("{$dnssec_bin} -K ".CHROOT_LOCALBASE."/etc/namedb/keys -fk {$zonename}",$kout);
-									foreach($kout as $filename){
-										chown(CHROOT_LOCALBASE."/etc/namedb/keys/{$filename}.key","bind");
-										chown(CHROOT_LOCALBASE."/etc/namedb/keys/{$filename}.private","bind");
-										}
-									log_error("[bind] DNSSEC keys for {$zonename} created.");
-									}
-	        					}
-	        				//get ds keys
-	        				$dsfromkey="/usr/local/sbin/dnssec-dsfromkey";
-	        				foreach (glob(CHROOT_LOCALBASE."/etc/namedb/keys/*{$zonename}*key",GLOB_NOSORT) as $filename) {
-	        						$zone_key=file_get_contents($filename);
-	        						if (preg_match("/IN DNSKEY 257 /",$zone_key) && file_exists($dsfromkey)){
-	        							exec("$dsfromkey $filename",$dsset);
-	        							$config["installedpackages"]["bindzone"]["config"][$x]['dsset']=base64_encode(array_pop($dsset)."\n".array_pop($dsset));
-	        							$write_config++;
-	        							}
 								}
-							//save dnssec keys to xml
-							
-							if($zone['backupkeys']=="on"){
-								$dnssec_keys=0;
-								foreach (glob(CHROOT_LOCALBASE."/etc/namedb/keys/*{$zonename}*",GLOB_NOSORT) as $filename){
-									$file_found=0;
-									if(is_array($config['installedpackages']['dnsseckeys']) && is_array($config['installedpackages']['dnsseckeys']['config'])){
-										foreach ($config['installedpackages']['dnsseckeys']['config']as $filer){
-											if ($filer['fullfile']==$filename)
+								if ($key_restored > 0) {
+									log_error("[bind] {$key_restored} DNSSEC keys restored from XML backup for {$zonename} zone.");
+								}
+								$dnssec_bin = "/usr/local/sbin/dnssec-keygen";
+								if (file_exists($dnssec_bin) && $key_restored == 0) {
+									exec("{$dnssec_bin} -K ".CHROOT_LOCALBASE."/etc/namedb/keys {$zonename}", $kout);
+									exec("{$dnssec_bin} -K ".CHROOT_LOCALBASE."/etc/namedb/keys -fk {$zonename}", $kout);
+									foreach ($kout as $filename) {
+										chown(CHROOT_LOCALBASE."/etc/namedb/keys/{$filename}.key", "bind");
+										chown(CHROOT_LOCALBASE."/etc/namedb/keys/{$filename}.private", "bind");
+									}
+									log_error("[bind] DNSSEC keys for {$zonename} created.");
+								}
+							}
+							// get ds keys
+							$dsfromkey = "/usr/local/sbin/dnssec-dsfromkey";
+							foreach (glob(CHROOT_LOCALBASE."/etc/namedb/keys/*{$zonename}*key", GLOB_NOSORT) as $filename) {
+								$zone_key = file_get_contents($filename);
+								if (preg_match("/IN DNSKEY 257 /", $zone_key) && file_exists($dsfromkey)) {
+									exec("$dsfromkey $filename", $dsset);
+									$config['installedpackages']['bindzone']['config'][$x]['dsset'] = base64_encode(array_pop($dsset)."\n".array_pop($dsset));
+									$write_config++;
+								}
+							}
+
+							// save dnssec keys to xml
+							if ($zone['backupkeys'] == "on") {
+								$dnssec_keys = 0;
+								foreach (glob(CHROOT_LOCALBASE."/etc/namedb/keys/*{$zonename}*", GLOB_NOSORT) as $filename) {
+									$file_found = 0;
+									if (is_array($config['installedpackages']['dnsseckeys']) && is_array($config['installedpackages']['dnsseckeys']['config'])) {
+										foreach ($config['installedpackages']['dnsseckeys']['config'] as $filer) {
+											if ($filer['fullfile'] == $filename) {
 												$file_found++;
 											}
 										}
-									if ($file_found==0){
-										$config['installedpackages']['dnsseckeys']['config'][]=array('fullfile'=> $filename,
-																								'description'=> "bind {$zonename} DNSSEC backup file",
-																								'filedata'=> base64_encode(file_get_contents($filename)));
+									}
+									if ($file_found == 0) {
+										$config['installedpackages']['dnsseckeys']['config'][] = array('fullfile' => $filename,
+											'description' => "bind {$zonename} DNSSEC backup file",
+											'filedata' => base64_encode(file_get_contents($filename)));
 										$write_config++;
 										$dnssec_keys++;
-										}
-									}
-									if($dnssec_keys>0){
-										log_error("[bind] {$dnssec_keys} DNSSEC keys for {$zonename} zone saved on XML config.");
 									}
 								}
-        					}
-					break;
-					case "slave":
-					//check/update slave dir permission
-					chown(CHROOT_LOCALBASE."/etc/namedb/$zonetype","bind");
-					chown(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview","bind");
-					//check if exists slave zone file
-					$rsconfig="";
-					if ($zone['dnssec']=="on"){
-						if (file_exists(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview/$zonename.DB.signed"))
-						exec("/usr/local/sbin/named-checkzone -D -f raw -o - {$zonename} ".CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview/$zonename.DB.signed",$slave_file);
+								if ($dnssec_keys > 0) {
+									log_error("[bind] {$dnssec_keys} DNSSEC keys for {$zonename} zone saved on XML config.");
+								}
+							}
 						}
-					else{
-						if (file_exists(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview/$zonename.DB"))
-							$slave_file=file(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview/$zonename.DB");
+						break;
+					case 'slave':
+						// check/update slave dir permission
+						chown(CHROOT_LOCALBASE."/etc/namedb/$zonetype", "bind");
+						chown(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview", "bind");
+						// check if exists slave zone file
+						$rsconfig = "";
+						if ($zone['dnssec'] == "on") {
+							if (file_exists(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview/$zonename.DB.signed")) {
+								exec("/usr/local/sbin/named-checkzone -D -f raw -o - {$zonename} ".CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview/$zonename.DB.signed", $slave_file);
+							}
+						} else {
+							if (file_exists(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview/$zonename.DB")) {
+								$slave_file = file(CHROOT_LOCALBASE."/etc/namedb/$zonetype/$zoneview/$zonename.DB");
+							}
 						}
-					if (is_array($slave_file)){
-					foreach ($slave_file as $zfile)
-						$rsconfig.= $zfile;
-					$config["installedpackages"]["bindzone"]["config"][$x][resultconfig]=base64_encode($rsconfig);
-					$write_config++;
-					}
-					break;
-					}
+						// TODO is is_array() the best test to use?  is it only checking for existence?
+						if (is_array($slave_file)) {
+							foreach ($slave_file as $zfile) {
+								$rsconfig .= $zfile;
+							}
+						}
+						$config['installedpackages']['bindzone']['config'][$x]['resultconfig'] = base64_encode($rsconfig);
+						$write_config++;
+						break;
 				}
-		}
-		if (!$custom_root_zone[$i]){
-			$bind_conf .="\tzone \".\" {\n";
-			$bind_conf .="\t\ttype hint;\n";
-			$bind_conf .="\t\tfile \"/etc/namedb/named.root\";\n";
-			$bind_conf .= "\t};\n\n";
 			}
-		if($write_config > 0){
+		}
+		if (!$custom_root_zone[$i]) {
+			$bind_conf .= "\tzone \".\" {\n";
+			$bind_conf .= "\t\ttype hint;\n";
+			$bind_conf .= "\t\tfile \"/etc/namedb/named.root\";\n";
+			$bind_conf .= "\t};\n\n";
+		}
+		if ($write_config > 0) {
 			write_config("save result config file for zone on xml");
 		}
 		$bind_conf .= "};\n";
 	}
-	$dirs=array("/etc/namedb/keys","/var/run/named","/var/dump","/var/log","/var/stats","/dev");
-	foreach ($dirs as $dir){
-		if (!is_dir(CHROOT_LOCALBASE .$dir))
-			mkdir(CHROOT_LOCALBASE .$dir,0755,true);
+	$dirs = array("/etc/namedb/keys", "/var/run/named", "/var/dump", "/var/log", "/var/stats", "/dev");
+	foreach ($dirs as $dir) {
+		if (!is_dir(CHROOT_LOCALBASE.$dir)) {
+			mkdir(CHROOT_LOCALBASE.$dir, 0755, true);
 		}
-	//dev dirs for chroot
-	$bind_dev_dir=CHROOT_LOCALBASE."/dev";
-	if (!file_exists("$bind_dev_dir/random")){
-		$dev_dirs=array("null","zero","random","urandom");
-		exec("/sbin/mount -t devfs devfs {$bind_dev_dir}",$dout);
-		exec("/sbin/devfs -m {$bind_dev_dir} ruleset 1",$dout);
-		exec("/sbin/devfs -m {$bind_dev_dir} rule add hide",$dout);
-		foreach ($dev_dirs as $dev_dir)
-			exec("/sbin/devfs -m {$bind_dev_dir} rule add path $dev_dir unhide",$dout);
-		exec("/sbin/devfs -m {$bind_dev_dir} rule applyset",$dout);
 	}
-	//http://www.unixwiz.net/techtips/bind9-chroot.html
-    file_put_contents(CHROOT_LOCALBASE.'/etc/namedb/named.conf', $bind_conf);
-    file_put_contents(CHROOT_LOCALBASE.'/etc/namedb/rndc.conf', $rndc_file);
-    
-	if (!file_exists(CHROOT_LOCALBASE."/etc/namedb/named.root")){
-		//dig +tcp @a.root-servers.net > CHROOT_LOCALBASE."/etc/namedb/named.root"
-		$named_root=file_get_contents("http://www.internic.net/domain/named.root");
-		file_put_contents(CHROOT_LOCALBASE."/etc/namedb/named.root",$named_root,LOCK_EX);
+	// dev dirs for chroot
+	$bind_dev_dir = CHROOT_LOCALBASE."/dev";
+	if (!file_exists("$bind_dev_dir/random")) {
+		$dev_dirs = array("null", "zero", "random", "urandom");
+		exec("/sbin/mount -t devfs devfs {$bind_dev_dir}", $dout);
+		exec("/sbin/devfs -m {$bind_dev_dir} ruleset 1", $dout);
+		exec("/sbin/devfs -m {$bind_dev_dir} rule add hide", $dout);
+		foreach ($dev_dirs as $dev_dir) {
+			exec("/sbin/devfs -m {$bind_dev_dir} rule add path $dev_dir unhide", $dout);
+		}
+		exec("/sbin/devfs -m {$bind_dev_dir} rule applyset", $dout);
 	}
-	if (!file_exists(CHROOT_LOCALBASE."/etc/localtime")){
+	// http://www.unixwiz.net/techtips/bind9-chroot.html
+	file_put_contents(CHROOT_LOCALBASE.'/etc/namedb/named.conf', $bind_conf);
+	file_put_contents(CHROOT_LOCALBASE.'/etc/namedb/rndc.conf', $rndc_file);
+
+	if (!file_exists(CHROOT_LOCALBASE."/etc/namedb/named.root")) {
+		// dig +tcp @a.root-servers.net > CHROOT_LOCALBASE."/etc/namedb/named.root"
+		$named_root = file_get_contents("http://www.internic.net/domain/named.root");
+		file_put_contents(CHROOT_LOCALBASE."/etc/namedb/named.root", $named_root, LOCK_EX);
+	}
+	if (!file_exists(CHROOT_LOCALBASE."/etc/localtime")) {
 		copy("/etc/localtime", CHROOT_LOCALBASE."/etc/localtime");
 	}
-	
+
 	bind_write_rcfile();
-	chown(CHROOT_LOCALBASE."/etc/namedb/keys","bind");
-	chown(CHROOT_LOCALBASE."/etc/namedb","bind");
-	chown(CHROOT_LOCALBASE."/var/log","bind");
-	chown(CHROOT_LOCALBASE."/var/run/named","bind");
-	chgrp(CHROOT_LOCALBASE."/var/log","bind");
-	$bind_sh="/usr/local/etc/rc.d/named.sh";
- 	if($bind_enable == "on"){
- 		chmod ($bind_sh,0755);
- 		mwexec("{$bind_sh} restart");
- 		}
- 	elseif (is_service_running('named')){
- 		mwexec("{$bind_sh} stop");
-		chmod ($bind_sh,0644); 		
- 		}
- 	//sync to backup servers
- 	bind_sync_on_changes();
- 	conf_mount_ro();
+	chown(CHROOT_LOCALBASE."/etc/namedb/keys", "bind");
+	chown(CHROOT_LOCALBASE."/etc/namedb", "bind");
+	chown(CHROOT_LOCALBASE."/var/log", "bind");
+	chown(CHROOT_LOCALBASE."/var/run/named", "bind");
+	chgrp(CHROOT_LOCALBASE."/var/log", "bind");
+	$bind_sh = "/usr/local/etc/rc.d/named.sh";
+	if ($bind_enable == "on") {
+		chmod($bind_sh, 0755);
+		mwexec("{$bind_sh} restart");
+	} elseif (is_service_running('named')) {
+		mwexec("{$bind_sh} stop");
+		chmod($bind_sh, 0644);
+	}
+	// sync to backup servers
+	bind_sync_on_changes();
+	conf_mount_ro();
 }
 
-function bind_print_javascript_type_zone(){
-?>
-        <script language="JavaScript">
-        <!--
-        function on_type_zone_changed() {
+function bind_print_javascript_type_zone()
+{
+	?>
+	<script language="JavaScript">
+		<!--
+		function on_type_zone_changed() {
 
-		var field = document.iform.type;
-       		var tipo = field.options[field.selectedIndex].value;
-       			switch (tipo){
-       			case 'master':
+			var field = document.iform.type;
+			var tipo = field.options[field.selectedIndex].value;
+			switch (tipo) {
+				case 'master':
 					document.iform.slaveip.disabled = 1;
 					document.iform.tll.disabled = 0;
 					document.iform.nameserver.disabled = 0;
@@ -667,8 +726,8 @@ function bind_print_javascript_type_zone(){
 					document.iform.retry.disabled = 0;
 					document.iform.expire.disabled = 0;
 					document.iform.minimum.disabled = 0;
-               	break;
-               	case 'slave':
+					break;
+				case 'slave':
 					document.iform.slaveip.disabled = 0;
 					document.iform.tll.disabled = 1;
 					document.iform.nameserver.disabled = 1;
@@ -685,7 +744,7 @@ function bind_print_javascript_type_zone(){
 					document.iform.expire.disabled = 1;
 					document.iform.minimum.disabled = 1;
 					break;
-               	case 'forward':
+				case 'forward':
 					document.iform.slaveip.disabled = 1;
 					document.iform.tll.disabled = 1;
 					document.iform.nameserver.disabled = 1;
@@ -701,8 +760,8 @@ function bind_print_javascript_type_zone(){
 					document.iform.retry.disabled = 1;
 					document.iform.expire.disabled = 1;
 					document.iform.minimum.disabled = 1;
-				break;
-               	case 'redirect':
+					break;
+				case 'redirect':
 					document.iform.slaveip.disabled = 1;
 					document.iform.tll.disabled = 1;
 					document.iform.nameserver.disabled = 0;
@@ -718,127 +777,137 @@ function bind_print_javascript_type_zone(){
 					document.iform.retry.disabled = 0;
 					document.iform.expire.disabled = 0;
 					document.iform.minimum.disabled = 0;
-				break;
-       			}
-        }
-        -->
-        </script>
-<?php
+					break;
+				default:
+					break;
+			}
+		}
+		-->
+	</script>
+	<?php
 }
 
-function bind_print_javascript_type_zone2(){
-        print("<script language=\"JavaScript\">on_type_zone_changed();document.iform.resultconfig.disabled = 1;document.iform.dsset.disabled = 1;</script>\n");
+function bind_print_javascript_type_zone2()
+{
+	print("<script language=\"JavaScript\">on_type_zone_changed();document.iform.resultconfig.disabled = 1;document.iform.dsset.disabled = 1;</script>\n");
 }
 
-function bind_write_rcfile() {
-        $rc = array();
-        $BIND_LOCALBASE = "/usr/local";
-        $rc['file'] = 'named.sh';
-        $rc['start'] = <<<EOD
-if [ -z "`ps auxw | grep "[n]amed -c /etc/namedb/named.conf"|awk '{print $2}'`" ];then
-        {$BIND_LOCALBASE}/sbin/named -c /etc/namedb/named.conf -u bind -t /cf/named/
-fi
-
+function bind_write_rcfile()
+{
+	$rc = array();
+	$BIND_LOCALBASE = "/usr/local";
+	$rc['file'] = 'named.sh';
+	$rc['start'] = <<<EOD
+		if [ -z "`ps auxw | grep "[n]amed -c /etc/namedb/named.conf"|awk '{print $2}'`" ];then
+			{$BIND_LOCALBASE}/sbin/named -c /etc/namedb/named.conf -u bind -t /cf/named/
+		fi
 EOD;
-        $rc['stop'] = <<<EOD
-killall -9 named 2>/dev/null
-sleep 2
-EOD;
-        $rc['restart'] = <<<EOD
-if [ -z "`ps auxw | grep "[n]amed -c /etc/namedb/named.conf"|awk '{print $2}'`" ];then
-        	{$BIND_LOCALBASE}/sbin/named -c /etc/namedb/named.conf -u bind -t /cf/named/
-        else
+	$rc['stop'] = <<<EOD
 		killall -9 named 2>/dev/null
-         	sleep 3	
-        	{$BIND_LOCALBASE}/sbin/named -c /etc/namedb/named.conf -u bind -t /cf/named/
-        fi
-
+		sleep 2
 EOD;
-        conf_mount_rw();
-        write_rcfile($rc);
-        conf_mount_ro();
+	$rc['restart'] = <<<EOD
+		if [ -z "`ps auxw | grep "[n]amed -c /etc/namedb/named.conf"|awk '{print $2}'`" ];then
+			{$BIND_LOCALBASE}/sbin/named -c /etc/namedb/named.conf -u bind -t /cf/named/
+		else
+			killall -9 named 2>/dev/null
+		        sleep 3
+			{$BIND_LOCALBASE}/sbin/named -c /etc/namedb/named.conf -u bind -t /cf/named/
+		fi
+EOD;
+	conf_mount_rw();
+	write_rcfile($rc);
+	conf_mount_ro();
 }
 
 /* Uses XMLRPC to synchronize the changes to a remote node */
-function bind_sync_on_changes() {
+function bind_sync_on_changes()
+{
 	global $config, $g;
-	if (is_array($config['installedpackages']['bindsync']['config'])){
-		$bind_sync=$config['installedpackages']['bindsync']['config'][0];
+	if (is_array($config['installedpackages']['bindsync']['config'])) {
+		$bind_sync = $config['installedpackages']['bindsync']['config'][0];
 		$synconchanges = $bind_sync['synconchanges'];
 		$synctimeout = $bind_sync['synctimeout'];
-		$master_zone_ip=$bind_sync['masterip'];
-		switch ($synconchanges){
-			case "manual":
-				if (is_array($bind_sync[row])){
-					$rs=$bind_sync[row];
-					}
-				else{
+		$master_zone_ip = $bind_sync['masterip'];
+		switch ($synconchanges) {
+			case 'manual':
+				if (is_array($bind_sync['row'])) {
+					$rs = $bind_sync['row'];
+				} else {
 					log_error("[bind] xmlrpc sync is enabled but there is no hosts to push on bind config.");
 					return;
-					}
+				}
 				break;
-			case "auto":
-					if (is_array($config['hasync'])){
-						$hasync=$config['hasync'][0];
-						$rs[0]['ipaddress']=$hasync['synchronizetoip'];
-						$rs[0]['username']=$hasync['username'];
-						$rs[0]['password']=$hasync['password'];
-					}
-					else{
-						log_error("[bind] xmlrpc sync is enabled but there is no system backup hosts to push bind config.");
-						return;
-					}
-				break;			
+			case 'auto':
+				if (is_array($config['hasync'])) {
+					$hasync = $config['hasync'][0];
+					$rs[0]['ipaddress'] = $hasync['synchronizetoip'];
+					$rs[0]['username'] = $hasync['username'];
+					$rs[0]['password'] = $hasync['password'];
+				} else {
+					log_error("[bind] xmlrpc sync is enabled but there is no system backup hosts to push bind config.");
+					return;
+				}
+				break;
 			default:
 				return;
-			break;
+				break;
 		}
-		if (is_array($rs)){
+		if (is_array($rs)) {
 			log_error("[bind] xmlrpc sync is starting.");
-			foreach($rs as $sh){
+			foreach ($rs as $sh) {
 				$sync_to_ip = $sh['ipaddress'];
 				$password = $sh['password'];
-				if($sh['username'])
+				if ($sh['username']) {
 					$username = $sh['username'];
-				else
+				} else {
 					$username = 'admin';
-				if($password && $sync_to_ip)
-					bind_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout,$master_zone_ip);
 				}
-			log_error("[bind] xmlrpc sync is ending.");
+				if ($password && $sync_to_ip) {
+					bind_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout, $master_zone_ip);
+				}
 			}
- 		}
+			log_error("[bind] xmlrpc sync is ending.");
+		}
+	}
 }
+
 /* Do the actual XMLRPC sync */
-function bind_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout,$master_zone_ip) {
+function bind_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout, $master_zone_ip)
+{
 	global $config, $g;
 
-	if(!$username)
+	if (!$username) {
 		return;
-		
-	if(!$password)
-		return;
+	}
 
-	if(!$sync_to_ip)
+	if (!$password) {
 		return;
+	}
 
-	if(!$synctimeout)
-		$synctimeout=25;
-		
-		
+	if (!$sync_to_ip) {
+		return;
+	}
+
+	if (!$synctimeout) {
+		$synctimeout = 25;
+	}
+
+
 	$xmlrpc_sync_neighbor = $sync_to_ip;
-    if($config['system']['webgui']['protocol'] != "") {
+	if ($config['system']['webgui']['protocol'] != "") {
 		$synchronizetoip = $config['system']['webgui']['protocol'];
 		$synchronizetoip .= "://";
-    }
-    $port = $config['system']['webgui']['port'];
-    /* if port is empty lets rely on the protocol selection */
-    if($port == "") {
-		if($config['system']['webgui']['protocol'] == "http") 
+	}
+	$port = $config['system']['webgui']['port'];
+	/* if port is empty lets rely on the protocol selection */
+	if ($port == "") {
+		if ($config['system']['webgui']['protocol'] == "http") {
 			$port = "80";
-		else 
+		} else {
 			$port = "443";
-    }
+		}
+	}
 	$synchronizetoip .= $sync_to_ip;
 
 	/* xml will hold the sections to sync */
@@ -847,17 +916,19 @@ function bind_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout,$ma
 	$xml['bindacls'] = $config['installedpackages']['bindacls'];
 	$xml['bindviews'] = $config['installedpackages']['bindviews'];
 	$xml['bindzone'] = $config['installedpackages']['bindzone'];
-	if (is_array($config['installedpackages']['dnsseckeys']))
-		$xml['dnsseckeys']=$config['installedpackages']['dnsseckeys'];
+	if (is_array($config['installedpackages']['dnsseckeys'])) {
+		$xml['dnsseckeys'] = $config['installedpackages']['dnsseckeys'];
+	}
 	//change master zone to slave on backup servers
-	if(is_array($xml['bindzone']["config"])) 
-		for ($x=0; $x<sizeof($xml['bindzone']["config"]); $x++){
-			if ($xml['bindzone']["config"][$x]['type']=="master"){
-				$xml['bindzone']["config"][$x]['type']="slave";
-				$xml['bindzone']["config"][$x]['slaveip']=$master_zone_ip;
+	if (is_array($xml['bindzone']["config"])) {
+		for ($x = 0; $x < sizeof($xml['bindzone']["config"]); $x++) {
+			if ($xml['bindzone']["config"][$x]['type'] == "master") {
+				$xml['bindzone']["config"][$x]['type'] = "slave";
+				$xml['bindzone']["config"][$x]['slaveip'] = $master_zone_ip;
 			}
-			
+
 		}
+	}
 	/* assemble xmlrpc payload */
 	$params = array(
 		XML_RPC_encode($password),
@@ -871,52 +942,53 @@ function bind_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout,$ma
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
-	if($g['debug'])
+	if ($g['debug']) {
 		$cli->setDebug(1);
+	}
 	/* send our XMLRPC message and timeout after defined sync timeout value*/
 	$resp = $cli->send($msg, $synctimeout);
-	if(!$resp) {
+	if (!$resp) {
 		$error = "A communications error occurred while attempting BIND XMLRPC sync with {$url}:{$port}.";
 		log_error($error);
 		file_notice("sync_settings", $error, "bind Settings Sync", "");
-	} elseif($resp->faultCode()) {
+	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, $synctimeout);
-		$error = "An error code was received while attempting BIND XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		$error = "An error code was received while attempting BIND XMLRPC sync with {$url}:{$port} - Code ".$resp->faultCode().": ".$resp->faultString();
 		log_error($error);
 		file_notice("sync_settings", $error, "bind Settings Sync", "");
 	} else {
 		log_error("[bind] XMLRPC sync successfully completed with {$url}:{$port}.");
 	}
-	
+
 	/* tell bind to reload our settings on the destination sync host. */
 	$method = 'pfsense.exec_php';
-	$execcmd  = "require_once('/usr/local/pkg/bind.inc');\n";
+	$execcmd = "require_once('/usr/local/pkg/bind.inc');\n";
 	$execcmd .= "bind_sync('yes');";
 	/* assemble xmlrpc payload */
 	$params = array(
 		XML_RPC_encode($password),
 		XML_RPC_encode($execcmd)
 	);
-	
+
 	log_error("[bind] XMLRPC reload data {$url}:{$port}.");
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
 	$resp = $cli->send($msg, $synctimeout);
-	if(!$resp) {
+	if (!$resp) {
 		$error = "A communications error occurred while attempting BIND XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
 		log_error($error);
 		file_notice("sync_settings", $error, "Bind Settings Sync", "");
-	} elseif($resp->faultCode()) {
+	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, $synctimeout);
-		$error = "[Bind] An error code was received while attempting BIND XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		$error = "[Bind] An error code was received while attempting BIND XMLRPC sync with {$url}:{$port} - Code ".$resp->faultCode().": ".$resp->faultString();
 		log_error($error);
 		file_notice("sync_settings", $error, "bind Settings Sync", "");
 	} else {
 		log_error("BIND XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
 	}
-	
 }
+
 ?>

--- a/config/bind/bind.widget.php
+++ b/config/bind/bind.widget.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /*
         Copyright 2013 Marcello Coutinho
         Part of bind package for pfSense(www.pfsense.org)
@@ -28,59 +28,65 @@
 @require_once("pfsense-utils.inc");
 @require_once("functions.inc");
 
-$uname=posix_uname();
-if ($uname['machine']=='amd64')
-        ini_set('memory_limit', '250M');
-        
-function open_table(){
-	echo "<table style=\"padding-top:0px; padding-bottom:0px; padding-left:0px; padding-right:0px\" width=\"100%\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\">";
-	echo"  <tr>";
-}
-function close_table(){
-	echo"  </tr>";
-	echo"</table>";
-	
+$uname = posix_uname();
+if ($uname['machine'] == 'amd64') {
+	ini_set('memory_limit', '250M');
 }
 
-$pfb_table=array();
-$img['Sick']="<img src ='/themes/{$g['theme']}/images/icons/icon_interface_down.gif'>";
-$img['Healthy']="<img src ='/themes/{$g['theme']}/images/icons/icon_interface_up.gif'>";
+function open_table()
+{
+	echo "<table style=\"padding-top:0px; padding-bottom:0px; padding-left:0px; padding-right:0px\" width=\"100%\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\">";
+	echo "  <tr>";
+}
+
+function close_table()
+{
+	echo "  </tr>";
+	echo "</table>";
+
+}
+
+$pfb_table = array();
+$img['Sick'] = "<img src ='/themes/{$g['theme']}/images/icons/icon_interface_down.gif'>";
+$img['Healthy'] = "<img src ='/themes/{$g['theme']}/images/icons/icon_interface_up.gif'>";
 
 
 #var_dump($pfb_table);
 #exit;
-?><div id='bind'><?php 
-global $config;
-$rndc_bin="/usr/local/sbin/rndc";
-
-if (file_exists($rndc_bin))
-	exec("$rndc_bin status",$status);
-
-open_table();
-foreach($status as $line){
-	$fields=explode(":",$line);
-	print "<tr><td class=\"vncellt\"width=50%><strong>".ucfirst($fields[0])."</strong></td>\n";
-	print "<td class=\"listlr\">{$fields[1]}</td>\n</tr>";
-	}
-close_table();
-echo"</div>";
-
 ?>
-<script type="text/javascript">
-	function getstatus_bind() {
-		var url = "/widgets/widgets/bind.widget.php";
-		var pars = 'getupdatestatus=yes';
-		var myAjax = new Ajax.Request(
-			url,
-			{
-				method: 'get',
-				parameters: pars,
-				onComplete: activitycallback_bind
-			});
-		}
-	function activitycallback_bind(transport) {
-		$('bind').innerHTML = transport.responseText;
-		setTimeout('getstatus_postfix()', 5000);
+<div id='bind'><?php
+	global $config;
+	$rndc_bin = "/usr/local/sbin/rndc";
+
+	if (file_exists($rndc_bin)) {
+		exec("$rndc_bin status", $status);
 	}
-	getstatus_bind();
-</script>
+
+	open_table();
+	foreach ($status as $line) {
+		$fields = explode(":", $line);
+		print "<tr><td class=\"vncellt\"width=50%><strong>" . ucfirst($fields[0]) . "</strong></td>\n";
+		print "<td class=\"listlr\">{$fields[1]}</td>\n</tr>";
+	}
+	close_table();
+	echo "</div>";
+
+	?>
+	<script type="text/javascript">
+		function getstatus_bind() {
+			var url = "/widgets/widgets/bind.widget.php";
+			var pars = 'getupdatestatus=yes';
+			var myAjax = new Ajax.Request(
+				url,
+				{
+					method: 'get',
+					parameters: pars,
+					onComplete: activitycallback_bind
+				});
+		}
+		function activitycallback_bind(transport) {
+			$('bind').innerHTML = transport.responseText;
+			setTimeout('getstatus_postfix()', 5000);
+		}
+		getstatus_bind();
+	</script>

--- a/config/bind/bind.xml
+++ b/config/bind/bind.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
 <?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-        <copyright>
-        <![CDATA[
+	<copyright>
+		<![CDATA[
 /* $Id$ */
 /* ========================================================================== */
 /*
@@ -43,273 +43,277 @@
 /* ========================================================================== */
         ]]>
 
-        </copyright>
-    <description>Describe your package here</description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
-        <name>bind</name>
-        <version>1.0</version>
-        <title>Bind: Domain Named Settings</title>
-        <include_file>/usr/local/pkg/bind.inc</include_file>
-        <menu>
-                <name>BIND Server</name>
-                <tooltiptext>Modify BIND settings</tooltiptext>
-                <section>Services</section>
-                <url>/pkg_edit.php?xml=bind.xml</url>
-        </menu>
-        <service>
-                <name>named</name>
-                <rcfile>named.sh</rcfile>
-                <executable>named</executable>
-                <description>Domain Name Service</description>
-        </service>
-        <tabs>
-                <tab>
-                        <text>Settings</text>
-                        <url>/pkg_edit.php?xml=bind.xml</url>
-                        <active/>
-                </tab>
-                <tab>
-                        <text>ACLs</text>
-                        <url>/pkg.php?xml=bind_acls.xml</url>
-                </tab>
-                <tab>
-                        <text>Views</text>
-                        <url>/pkg.php?xml=bind_views.xml</url>
-                </tab>
-                <tab>
-                        <text>Zones</text>
-                         <url>/pkg.php?xml=bind_zones.xml</url>
-                </tab>
-                <tab>
-                        <text>Sync</text>
-                         <url>/pkg_edit.php?xml=bind_sync.xml</url>
-                </tab>
+	</copyright>
+	<description>Describe your package here</description>
+	<requirements>Describe your package requirements here</requirements>
+	<faq>Currently there are no FAQ items provided.</faq>
+	<name>bind</name>
+	<version>1.0</version>
+	<title>Bind: Domain Named Settings</title>
+	<include_file>/usr/local/pkg/bind.inc</include_file>
+	<menu>
+		<name>BIND Server</name>
+		<tooltiptext>Modify BIND settings</tooltiptext>
+		<section>Services</section>
+		<url>/pkg_edit.php?xml=bind.xml</url>
+	</menu>
+	<service>
+		<name>named</name>
+		<rcfile>named.sh</rcfile>
+		<executable>named</executable>
+		<description>Domain Name Service</description>
+	</service>
+	<tabs>
+		<tab>
+			<text>Settings</text>
+			<url>/pkg_edit.php?xml=bind.xml</url>
+			<active/>
+		</tab>
+		<tab>
+			<text>ACLs</text>
+			<url>/pkg.php?xml=bind_acls.xml</url>
+		</tab>
+		<tab>
+			<text>Views</text>
+			<url>/pkg.php?xml=bind_views.xml</url>
+		</tab>
+		<tab>
+			<text>Zones</text>
+			<url>/pkg.php?xml=bind_zones.xml</url>
+		</tab>
+		<tab>
+			<text>Sync</text>
+			<url>/pkg_edit.php?xml=bind_sync.xml</url>
+		</tab>
 
-        </tabs>
-        <!-- Installation -->
-        <additional_files_needed>
-            <prefix>/usr/local/pkg/</prefix>
-            <chmod>0755</chmod>
-                <item>https://packages.pfsense.org/packages/config/bind/bind.xml</item>
-        </additional_files_needed>
-        <additional_files_needed>
-            <prefix>/usr/local/pkg/</prefix>
-            <chmod>0755</chmod>
-                <item>https://packages.pfsense.org/packages/config/bind/bind_views.xml</item>
-        </additional_files_needed>
-        <additional_files_needed>
-            <prefix>/usr/local/pkg/</prefix>
-            <chmod>0755</chmod>
-                <item>https://packages.pfsense.org/packages/config/bind/bind_zones.xml</item>
-        </additional_files_needed>
-        <additional_files_needed>
-            <prefix>/usr/local/pkg/</prefix>
-            <chmod>0755</chmod>
-                <item>https://packages.pfsense.org/packages/config/bind/bind_acls.xml</item>
-        </additional_files_needed>
-        <additional_files_needed>
-            <prefix>/usr/local/pkg/</prefix>
-            <chmod>0755</chmod>
-                <item>https://packages.pfsense.org/packages/config/bind/bind.inc</item>
-        </additional_files_needed>
-        <additional_files_needed>
-            <prefix>/usr/local/pkg/</prefix>
-            <chmod>0755</chmod>
-                <item>https://packages.pfsense.org/packages/config/bind/bind_sync.xml</item>
-        </additional_files_needed>
-        <additional_files_needed>
-            <prefix>/usr/local/www/shortcuts/</prefix>
-            <chmod>0755</chmod>
-                <item>https://packages.pfsense.org/packages/config/bind/pkg_bind.inc</item>
-        </additional_files_needed>
-        <additional_files_needed>
-            <prefix>/usr/local/www/widgets/widgets/</prefix>
-            <chmod>0755</chmod>
-                <item>https://packages.pfsense.org/packages/config/bind/bind.widget.php</item>
-        </additional_files_needed>
-        <fields>
-                <field>
-                        <type>listtopic</type>
-                        <name>Daemon Settings</name>
-                        <fieldname>temp01</fieldname>
-                </field>
-                <field>
-                        <fielddescr>Enable BIND</fielddescr>
-                        <fieldname>enable_bind</fieldname>
-                        <description><![CDATA[Enable BIND DNS server<br>
+	</tabs>
+	<!-- Installation -->
+	<additional_files_needed>
+		<prefix>/usr/local/pkg/</prefix>
+		<chmod>0755</chmod>
+		<item>https://packages.pfsense.org/packages/config/bind/bind.xml</item>
+	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/usr/local/pkg/</prefix>
+		<chmod>0755</chmod>
+		<item>https://packages.pfsense.org/packages/config/bind/bind_views.xml</item>
+	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/usr/local/pkg/</prefix>
+		<chmod>0755</chmod>
+		<item>https://packages.pfsense.org/packages/config/bind/bind_zones.xml</item>
+	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/usr/local/pkg/</prefix>
+		<chmod>0755</chmod>
+		<item>https://packages.pfsense.org/packages/config/bind/bind_acls.xml</item>
+	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/usr/local/pkg/</prefix>
+		<chmod>0755</chmod>
+		<item>https://packages.pfsense.org/packages/config/bind/bind.inc</item>
+	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/usr/local/pkg/</prefix>
+		<chmod>0755</chmod>
+		<item>https://packages.pfsense.org/packages/config/bind/bind_sync.xml</item>
+	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/usr/local/www/shortcuts/</prefix>
+		<chmod>0755</chmod>
+		<item>https://packages.pfsense.org/packages/config/bind/pkg_bind.inc</item>
+	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/usr/local/www/widgets/widgets/</prefix>
+		<chmod>0755</chmod>
+		<item>https://packages.pfsense.org/packages/config/bind/bind.widget.php</item>
+	</additional_files_needed>
+	<fields>
+		<field>
+			<type>listtopic</type>
+			<name>Daemon Settings</name>
+			<fieldname>temp01</fieldname>
+		</field>
+		<field>
+			<fielddescr>Enable BIND</fielddescr>
+			<fieldname>enable_bind</fieldname>
+			<description><![CDATA[Enable BIND DNS server<br>
                         	Disable DNS Forwarder and Resolver services on selected interfaces before enabling BIND.]]></description>
-                        <type>checkbox</type>
-                        <required/>
-                </field>
-              <field>
-                        <fielddescr>Listen on</fielddescr>
-                        <fieldname>listenon</fieldname>
-                        <description><![CDATA[Choose the interfaces on which to enable BIND.]]></description>
-                        <type>interfaces_selection</type>
-                        <showlistenall/>
-                        <showvirtualips/>
-                        <multiple/>
-                </field>
-                <field>
-                        <fielddescr>Enable Notify</fielddescr>
-                        <fieldname>bind_notify</fieldname>
-                        <description>Notify slave server after any update on master.</description>
-                        <type>checkbox</type>
-                </field>
-                <field>
-                        <fielddescr>Hide Version</fielddescr>
-                        <fieldname>bind_hide_version</fieldname>
-                        <description>Hide the version of BIND (ignore queries for version.bind).</description>
-                        <type>checkbox</type>
-                </field>
-                <field>
-					<fielddescr>Limit Memory use</fielddescr>
-					<fieldname>bind_ram_limit</fieldname>
-					<description>Limits RAM use for DNS server, recommend 256M</description>
-					<type>input</type>
-                	<size>10</size>
-					<default_value>256M</default_value>
-               	</field>
-                <field>
-                        <type>listtopic</type>
-                        <name>Logging options</name>
-                        <fieldname>temp01</fieldname>
-                </field>
-                <field>
-                        <fielddescr>Enable logging</fielddescr>
-                        <fieldname>bind_logging</fieldname>
-                        <description><![CDATA[Enable BIND logs under Status > System logs, Resolver tab.]]></description>
-                        <type>checkbox</type>
-                </field>
-				<field>
-					<fielddescr>Logging serverity</fielddescr>
-					<fieldname>log_severity</fieldname>
-					<description><![CDATA[Choose logging level for selected categories.<BR>
-								The value 'dynamic' means assume the global level defined by either the command line parameter -d or by running rndc trace.]]></description>
-					<type>select</type>
-						<options>
-							<option><name>Critital</name><value>critical</value></option>
-							<option><name>Error</name><value>error</value></option>
-							<option><name>Warning</name><value>warning</value></option>
-							<option><name>Notice</name><value>Notice</value></option>
-							<option><name>info</name><value>info</value></option>
-							<option><name>Debug level 1</name><value>debug 1</value></option>
-							<option><name>Debug level 3</name><value>debug 3</value></option>
-							<option><name>Debug level 5</name><value>debug 5</value></option>
-							<option><name>Dynamic</name><value>dynamic</value></option>
-						</options>
-				</field>
-				<field>
-					<fielddescr>Logging options</fielddescr>
-					<fieldname>log_options</fieldname>
-					<description><![CDATA[Select categories to log.<BR>
-								use CTRL+click to select/unselect.]]></description>
-					<type>select</type>
-						<options>
-							<option><name>Default-if this is the only category selected, it will log all categories except queries</name><value>default</value></option>
-							<option><name>General-Anything that is not classified as any other item in this list defaults to this category</name><value>general</value></option>
-							<option><name>Database-The value 'dynamic' means assume the global level defined by either the command line parameter -d or by running rndc trace</name><value>database</value></option>
-							<option><name>Security-Approval and denial of requests</name><value>security</value></option>
-							<option><name>Config-Configuration file parsing and processing</name><value>config</value></option>
-							<option><name>Resolver-Name resolution including recursive lookups</name><value>resolver</value></option>
-							<option><name>Xfer-in-Details of zone transfers the server is receiving.</name><value>xfer-in</value></option>
-							<option><name>Xfer-out-Details of zone transfers the server is sending.</name><value>xfer-out</value></option>
-							<option><name>Notify-Logs all NOTIFY operations.</name><value>notify</value></option>
-							<option><name>Client-Processing of client requests</name><value>client</value></option>
-							<option><name>Unmatched-No matching view clause or unrecognized class value.</name><value>unmatched</value></option>
-							<option><name>Queries-Logs all query transactions</name><value>queries</value></option>
-							<option><name>Network-Logs all network operations</name><value>network</value></option>
-							<option><name>Update-Logging of all dynamic update (DDNS) transactions</name><value>update</value></option>
-							<option><name>Dispatch-Dispatching of incoming packets to the server modules</name><value>dispatch</value></option>
-							<option><name>DNSSEC-DNSSEC and TSIG protocol processing</name><value>dnssec</value></option>
-							<option><name>lame-servers-Mis-configuration in the delegation of domains discovered by BIND</name><value>lame-servers</value></option>
-						</options>
-						<multiple/>
-						<size>18</size>
-				</field>
-                <field>
-                        <type>listtopic</type>
-                        <name>Response Rate Limit</name>
-                        <fieldname>temp01</fieldname>
-                </field>
-                <field>
-                        <fielddescr>Rate limit</fielddescr>
-                        <fieldname>rate_enabled</fieldname>
-                        <description><![CDATA[<a target=_new href='https://kb.isc.org/article/AA-01000/189/A-Quick-Introduction-to-Response-Rate-Limiting.html?utm_source=isc&utm_medium=website&utm_term=rrl-kb&utm_content=kbarticle&utm_campaign=bind994_release_091913'>
-                        Limit/rate response queries</a> to prevent DOS attack.]]></description>
-                        <type>checkbox</type>
-                        <enablefields>rate_limit,log_only</enablefields>
-                </field>
-				<field>
-					<fielddescr>Limit Action</fielddescr>
-					<fieldname>log_only</fieldname>
-					<description>Select what to do when a query reaches a limit.</description>
-					<type>select</type>
-						<options>
-							<option><name>Deny query</name><value>no</value></option>
-							<option><name>Log only</name><value>yes</value></option>
-						</options>
-				</field>
-				<field>
-					<fielddescr>limit</fielddescr>
-					<fieldname>rate_limit</fieldname>
-					<description>Set rate limit. Default to 15.</description>
-					<type>input</type>
-                	<size>10</size>
-                </field>
-
-                <field>
-                        <type>listtopic</type>
-                        <name>Forwarder Config</name>
-                        <fieldname>temp01</fieldname>
-                </field>
-                <field>
-                        <fielddescr>Enable Forwarding</fielddescr>
-                        <fieldname>bind_forwarder</fieldname>
-                        <description>Enable forwarding queries to other DNS servers listed below rather than this server performing its own recursion.</description>
-                        <type>checkbox</type>
-                        <enablefields>bind_forwarder_ips</enablefields>
-                </field>
-                <field>
-                        <fielddescr>Forwarder IPs</fielddescr>
-                        <fieldname>bind_forwarder_ips</fieldname>
-                        <description>Enter IPs of DNS servers to use for recursion. Separate by semi-colons (;). Applies only if Enable Forwarding is chosen.</description>
-                        <type>input</type>
-                	<size>80</size>
-                </field>
-                <field>
-                        <type>listtopic</type>
-                        <name>custom Options</name>
-                        <fieldname>temp01</fieldname>
-                </field>
-    		<field>
-                        <fielddescr>Custom Options</fielddescr>
-                        <fieldname>bind_custom_options</fieldname>
-                        <description><![CDATA[You can put your own custom options here, one per line.<br>
-                        			They'll be added to the configuration. They need to be named.conf native options.]]>
-                       	</description>
-                        <type>textarea</type>
-                        <cols>65</cols>
-                        <rows>5</rows>
-                        <encoding>base64</encoding>
-                </field>
-        </fields>
-    	<custom_php_after_head_command>
-    	</custom_php_after_head_command>
-        <custom_php_command_before_form>
-        </custom_php_command_before_form>
-        <custom_add_php_command>
-        </custom_add_php_command>
-    	<custom_php_validation_command>
-    	</custom_php_validation_command>
-        <custom_php_resync_config_command>
-        	bind_sync();
-        </custom_php_resync_config_command>
-        <custom_php_install_command>
-       		bind_write_rcfile();
+			<type>checkbox</type>
+			<required/>
+		</field>
+		<field>
+			<fielddescr>Listen on</fielddescr>
+			<fieldname>listenon</fieldname>
+			<description><![CDATA[Choose the interfaces on which to enable BIND.]]></description>
+			<type>interfaces_selection</type>
+			<showlistenall/>
+			<showvirtualips/>
+			<multiple/>
+		</field>
+		<field>
+			<fielddescr>Enable Notify</fielddescr>
+			<fieldname>bind_notify</fieldname>
+			<description>Notify slave server after any update on master.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Hide Version</fielddescr>
+			<fieldname>bind_hide_version</fieldname>
+			<description>Hide the version of BIND (ignore queries for version.bind).</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Limit Memory Use</fielddescr>
+			<fieldname>bind_ram_limit</fieldname>
+			<description>Limits RAM use for DNS server, recommend 256M</description>
+			<type>input</type>
+			<size>10</size>
+			<default_value>256M</default_value>
+		</field>
+		<field>
+			<type>listtopic</type>
+			<name>Logging options</name>
+			<fieldname>temp01</fieldname>
+		</field>
+		<field>
+			<fielddescr>Enable Logging</fielddescr>
+			<fieldname>bind_logging</fieldname>
+			<description><![CDATA[Enable BIND logs under Status > System logs, Resolver tab.]]></description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Logging Serverity</fielddescr>
+			<fieldname>log_severity</fieldname>
+			<description><![CDATA[Choose logging level for selected categories.<BR>
+						The value 'dynamic' means assume the global level defined by either the command line parameter -d or by running rndc trace.]]></description>
+			<type>select</type>
+			<options>
+				<option><name>Critital</name><value>critical</value></option>
+				<option><name>Error</name><value>error</value></option>
+				<option><name>Warning</name><value>warning</value></option>
+				<option><name>Notice</name><value>Notice</value></option>
+				<option><name>info</name><value>info</value></option>
+				<option><name>Debug level 1</name><value>debug 1</value></option>
+				<option><name>Debug level 3</name><value>debug 3</value></option>
+				<option><name>Debug level 5</name><value>debug 5</value></option>
+				<option><name>Dynamic</name><value>dynamic</value></option>
+			</options>
+		</field>
+		<field>
+			<fielddescr>Logging Options</fielddescr>
+			<fieldname>log_options</fieldname>
+			<description><![CDATA[Select categories to log.<BR>
+						use CTRL+click to select/unselect.]]></description>
+			<type>select</type>
+			<options>
+				<option><name>Default-if this is the only category selected, it will log all categories except queries</name><value>default</value></option>
+				<option><name>General-Anything that is not classified as any other item in this list defaults to this category</name><value>general</value></option>
+				<option><name>Database-The value 'dynamic' means assume the global level defined by either the command line parameter -d or by running rndc trace</name><value>database</value></option>
+				<option><name>Security-Approval and denial of requests</name><value>security</value></option>
+				<option><name>Config-Configuration file parsing and processing</name><value>config</value></option>
+				<option><name>Resolver-Name resolution including recursive lookups</name><value>resolver</value></option>
+				<option><name>Xfer-in-Details of zone transfers the server is receiving.</name><value>xfer-in</value></option>
+				<option><name>Xfer-out-Details of zone transfers the server is sending.</name><value>xfer-out</value></option>
+				<option><name>Notify-Logs all NOTIFY operations.</name><value>notify</value></option>
+				<option><name>Client-Processing of client requests</name><value>client</value></option>
+				<option><name>Unmatched-No matching view clause or unrecognized class value.</name><value>unmatched</value></option>
+				<option><name>Queries-Logs all query transactions</name><value>queries</value></option>
+				<option><name>Network-Logs all network operations</name><value>network</value></option>
+				<option><name>Update-Logging of all dynamic update (DDNS) transactions</name><value>update</value></option>
+				<option><name>Dispatch-Dispatching of incoming packets to the server modules</name><value>dispatch</value></option>
+				<option><name>DNSSEC-DNSSEC and TSIG protocol processing</name><value>dnssec</value></option>
+				<option><name>lame-servers-Mis-configuration in the delegation of domains discovered by BIND</name><value>lame-servers</value></option>
+			</options>
+			<multiple/>
+			<size>18</size>
+		</field>
+		<field>
+			<type>listtopic</type>
+			<name>Response Rate Limit</name>
+			<fieldname>temp01</fieldname>
+		</field>
+		<field>
+			<fielddescr>Rate Limit</fielddescr>
+			<fieldname>rate_enabled</fieldname>
+			<description><![CDATA[<a target=_new href='https://kb.isc.org/article/AA-01000/189/A-Quick-Introduction-to-Response-Rate-Limiting.html?utm_source=isc&utm_medium=website&utm_term=rrl-kb&utm_content=kbarticle&utm_campaign=bind994_release_091913'>
+						Limit/rate response queries</a> to prevent DOS attack.]]></description>
+			<type>checkbox</type>
+			<enablefields>rate_limit,log_only</enablefields>
+		</field>
+		<field>
+			<fielddescr>Limit Action</fielddescr>
+			<fieldname>log_only</fieldname>
+			<description>Select what to do when a query reaches a limit.</description>
+			<type>select</type>
+			<options>
+				<option><name>Deny query</name><value>no</value></option>
+				<option><name>Log only</name><value>yes</value></option>
+			</options>
+		</field>
+		<field>
+			<fielddescr>Limit</fielddescr>
+			<fieldname>rate_limit</fieldname>
+			<description>Set rate limit. Default to 15.</description>
+			<type>input</type>
+			<size>10</size>
+		</field>
+		<field>
+			<type>listtopic</type>
+			<name>Forwarder Config</name>
+			<fieldname>temp01</fieldname>
+		</field>
+		<field>
+			<fielddescr>Enable Forwarding</fielddescr>
+			<fieldname>bind_forwarder</fieldname>
+			<description>Enable forwarding queries to other DNS servers listed below rather than this server
+					performing its own recursion.
+			</description>
+			<type>checkbox</type>
+			<enablefields>bind_forwarder_ips</enablefields>
+		</field>
+		<field>
+			<fielddescr>Forwarder IPs</fielddescr>
+			<fieldname>bind_forwarder_ips</fieldname>
+			<description>Enter IPs of DNS servers to use for recursion. Separate by semi-colons (;). Applies
+					only if Enable Forwarding is chosen.
+			</description>
+			<type>input</type>
+			<size>80</size>
+		</field>
+		<field>
+			<type>listtopic</type>
+			<name>Custom Options</name>
+			<fieldname>temp01</fieldname>
+		</field>
+		<field>
+			<fielddescr>Custom Options</fielddescr>
+			<fieldname>bind_custom_options</fieldname>
+			<description>
+				<![CDATA[You can put your own custom options here, one per line.<br>
+					They'll be added to the configuration. They need to be named.conf native options.]]>
+			</description>
+			<type>textarea</type>
+			<cols>65</cols>
+			<rows>5</rows>
+			<encoding>base64</encoding>
+		</field>
+	</fields>
+	<custom_php_after_head_command>
+	</custom_php_after_head_command>
+	<custom_php_command_before_form>
+	</custom_php_command_before_form>
+	<custom_add_php_command>
+	</custom_add_php_command>
+	<custom_php_validation_command>
+	</custom_php_validation_command>
+	<custom_php_resync_config_command>
+		bind_sync();
+	</custom_php_resync_config_command>
+	<custom_php_install_command>
+		bind_write_rcfile();
 	</custom_php_install_command>
-        <custom_php_deinstall_command>
-        </custom_php_deinstall_command>
-        <filter_rules_needed></filter_rules_needed>
+	<custom_php_deinstall_command>
+	</custom_php_deinstall_command>
+	<filter_rules_needed></filter_rules_needed>
 </packagegui>

--- a/config/bind/bind_acls.xml
+++ b/config/bind/bind_acls.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
-        <copyright>
-        <![CDATA[
+	<copyright>
+		<![CDATA[
 /* $Id$ */
 /* ========================================================================== */
 /*
@@ -42,10 +42,10 @@
                                                                               */
 /* ========================================================================== */
         ]]>
-        </copyright>
-    <description>Describe your package here</description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	</copyright>
+	<description>Describe your package here</description>
+	<requirements>Describe your package requirements here</requirements>
+	<faq>Currently there are no FAQ items provided.</faq>
 	<name>bindacls</name>
 	<version>0.1.0</version>
 	<title>BIND: ACLs Settings</title>
@@ -56,29 +56,29 @@
 		<section>Services</section>
 		<configfile>bind.xml</configfile>
 	</menu>
-	        <tabs>
-                <tab>
-                        <text>Settings</text>
-                        <url>/pkg_edit.php?xml=bind.xml</url>
-                </tab>
-                <tab>
-                        <text>ACLs</text>
-                        <url>/pkg.php?xml=bind_acls.xml</url>
-                        <active/>
-                </tab>
-                <tab>
-                        <text>Views</text>
-                        <url>/pkg.php?xml=bind_views.xml</url>
-                </tab>
-                <tab>
-                        <text>Zones</text>
-                        <url>/pkg.php?xml=bind_zones.xml</url>
-                </tab>
-                <tab>
-                        <text>Sync</text>
-                         <url>/pkg_edit.php?xml=bind_sync.xml</url>
-                </tab>
-        </tabs>
+	<tabs>
+		<tab>
+			<text>Settings</text>
+			<url>/pkg_edit.php?xml=bind.xml</url>
+		</tab>
+		<tab>
+			<text>ACLs</text>
+			<url>/pkg.php?xml=bind_acls.xml</url>
+			<active/>
+		</tab>
+		<tab>
+			<text>Views</text>
+			<url>/pkg.php?xml=bind_views.xml</url>
+		</tab>
+		<tab>
+			<text>Zones</text>
+			<url>/pkg.php?xml=bind_zones.xml</url>
+		</tab>
+		<tab>
+			<text>Sync</text>
+			<url>/pkg_edit.php?xml=bind_sync.xml</url>
+		</tab>
+	</tabs>
 	<configpath>['installedpackages']['bindacls']['config']</configpath>
 	<adddeleteeditpagefields>
 		<columnitem>
@@ -92,7 +92,7 @@
 		<movable>on</movable>
 	</adddeleteeditpagefields>
 	<!-- fields gets invoked when the user adds or edits a item.   the following items
-         will be parsed and rendered for the user as a gui with input, and selectboxes. -->
+		will be parsed and rendered for the user as a gui with input, and selectboxes. -->
 	<fields>
 		<field>
 			<fielddescr>ACL Name</fielddescr>
@@ -107,32 +107,32 @@
 			<description>Enter the description for this ACL.</description>
 			<type>input</type>
 		</field>
-                <field>
-                        <fielddescr>Enter IP or range block network.</fielddescr>
-                        <description>Leave blank to allow All</description>
-                        <fieldname>none</fieldname>
-                    <type>rowhelper</type>
-                    <rowhelper>
-                        <rowhelperfield>
-                            <fielddescr>Value</fielddescr>
-                            <fieldname>value</fieldname>
-                            <type>input</type>
-                            <size>20</size>
-                        </rowhelperfield>
-                        <rowhelperfield>
-                            <fielddescr>Description</fielddescr>
-                            <fieldname>description</fieldname>
-                            <type>input</type>
-                            <size>20</size>
-                        </rowhelperfield>
-                    </rowhelper>
-                </field>
+		<field>
+			<fielddescr>Enter IP or range block network.</fielddescr>
+			<description>Leave blank to allow All</description>
+			<fieldname>none</fieldname>
+			<type>rowhelper</type>
+			<rowhelper>
+				<rowhelperfield>
+					<fielddescr>Value</fielddescr>
+					<fieldname>value</fieldname>
+					<type>input</type>
+					<size>20</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Description</fielddescr>
+					<fieldname>description</fieldname>
+					<type>input</type>
+					<size>20</size>
+				</rowhelperfield>
+			</rowhelper>
+		</field>
 	</fields>
-        <custom_php_command_before_form>
-        </custom_php_command_before_form>
+	<custom_php_command_before_form>
+	</custom_php_command_before_form>
 	<custom_delete_php_command>
-	</custom_delete_php_command>	
-        <custom_php_resync_config_command>
-	        bind_sync();
-        </custom_php_resync_config_command>
+	</custom_delete_php_command>
+	<custom_php_resync_config_command>
+		bind_sync();
+	</custom_php_resync_config_command>
 </packagegui>

--- a/config/bind/bind_sync.xml
+++ b/config/bind/bind_sync.xml
@@ -3,7 +3,7 @@
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-	<![CDATA[
+		<![CDATA[
 /* $Id$ */
 /* ========================================================================== */
 /*
@@ -105,7 +105,7 @@
 			<fielddescr>Zone Master IP</fielddescr>
 			<fieldname>masterip</fieldname>
 			<description><![CDATA[Set master zone ip you want to use to sync backup server zones with master.<br>
-							<b>All master zones will be configured as backup on slave servers.<b>]]></description>
+						<b>All master zones will be configured as backup on slave servers.<b>]]></description>
 			<type>input</type>
 			<size>20</size>
 			<required/>
@@ -115,24 +115,24 @@
 			<fieldname>none</fieldname>
 			<type>rowhelper</type>
 			<description><![CDATA[<b>Do not forget to:</b><br>
-							&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Create firewall rules to allow zone transfer between master and slave servers.<br>
-							&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Create a acls with these slave servers.<br>
-							&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Include created acl on allow-transfer option on zone config.]]></description>
+						&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Create firewall rules to allow zone transfer between master and slave servers.<br>
+						&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Create a acls with these slave servers.<br>
+						&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Include created acl on allow-transfer option on zone config.]]></description>
 			<rowhelper>
-			<rowhelperfield>
-				<fielddescr>IP Address</fielddescr>
-				<fieldname>ipaddress</fieldname>
-				<description>IP Address of remote server</description>
-				<type>input</type>
-				<size>20</size>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>Password</fielddescr>
-				<fieldname>password</fieldname>
-				<description>Password for remote server.</description>
-				<type>password</type>
-				<size>20</size>
-			</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>IP Address</fielddescr>
+					<fieldname>ipaddress</fieldname>
+					<description>IP Address of remote server</description>
+					<type>input</type>
+					<size>20</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Password</fielddescr>
+					<fieldname>password</fieldname>
+					<description>Password for remote server.</description>
+					<type>password</type>
+					<size>20</size>
+				</rowhelperfield>
 			</rowhelper>
 		</field>
 	</fields>

--- a/config/bind/bind_views.xml
+++ b/config/bind/bind_views.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
-        <copyright>
-        <![CDATA[
+	<copyright>
+		<![CDATA[
 /* $Id$ */
 /* ========================================================================== */
 /*
@@ -42,10 +42,10 @@
                                                                               */
 /* ========================================================================== */
         ]]>
-        </copyright>
-    <description>Describe your package here</description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	</copyright>
+	<description>Describe your package here</description>
+	<requirements>Describe your package requirements here</requirements>
+	<faq>Currently there are no FAQ items provided.</faq>
 	<name>bindviews</name>
 	<version>0.1.0</version>
 	<title>Bind: Views Settings</title>
@@ -56,29 +56,29 @@
 		<section>Services</section>
 		<configfile>bind.xml</configfile>
 	</menu>
-	        <tabs>
-                <tab>
-                        <text>Settings</text>
-                        <url>/pkg_edit.php?xml=bind.xml</url>
-                </tab>
-                <tab>
-                        <text>ACLs</text>
-                        <url>/pkg.php?xml=bind_acls.xml</url>
-                </tab>
-                <tab>
-                        <text>Views</text>
-                        <url>/pkg.php?xml=bind_views.xml</url>
-                        <active/>
-                </tab>
-                <tab>
-                        <text>Zones</text>
-                        <url>/pkg.php?xml=bind_zones.xml</url>
-                </tab>
-                <tab>
-                        <text>Sync</text>
-                         <url>/pkg_edit.php?xml=bind_sync.xml</url>
-                </tab>
-        </tabs>
+	<tabs>
+		<tab>
+			<text>Settings</text>
+			<url>/pkg_edit.php?xml=bind.xml</url>
+		</tab>
+		<tab>
+			<text>ACLs</text>
+			<url>/pkg.php?xml=bind_acls.xml</url>
+		</tab>
+		<tab>
+			<text>Views</text>
+			<url>/pkg.php?xml=bind_views.xml</url>
+			<active/>
+		</tab>
+		<tab>
+			<text>Zones</text>
+			<url>/pkg.php?xml=bind_zones.xml</url>
+		</tab>
+		<tab>
+			<text>Sync</text>
+			<url>/pkg_edit.php?xml=bind_sync.xml</url>
+		</tab>
+	</tabs>
 	<configpath>['installedpackages']['bindviews']['config']</configpath>
 	<adddeleteeditpagefields>
 		<columnitem>
@@ -106,19 +106,26 @@
 			<type>input</type>
 		</field>
 		<field>
-           <fielddescr>Recursion</fielddescr>
-           <fieldname>recursion</fieldname>
-           <description>A recursive query occurs when your DNS server is queried for a domain that it currently knows nothing about, in which case it will try to resolve the given host by performing further queries (eg by starting at the root servers and working out, or by simply passing the request to yet another DNS server).</description>
-           <type>select</type>
-	       <options>
-			<option><name>No</name><value>no</value></option>
-			<option><name>Yes</name><value>yes</value></option>
-		   </options>
+			<fielddescr>Recursion</fielddescr>
+			<fieldname>recursion</fieldname>
+			<description>A recursive query occurs when your DNS server is queried for a domain that it
+					currently knows nothing about, in which case it will try to resolve the given host by
+					performing further queries (eg by starting at the root servers and working out, or by
+					simply passing the request to yet another DNS server).
+			</description>
+			<type>select</type>
+			<options>
+				<option><name>No</name><value>no</value></option>
+				<option><name>Yes</name><value>yes</value></option>
+			</options>
 		</field>
 		<field>
 			<fielddescr>Match-clients</fielddescr>
 			<fieldname>match-clients</fieldname>
-			<description>If either or both of match-clients are missing they default to any (all hosts match). The match-clients statement defines the address_match_list for the source IP address of the incoming messages.</description>
+			<description>If either or both of match-clients are missing they default to any (all hosts
+					match). The match-clients statement defines the address_match_list for the source IP
+					address of the incoming messages.
+			</description>
 			<type>select_source</type>
 			<source><![CDATA[$config['installedpackages']['bindacls']['config']]]></source>
 			<source_name>name</source_name>
@@ -129,8 +136,10 @@
 		<field>
 			<fielddescr>Allow-recursion</fielddescr>
 			<fieldname>allow-recursion</fieldname>
-			<description>For example, if you have one DNS server serving your local network, you may want all of your local computers to use your DNS server.</description>
-	    	<type>select_source</type>
+			<description>For example, if you have one DNS server serving your local network, you may want
+					all of your local computers to use your DNS server.
+			</description>
+			<type>select_source</type>
 			<source><![CDATA[$config['installedpackages']['bindacls']['config']]]></source>
 			<source_name>name</source_name>
 			<source_value>name</source_value>
@@ -138,25 +147,26 @@
 			<size>03</size>
 		</field>
 		<field>
-                        <type>listtopic</type>
-                        <name>Custom Views </name>
-                        <fieldname>temp</fieldname>
-                </field>
-	        <field>
-                        <fielddescr>Custom Options</fielddescr>
-                        <fieldname>bind_custom_options</fieldname>
-                        <description>You can put your own custom options here, separated by semi-colons (;).</description>
-                        <type>textarea</type>
-                        <cols>65</cols>
-                        <rows>8</rows>
-                        <encoding>base64</encoding>
-                </field>
+			<type>listtopic</type>
+			<name>Custom Views</name>
+			<fieldname>temp</fieldname>
+		</field>
+		<field>
+			<fielddescr>Custom Options</fielddescr>
+			<fieldname>bind_custom_options</fieldname>
+			<description>You can put your own custom options here, separated by semi-colons (;).
+			</description>
+			<type>textarea</type>
+			<cols>65</cols>
+			<rows>8</rows>
+			<encoding>base64</encoding>
+		</field>
 	</fields>
-        <custom_php_command_before_form>
-        </custom_php_command_before_form>
+	<custom_php_command_before_form>
+	</custom_php_command_before_form>
 	<custom_delete_php_command>
-	</custom_delete_php_command>	
-        <custom_php_resync_config_command>
-	        bind_sync();
-        </custom_php_resync_config_command>
+	</custom_delete_php_command>
+	<custom_php_resync_config_command>
+		bind_sync();
+	</custom_php_resync_config_command>
 </packagegui>

--- a/config/bind/bind_zones.xml
+++ b/config/bind/bind_zones.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
-        <copyright>
-        <![CDATA[
+	<copyright>
+		<![CDATA[
 /* $Id$ */
 /* ========================================================================== */
 /*
@@ -42,10 +42,10 @@
                                                                               */
 /* ========================================================================== */
         ]]>
-        </copyright>
-    <description>Describe your package here</description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	</copyright>
+	<description>Describe your package here</description>
+	<requirements>Describe your package requirements here</requirements>
+	<faq>Currently there are no FAQ items provided.</faq>
 	<name>bindzone</name>
 	<version>none</version>
 	<title>BIND: Zones Settings</title>
@@ -56,47 +56,47 @@
 		<section>Services</section>
 		<configfile>bind.xml</configfile>
 	</menu>
-        <tabs>
-                <tab>
-                        <text>Settings</text>
-                        <url>/pkg_edit.php?xml=bind.xml</url>
-                </tab>
-                <tab>
-                        <text>ACLs</text>
-                        <url>/pkg.php?xml=bind_acls.xml</url>
-                </tab>
-                <tab>
-                        <text>Views</text>
-                        <url>/pkg.php?xml=bind_views.xml</url>
-                </tab>
-                <tab>
-                        <text>Zones</text>
-                        <url>/pkg.php?xml=bind_zones.xml&amp;id=0</url>
-                        <active/>
-                </tab>
-                <tab>
-                        <text>Sync</text>
-                         <url>/pkg_edit.php?xml=bind_sync.xml</url>
-                </tab>
-        </tabs>
+	<tabs>
+		<tab>
+			<text>Settings</text>
+			<url>/pkg_edit.php?xml=bind.xml</url>
+		</tab>
+		<tab>
+			<text>ACLs</text>
+			<url>/pkg.php?xml=bind_acls.xml</url>
+		</tab>
+		<tab>
+			<text>Views</text>
+			<url>/pkg.php?xml=bind_views.xml</url>
+		</tab>
+		<tab>
+			<text>Zones</text>
+			<url>/pkg.php?xml=bind_zones.xml&amp;id=0</url>
+			<active/>
+		</tab>
+		<tab>
+			<text>Sync</text>
+			<url>/pkg_edit.php?xml=bind_sync.xml</url>
+		</tab>
+	</tabs>
 	<configpath>['installedpackages']['bindzone']['config']</configpath>
 	<adddeleteeditpagefields>
 		<columnitem>
-			<fielddescr>status</fielddescr>
+			<fielddescr>Status</fielddescr>
 			<fieldname>disabled</fieldname>
 			<listmodeon>Disabled</listmodeon>
 			<listmodeoff>Enabled</listmodeoff>
 		</columnitem>
 		<columnitem>
-			<fielddescr>Zone Name</fielddescr>
+			<fielddescr>Name</fielddescr>
 			<fieldname>name</fieldname>
 		</columnitem>
 		<columnitem>
-			<fielddescr>Zone Type</fielddescr>
+			<fielddescr>Type</fielddescr>
 			<fieldname>type</fieldname>
 		</columnitem>
 		<columnitem>
-			<fielddescr>View Name</fielddescr>
+			<fielddescr>View(s)</fielddescr>
 			<fieldname>view</fieldname>
 		</columnitem>
 		<columnitem>
@@ -111,9 +111,9 @@
 	</adddeleteeditpagefields>
 	<fields>
 		<field>
-		        <type>listtopic</type>
-                        <name>Domain Zone Configuration</name>
-                        <fieldname>temp01</fieldname>
+			<type>listtopic</type>
+			<name>Domain Zone Configuration</name>
+			<fieldname>temp01</fieldname>
 		</field>
 		<field>
 			<fielddescr>Disable this zone</fielddescr>
@@ -141,21 +141,21 @@
 			<fielddescr>Zone Type</fielddescr>
 			<fieldname>type</fieldname>
 			<description><![CDATA[Select zone type.]]></description>
-		        <type>select</type>
-					<options>
-						<option><name>Master</name><value>master</value><enablefields>description</enablefields></option>
-						<option><name>Slave</name><value>slave</value><enablefields>ttl</enablefields></option>
-						<option><name>Forward</name><value>forward</value><enablefields>forward</enablefields></option>
-						<option><name>Redirect</name><value>redirect</value><enablefields>redirect</enablefields></option>
-					</options>
-                       <onchange>on_type_zone_changed()</onchange>
+			<type>select</type>
+			<options>
+				<option><name>Master</name><value>master</value><enablefields>description</enablefields></option>
+				<option><name>Slave</name><value>slave</value><enablefields>ttl</enablefields></option>
+				<option><name>Forward</name><value>forward</value><enablefields>forward</enablefields></option>
+				<option><name>Redirect</name><value>redirect</value><enablefields>redirect</enablefields></option>
+			</options>
+			<onchange>on_type_zone_changed()</onchange>
 			<required/>
 		</field>
 		<field>
 			<fielddescr>View</fielddescr>
 			<fieldname>view</fieldname>
-			<description><![CDATA[Select the View that this area will belong.]]></description>
-	    	<type>select_source</type>
+			<description><![CDATA[Select the View that this zone will belong.]]></description>
+			<type>select_source</type>
 			<source><![CDATA[$config['installedpackages']['bindviews']['config']]]></source>
 			<source_name>name</source_name>
 			<source_value>name</source_value>
@@ -204,20 +204,21 @@
 			<encoding>base64</encoding>
 		</field>
 		<field>
-		        <type>listtopic</type>
-                        <name>Slave Zone Configuration </name>
-                        <fieldname>temp04</fieldname>
+			<type>listtopic</type>
+			<name>Slave Zone Configuration</name>
+			<fieldname>temp04</fieldname>
 		</field>
 		<field>
 			<fielddescr>Master Zone IP</fielddescr>
 			<fieldname>slaveip</fieldname>
-			<description>If this is a slave zone, enter the IP address of the master DNS server.</description>
+			<description>If this is a slave zone, enter the IP address of the master DNS server.
+			</description>
 			<type>input</type>
 		</field>
 		<field>
-		        <type>listtopic</type>
-                        <name>Forward Zone Configuration </name>
-                        <fieldname>temp04</fieldname>
+			<type>listtopic</type>
+			<name>Forward Zone Configuration</name>
+			<fieldname>temp04</fieldname>
 		</field>
 		<field>
 			<fielddescr>Forwarders</fielddescr>
@@ -228,14 +229,15 @@
 		</field>
 
 		<field>
-		        <type>listtopic</type>
-                        <name>Master Zone Configuration </name>
-                        <fieldname>temp03</fieldname>
+			<type>listtopic</type>
+			<name>Master Zone Configuration</name>
+			<fieldname>temp03</fieldname>
 		</field>
 		<field>
 			<fielddescr>TLL</fielddescr>
 			<fieldname>tll</fieldname>
-			<description>Default expiration time of all resource records without their own TTL value</description>
+			<description>Default expiration time of all resource records without their own TTL value
+			</description>
 			<type>input</type>
 		</field>
 		<field>
@@ -267,35 +269,35 @@
 			<fieldname>refresh</fieldname>
 			<description>Slave refresh (1 day)</description>
 			<type>input</type>
-	                	<default_value>1d</default_value>
+			<default_value>1d</default_value>
 		</field>
 		<field>
 			<fielddescr>Retry</fielddescr>
 			<fieldname>retry</fieldname>
 			<description>Slave retry time in case of a problem (2 hours)</description>
 			<type>input</type>
-	                	<default_value>2h</default_value>
+			<default_value>2h</default_value>
 		</field>
 		<field>
 			<fielddescr>Expire</fielddescr>
 			<fieldname>expire</fieldname>
 			<description>Slave expiration time (4 weeks)</description>
 			<type>input</type>
-	                	<default_value>4w</default_value>
+			<default_value>4w</default_value>
 		</field>
 		<field>
 			<fielddescr>Minimum</fielddescr>
 			<fieldname>minimum</fieldname>
 			<description>Maximum caching time in case of failed lookups (1 hour)</description>
 			<type>input</type>
-	                	<default_value>1h</default_value>
+			<default_value>1h</default_value>
 		</field>
 		<field>
 			<fielddescr>Allow-update</fielddescr>
 			<fieldname>allowupdate</fieldname>
 			<description><![CDATA[Select(CTRL+click) who are allowed to send updates to this zone.<br>
-						Allow-update defines a match list eg IP address(es) that are allowed to submit dynamic updates for 'master' zones ie it enables Dynamic DNS (DDNS).]]></description>
-	    	<type>select_source</type>
+						Allow-update defines a match list eg IP address(es) that are allowed to submit dynamic updates for 'master' zones, ie it enables Dynamic DNS (DDNS).]]></description>
+			<type>select_source</type>
 			<source><![CDATA[$config['installedpackages']['bindacls']['config']]]></source>
 			<source_name>name</source_name>
 			<source_value>name</source_value>
@@ -306,7 +308,7 @@
 			<fielddescr>Allow-query</fielddescr>
 			<fieldname>allowquery</fieldname>
 			<description><![CDATA[Select(CTRL+click) who are allowed to query this zone.<br>
-			Allow-query defines an match list of IP address(es) which are allowed to issue queries to the server.]]></description>
+						Allow-query defines an match list of IP address(es) which are allowed to issue queries to the server.]]></description>
 			<type>select_source</type>
 			<source><![CDATA[$config['installedpackages']['bindacls']['config']]]></source>
 			<source_name>name</source_name>
@@ -319,7 +321,7 @@
 			<fieldname>allowtransfer</fieldname>
 			<description><![CDATA[Select(CTRL+click) who are allowed to copy this zone.<br>
 						Allow-transfer defines a match list eg IP address(es) that are allowed to transfer (copy) the zone information from the server (master or slave for the zone). While on its face this may seem an excessively friendly default, DNS data is essentially public (that's why its there) and the bad guys can get all of it anyway. However if the thought of anyone being able to transfer your precious zone file is repugnant, or (and this is far more significant) you are concerned about possible DoS attack initiated by XFER requests, then use the following policy.]]></description>
-				    	<type>select_source</type>
+			<type>select_source</type>
 			<source><![CDATA[$config['installedpackages']['bindacls']['config']]]></source>
 			<source_name>name</source_name>
 			<source_value>name</source_value>
@@ -327,69 +329,72 @@
 			<size>03</size>
 		</field>
 		<field>
-		        <type>listtopic</type>
-                        <name>Zone Domain records</name>
-                        <fieldname>temp02</fieldname>
+			<type>listtopic</type>
+			<name>Zone Domain records</name>
+			<fieldname>temp02</fieldname>
 		</field>
-                <field>
-                        <fielddescr>Enter Domain records.</fielddescr>
-                        <description><![CDATA[<b>"Record"</b> is the name or last octet of IP. Example: www or pop<br>
-                        		 <b>"Type"</b> is the type of the record Sample: A CNAME MX NS<br>
-                        		 <b>"Priority"</b> in used only in mx records to define its priority<br>
-                        		 <b>"Alias or IP address"</b> is the destination host or ip address.<br><br>
-                        		 You can order elements on this list with drag and drop between columns.]]></description>
-                        <fieldname>none</fieldname>
-                    <type>rowhelper</type>
-                    <rowhelper>
-                        <rowhelperfield>
-                            <fielddescr>Record</fielddescr>
-                            <fieldname>hostname</fieldname>
-                            <description>Enter the Host Name (ex: www)</description>
-                            <type>input</type>
-                            <size>10</size>
-                        </rowhelperfield>
-                        <rowhelperfield>
-			<fielddescr>Type</fielddescr>
-			<fieldname>hosttype</fieldname>
-			<description>Select Type Host</description>
-		        <type>select</type>
-                        	<options>
-                                <option><name>A</name><value>A</value></option>
-                                <option><name>AAAA</name><value>AAAA</value></option>
-                                <option><name>DNAME</name><value>DNAME</value></option>
-                                <option><name>MX</name><value>MX</value></option>
-                                <option><name>CNAME</name><value>CNAME</value></option>
-                                <option><name>NS</name><value>NS</value></option>
-                                <option><name>LOC</name><value>LOC</value></option>
-                                <option><name>SRV</name><value>SRV</value></option>
-                                <option><name>PTR</name><value>PTR</value></option>
-                                <option><name>TXT</name><value>TXT</value></option>
-                                <option><name>SPF</name><value>SPF</value></option>
-                        </options>
-                        </rowhelperfield>
-                        <rowhelperfield>
-                            <fielddescr>Priority</fielddescr>
-                            <fieldname>hostvalue</fieldname>
-                            <description>MX 10 or 20</description>
-                            <type>input</type>
-                            <size>3</size>
-                        </rowhelperfield>
-                        <rowhelperfield>
-                            <fielddescr>Alias or IP address</fielddescr>
-                            <fieldname>hostdst</fieldname>
-                            <description>Enter the IP address or FQDN destination for domain MX (ex: 10.31.11.1 or mail.example.com)</description>
-                            <type>input</type>
-                            <size>35</size>
-                        </rowhelperfield>
-                        <movable>on</movable>
-                    </rowhelper>
-                </field>
+		<field>
+			<fielddescr>Enter Domain records.</fielddescr>
+			<description><![CDATA[<b>"Record"</b> is the name or last octet of IP. Example: www or pop<br>
+						<b>"Type"</b> is the type of the record Sample: A CNAME MX NS<br>
+						<b>"Priority"</b> in used only in mx records to define its priority<br>
+						<b>"Alias or IP address"</b> is the destination host or ip address.<br><br>
+						You can order elements on this list with drag and drop between columns.]]></description>
+			<fieldname>none</fieldname>
+			<type>rowhelper</type>
+			<rowhelper>
+				<rowhelperfield>
+					<fielddescr>Record</fielddescr>
+					<fieldname>hostname</fieldname>
+					<description>Enter the Host Name (ex: www)</description>
+					<type>input</type>
+					<size>10</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Type</fielddescr>
+					<fieldname>hosttype</fieldname>
+					<description>Select Type Host</description>
+					<type>select</type>
+					<options>
+						<option><name>A</name><value>A</value></option>
+						<option><name>AAAA</name><value>AAAA</value></option>
+						<option><name>DNAME</name><value>DNAME</value></option>
+						<option><name>MX</name><value>MX</value></option>
+						<option><name>CNAME</name><value>CNAME</value></option>
+						<option><name>NS</name><value>NS</value></option>
+						<option><name>LOC</name><value>LOC</value></option>
+						<option><name>SRV</name><value>SRV</value></option>
+						<option><name>PTR</name><value>PTR</value></option>
+						<option><name>TXT</name><value>TXT</value></option>
+						<option><name>SPF</name><value>SPF</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Priority</fielddescr>
+					<fieldname>hostvalue</fieldname>
+					<description>MX 10 or 20</description>
+					<type>input</type>
+					<size>3</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Alias or IP address</fielddescr>
+					<fieldname>hostdst</fieldname>
+					<description>Enter the IP address or FQDN destination for domain MX (ex: 10.31.11.1 or mail.example.com)
+					</description>
+					<type>input</type>
+					<size>35</size>
+				</rowhelperfield>
+				<movable>on</movable>
+			</rowhelper>
+		</field>
 		<field>
 			<fieldname>regdhcpstatic</fieldname>
 			<fielddescr>Register DHCP static mappings</fielddescr>
-			<description>If this option is set, then DHCP static mappings will be registered in DNS, so that their name can be resolved.</description>
+			<description>If this option is set, then DHCP static mappings will be registered in DNS, so that
+					their name can be resolved.
+			</description>
 			<type>checkbox</type>
-        </field>
+		</field>
 		<field>
 			<type>listtopic</type>
 			<name>Custom Zone Domain records</name>
@@ -399,13 +404,13 @@
 			<fielddescr></fielddescr>
 			<fieldname>customzonerecords</fieldname>
 			<description><![CDATA[Paste any custom zone records to include in this zone.<br>
-							This can be used for a fast migration setup.]]></description>
-	                <type>textarea</type>
-                        <cols>84</cols>
-                        <rows>10</rows>
-		<encoding>base64</encoding>
-		<dontdisplayname/>
-		<usecolspan2/>
+						This can be used for a fast migration setup.]]></description>
+			<type>textarea</type>
+			<cols>84</cols>
+			<rows>10</rows>
+			<encoding>base64</encoding>
+			<dontdisplayname/>
+			<usecolspan2/>
 		</field>
 		<field>
 			<type>listtopic</type>
@@ -415,31 +420,32 @@
 			<fielddescr></fielddescr>
 			<fieldname>resultconfig</fieldname>
 			<description>Resulting BIND config file for this zone.</description>
-	                <type>textarea</type>
-                        <cols>84</cols>
-                        <rows>15</rows>
-		<encoding>base64</encoding>
-		<dontdisplayname/>
-		<usecolspan2/>
+			<type>textarea</type>
+			<cols>84</cols>
+			<rows>15</rows>
+			<encoding>base64</encoding>
+			<dontdisplayname/>
+			<usecolspan2/>
 		</field>
 	</fields>
-        <custom_php_after_form_command>
-                bind_print_javascript_type_zone2();
-        </custom_php_after_form_command>
-        <custom_php_after_head_command>
-                bind_print_javascript_type_zone();
-        </custom_php_after_head_command>
-        <custom_php_command_before_form>
-        </custom_php_command_before_form>
+	<custom_php_after_form_command>
+		bind_print_javascript_type_zone2();
+	</custom_php_after_form_command>
+	<custom_php_after_head_command>
+		bind_print_javascript_type_zone();
+	</custom_php_after_head_command>
+	<custom_php_command_before_form>
+	</custom_php_command_before_form>
 	<custom_php_validation_command>
-		if ($_POST['type']=="master" and $_POST['serial']=="")
+		if ($_POST['type']=="master" and $_POST['serial']=="") {
 			$_POST['serial']=(date("U")+ 1000000000);
+		}
 		bind_zone_validate($_POST, $input_errors);
 	</custom_php_validation_command>
 	<custom_delete_php_command>
-	        bind_sync();
-	</custom_delete_php_command>	
-        <custom_php_resync_config_command>
-	        bind_sync();
-        </custom_php_resync_config_command>
+		bind_sync();
+	</custom_delete_php_command>
+	<custom_php_resync_config_command>
+		bind_sync();
+	</custom_php_resync_config_command>
 </packagegui>


### PR DESCRIPTION
Code cleanup to reflect coding style guidelines and consistency
Tabs only, always uses braces, spacing
C/C++ style comments
Use array_key_exists instead of key_exists
$config[] keys are always enclosed in quotes and use single quotes for literals