### PR TITLE
freeradius2: Show max shared secret length

### DIFF
--- a/config/freeradius2/freeradiusclients.xml
+++ b/config/freeradius2/freeradiusclients.xml
@@ -163,7 +163,7 @@
 		<field>
 			<fielddescr>Client Shared Secret</fielddescr>
 			<fieldname>varclientsharedsecret</fieldname>
-			<description><![CDATA[Enter the shared secret of the RADIUS client here. This is the shared secret (password) which the NAS (switch or accesspoint) needs to communicate with the RADIUS server.]]></description>
+			<description><![CDATA[Enter the shared secret of the RADIUS client here. This is the shared secret (password) which the NAS (switch or accesspoint) needs to communicate with the RADIUS server. FreeRADIUS is limited to 31 characters for the shared secret.]]></description>
 			<type>password</type>
 			<required/>
 		</field>


### PR DESCRIPTION
Shared secrets longer than 31 characters will display garbage passwords.
Another cause of garbage passwords being logged is the secret being too long. Certain NAS boxes have limitations on the length of the secret and don't complain about it. FreeRADIUS is limited to 31 characters for the shared secret.

http://wiki.freeradius.org/guide/faq#Common-problems-and-their-solutions