### PR TITLE
squidguard: repair ramdisk functionality for blacklist updates

### DIFF
--- a/config/squidGuard/squidguard_configurator.inc
+++ b/config/squidGuard/squidguard_configurator.inc
@@ -2038,15 +2038,16 @@ function squidguard_ramdisk($enable)
 
     # delete old squidguard ramdisk
     if (file_exists("/dev/md15")) {
-        mwexec("umount -f " . SQUIDGUARD_TMP);
+        mwexec("/sbin/umount -f " . SQUIDGUARD_TMP);
         mwexec("sleep 1");
-        mwexec("mdconfig -d -u 15");
+        mwexec("/sbin/mdconfig -d -u 15");
     }
 
     if ($enable === true) {
         # create temp ramdisk
         # size 300Mb very nice for work with Archive < 30Mb
         # this is size use physical RAM + Swap file
+        mkdir(SQUIDGUARD_TMP);
         mwexec("/sbin/mdmfs -s {$ramsize}M md15 " . SQUIDGUARD_TMP);
         mwexec("chmod 1777 " . SQUIDGUARD_TMP);
     }


### PR DESCRIPTION
mountpoint for ramdisk needs to be created first, now used PHP mkdir().
umount and mdconfig need complete path.