### PR TITLE
Allow open bg pd use with carp and ix

### DIFF
--- a/config/openbgpd/openbgpd_neighbors.xml
+++ b/config/openbgpd/openbgpd_neighbors.xml
@@ -136,6 +136,7 @@
 						<option><name>Announce none</name><value>announce none</value></option>
 						<option><name>Announce self</name><value>announce self</value></option>
 						<option><name>Announce default-route</name><value>announce default-route</value></option>
+						<option><name>Depend on X</name><value>Depend on</value></option>
 						<option><name>Enforce Neighbor-AS X</name><value>enforce neighbor-as</value></option>
 						<option><name>Holdtime X</name><value>holdtime</value></option>
 						<option><name>Metric X</name><value>set metric</value></option>

--- a/config/openbgpd/openbgpd_neighbors.xml
+++ b/config/openbgpd/openbgpd_neighbors.xml
@@ -136,6 +136,7 @@
 						<option><name>Announce none</name><value>announce none</value></option>
 						<option><name>Announce self</name><value>announce self</value></option>
 						<option><name>Announce default-route</name><value>announce default-route</value></option>
+						<option><name>Enforce Neighbor-AS X</name><value>enforce neighbor-as</value></option>
 						<option><name>Holdtime X</name><value>holdtime</value></option>
 						<option><name>Metric X</name><value>set metric</value></option>
 						<option><name>Multihop X</name><value>multihop</value></option>

--- a/config/openbgpd/openbgpd_neighbors.xml
+++ b/config/openbgpd/openbgpd_neighbors.xml
@@ -136,7 +136,7 @@
 						<option><name>Announce none</name><value>announce none</value></option>
 						<option><name>Announce self</name><value>announce self</value></option>
 						<option><name>Announce default-route</name><value>announce default-route</value></option>
-						<option><name>Depend on X</name><value>Depend on</value></option>
+						<option><name>Depend on X</name><value>depend on</value></option>
 						<option><name>Enforce Neighbor-AS X</name><value>enforce neighbor-as</value></option>
 						<option><name>Holdtime X</name><value>holdtime</value></option>
 						<option><name>Metric X</name><value>set metric</value></option>


### PR DESCRIPTION
I think "depend on" might normally be handled by local-address, but not everyone wants to do it that way.
The other setting, enforce neighbor-as, is required when connecting to an IX that hides its internal ASN.