### PR TITLE
Fix invalid proxyport default

### DIFF
--- a/config/dansguardian/dansguardian.inc
+++ b/config/dansguardian/dansguardian.inc
@@ -164,7 +164,7 @@ function sync_package_dansguardian($via_rpc="no",$install_process=false) {
 	$maxips=($dansguardian['maxips']?$dansguardian['maxips']:"0");
 	$preforkchildren=($dansguardian['preforkchildren']?$dansguardian['preforkchildren']:"10");
 	$proxyip=($dansguardian['proxyip']?$dansguardian['proxyip']:"127.0.0.1");
-	$proxyport=($dansguardian['proxyport']?$dansguardian['proxyport']:"127.0.0.1");
+	$proxyport=($dansguardian['proxyport']?$dansguardian['proxyport']:"3128");
 	$proxytimeout=($dansguardian['proxytimeout']?$dansguardian['proxytimeout']:"30");
 	
 	#general options


### PR DESCRIPTION
proxyport setting defaults to localhost IP address rather than default squid proxy port