### PR TITLE
Use last working stable release of check-mk-agent (v1.2.5i7)

### DIFF
--- a/config/checkmk-agent/checkmk.inc
+++ b/config/checkmk-agent/checkmk.inc
@@ -39,7 +39,7 @@ define('ETC_RC_CONF','/etc/rc.conf.local');
 function checkmk_install() {
 	// Download latest check_mk version from head repo
 	$checkmk_bin="/usr/local/bin/check_mk_agent";
-	mwexec("fetch -o {$checkmk_bin} 'http://git.mathias-kettner.de/git/?p=check_mk.git;a=blob_plain;f=agents/check_mk_agent.freebsd;hb=refs/heads/1.2.6'");
+	mwexec("fetch -o {$checkmk_bin} 'http://git.mathias-kettner.de/git/?p=check_mk.git;a=blob_plain;f=agents/check_mk_agent.freebsd;hb=e13899bde8bdafe13780427811c8153c59be807f'");
 	chmod($checkmk_bin,0755);
 	sync_package_checkmk();
 }
@@ -69,7 +69,7 @@ function sync_package_checkmk() {
 	$checkmk_bin="/usr/local/bin/check_mk_agent";
 	if (!file_exists($checkmk_bin) && $mk_config['checkmkenable']=="on"){
 		$error = "Check_mk-agent Binary file not found";
-		log_error($error." You can manually download it using this cmd: fetch -o {$checkmk_bin} 'http://git.mathias-kettner.de/git/?p=check_mk.git;a=blob_plain;f=agents/check_mk_agent.freebsd;hb=refs/heads/1.2.6'");
+		log_error($error." You can manually download it using this cmd: fetch -o {$checkmk_bin} 'http://git.mathias-kettner.de/git/?p=check_mk.git;a=blob_plain;f=agents/check_mk_agent.freebsd;hb=e13899bde8bdafe13780427811c8153c59be807f'");
 		file_notice("Check_mk-agent", $error, "checkmk save config", "");
 		return;
 		}


### PR DESCRIPTION
Never versions are not compabile with pfsense since they
depend on bash instead of sh.