### PR TITLE
repair ramdisk functionality for blacklist updates

### DIFF
--- a/config/squidGuard/squidguard_configurator.inc
+++ b/config/squidGuard/squidguard_configurator.inc
@@ -2038,15 +2038,16 @@ function squidguard_ramdisk($enable)
 
     # delete old squidguard ramdisk
     if (file_exists("/dev/md15")) {
-        mwexec("umount -f " . SQUIDGUARD_TMP);
+        mwexec("/sbin/umount -f " . SQUIDGUARD_TMP);
         mwexec("sleep 1");
-        mwexec("mdconfig -d -u 15");
+        mwexec("/sbin/mdconfig -d -u 15");
     }
 
     if ($enable === true) {
         # create temp ramdisk
         # size 300Mb very nice for work with Archive < 30Mb
         # this is size use physical RAM + Swap file
+        mwexec("mkdir -p ".SQUIDGUARD_TMP);
         mwexec("/sbin/mdmfs -s {$ramsize}M md15 " . SQUIDGUARD_TMP);
         mwexec("chmod 1777 " . SQUIDGUARD_TMP);
     }

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -990,7 +990,7 @@
 		<website>http://www.squidGuard.org/</website>
 		<maintainer>dv_serg@mail.ru</maintainer>
 		<category>Network Management</category>
-		<version>1.4_7 pkg v.1.9.12</version>
+		<version>1.4_7 pkg v.1.9.13</version>
 		<status>Beta</status>
 		<required_version>2.2</required_version>
 		<depends_on_package_pbi>squidguard-1.4_7-##ARCH##.pbi</depends_on_package_pbi>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1292,7 +1292,7 @@
 		<website>http://www.squidGuard.org/</website>
 		<maintainer>dv_serg@mail.ru</maintainer>
 		<category>Network Management</category>
-		<version>1.4_4 pkg v.1.9.12</version>
+		<version>1.4_4 pkg v.1.9.13</version>
 		<status>Beta</status>
 		<required_version>1.1</required_version>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
@@ -1337,7 +1337,7 @@
 		<website>http://www.squidGuard.org/</website>
 		<maintainer>dv_serg@mail.ru</maintainer>
 		<category>Network Management</category>
-		<version>1.4_4 pkg v.1.9.12</version>
+		<version>1.4_4 pkg v.1.9.13</version>
 		<status>Beta</status>
 		<required_version>2.1</required_version>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1279,7 +1279,7 @@
 		<website>http://www.squidGuard.org/</website>
 		<maintainer>dv_serg@mail.ru</maintainer>
 		<category>Network Management</category>
-		<version>1.4_4 pkg v.1.9.12</version>
+		<version>1.4_4 pkg v.1.9.13</version>
 		<status>Beta</status>
 		<required_version>1.1</required_version>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
@@ -1324,7 +1324,7 @@
 		<website>http://www.squidGuard.org/</website>
 		<maintainer>dv_serg@mail.ru</maintainer>
 		<category>Network Management</category>
-		<version>1.4_4 pkg v.1.9.12</version>
+		<version>1.4_4 pkg v.1.9.13</version>
 		<status>Beta</status>
 		<required_version>2.1</required_version>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>


### PR DESCRIPTION
mountpoint for ramdisk needs to be created first, if not yet existing.
umount needs complete path.
