### PR TITLE
BIND - fix rate-limit option - remove {}

### DIFF
--- a/config/bind/bind.inc
+++ b/config/bind/bind.inc
@@ -179,8 +179,8 @@ EOD;
 		$log_only = ($bind['log_only'] == "no" ? "no" : "yes");
 		$bind_conf .= <<<EOD
 	rate-limit {
-		responses-per-second { $rate_limit };
-		log-only { $log_only };
+		responses-per-second $rate_limit;
+		log-only $log_only;
 	};
 
 EOD;

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -53,7 +53,7 @@
 		<descr><![CDATA[The most widely used name server software]]></descr>
 		<website>http://www.isc.org/downloads/BIND/</website>
 		<category>Services</category>
-		<version>9.9.6P1_3 pkg v 0.3.7</version>
+		<version>9.9.6P1_3 pkg v 0.3.8</version>
 		<status>RC</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/bind/bind.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -53,7 +53,7 @@
 		<descr><![CDATA[The most widely used name server software]]></descr>
 		<website>http://www.isc.org/downloads/BIND/</website>
 		<category>Services</category>
-		<version>9.9.5P1_5 pkg v 0.3.7</version>
+		<version>9.9.5P1_5 pkg v 0.3.8</version>
 		<status>RC</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/bind/bind.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -53,7 +53,7 @@
 		<descr><![CDATA[The most widely used name server software]]></descr>
 		<website>http://www.isc.org/downloads/BIND/</website>
 		<category>Services</category>
-		<version>9.9.5P1_5 pkg v 0.3.7</version>
+		<version>9.9.5P1_5 pkg v 0.3.8</version>
 		<status>RC</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/bind/bind.xml</config_file>


### PR DESCRIPTION
The rate-limit option should not have values with {} and look like this:

rate-limit {
    responses-per-second 15;
    log-only yes;
  };