### PR TITLE
Added (default enabled) option to name exported VPN config based on V…

### DIFF
--- a/config/openvpn-client-export/openvpn-client-export.inc
+++ b/config/openvpn-client-export/openvpn-client-export.inc
@@ -44,17 +44,20 @@ $current_openvpn_version_rev = "03";
 
 function openvpn_client_export_install() {
 	global $current_openvpn_version;
-	conf_mount_rw();
-	$tarpath = "/usr/local/pkg/openvpn-client-export-{$current_openvpn_version}.tgz";
-	$phpfile = "vpn_openvpn_export.php";
-	$ovpndir = "/usr/local/share/openvpn";
-	$workdir = "{$ovpndir}/client-export";
 
-	if (!is_dir($workdir))
-		mkdir($workdir, 0777, true);
+	$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
+	if ($pfs_version == "2.1" || $pfs_version == "2.2") {
+		conf_mount_rw();
+		$tarpath = "/usr/local/pkg/openvpn-client-export-{$current_openvpn_version}.tgz";
+		$ovpndir = "/usr/local/share/openvpn";
+		$workdir = "{$ovpndir}/client-export";
 
-	exec("/usr/bin/tar zxf {$tarpath} -C {$ovpndir}");
-	conf_mount_ro();
+		if (!is_dir($workdir))
+			mkdir($workdir, 0777, true);
+
+		exec("/usr/bin/tar zxf {$tarpath} -C {$ovpndir}");
+		conf_mount_ro();
+	}
 }
 
 function openvpn_client_export_deinstall() {
@@ -137,7 +140,7 @@ function openvpn_client_export_validate_config($srvid, $usrid, $crtid) {
 
 	// lookup server certificate info
 	$server_cert = lookup_cert($settings['certref']);
-	if (!$server_cert) 
+	if (!$server_cert)
 	{
 		$input_errors[] = "Could not locate server certificate.";
 	} else {
@@ -182,7 +185,7 @@ function openvpn_client_export_validate_config($srvid, $usrid, $crtid) {
 
 	if ($input_errors)
 		return false;
-		
+
 	return array($settings, $server_cert, $server_ca, $servercn, $user, $cert, $nokeys);
 }
 
@@ -259,7 +262,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 			}
 			$conf .= "http-proxy {$proxy['ip']} {$proxy['port']} ";
 		}
-		if ($proxy['proxy_type'] == "socks") 
+		if ($proxy['proxy_type'] == "socks")
 			$conf .= "socks-proxy {$proxy['ip']} {$proxy['port']} ";
 		if ($proxy['proxy_authtype'] != "none") {
 			if (!isset($proxy['passwdfile']))
@@ -367,7 +370,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 		$conf .= "management-forget-disconnect{$nl}";
 		$conf .= $nl;
 	};
-		
+
 	// add advanced options
 	$advancedoptions = str_replace("\r\n", "\n", $advancedoptions);
 	$advancedoptions = str_replace("\n", $nl, $advancedoptions);
@@ -813,7 +816,7 @@ function openvpn_client_export_sharedkey_config($srvid, $useaddr, $proxy, $zipco
 			}
 			$conf .= "http-proxy {$proxy['ip']} {$proxy['port']} ";
 		}
-		if ($proxy['proxy_type'] == "socks") 
+		if ($proxy['proxy_type'] == "socks")
 			$conf .= "socks-proxy {$proxy['ip']} {$proxy['port']} ";
 		if ($proxy['proxy_authtype'] != "none") {
 			if (!isset($proxy['passwdfile']))

--- a/config/openvpn-client-export/openvpn-client-export.inc
+++ b/config/openvpn-client-export/openvpn-client-export.inc
@@ -44,20 +44,17 @@ $current_openvpn_version_rev = "03";
 
 function openvpn_client_export_install() {
 	global $current_openvpn_version;
+	conf_mount_rw();
+	$tarpath = "/usr/local/pkg/openvpn-client-export-{$current_openvpn_version}.tgz";
+	$phpfile = "vpn_openvpn_export.php";
+	$ovpndir = "/usr/local/share/openvpn";
+	$workdir = "{$ovpndir}/client-export";
 
-	$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
-	if ($pfs_version == "2.1" || $pfs_version == "2.2") {
-		conf_mount_rw();
-		$tarpath = "/usr/local/pkg/openvpn-client-export-{$current_openvpn_version}.tgz";
-		$ovpndir = "/usr/local/share/openvpn";
-		$workdir = "{$ovpndir}/client-export";
+	if (!is_dir($workdir))
+		mkdir($workdir, 0777, true);
 
-		if (!is_dir($workdir))
-			mkdir($workdir, 0777, true);
-
-		exec("/usr/bin/tar zxf {$tarpath} -C {$ovpndir}");
-		conf_mount_ro();
-	}
+	exec("/usr/bin/tar zxf {$tarpath} -C {$ovpndir}");
+	conf_mount_ro();
 }
 
 function openvpn_client_export_deinstall() {
@@ -75,7 +72,7 @@ function openvpn_client_export_deinstall() {
 	conf_mount_ro();
 }
 
-function openvpn_client_export_prefix($srvid, $usrid = null, $crtid = null) {
+function openvpn_client_export_prefix($srvid, $usrid = null, $crtid = null, $usevpndescription) {
 	global $config;
 
 	// lookup server settings
@@ -88,14 +85,23 @@ function openvpn_client_export_prefix($srvid, $usrid = null, $crtid = null) {
 	$host = empty($config['system']['hostname']) ? "openvpn" : $config['system']['hostname'];
 	$prot = ($settings['protocol'] == 'UDP' ? 'udp' : $settings['protocol']);
 	$port = $settings['local_port'];
-	
+	$description = $settings['description'];
+
+	// strip out unwanted characters from the description (spaces etc make for bad filenames)
+	$description = $string = preg_replace('/[^\d\-a-z]/i', '', $description);
+
 	$filename_addition = "";
 	if ($usrid && is_numeric($usrid))
 		$filename_addition = "-".$config['system']['user'][$usrid]['name'];
 	elseif ($crtid && is_numeric($crtid) && function_exists("cert_get_cn"))
 		$filename_addition = "-" . str_replace(' ', '_', cert_get_cn($config['cert'][$crtid]['crt']));
 
-	return "{$host}-{$prot}-{$port}{$filename_addition}";
+	// if the usevpndescription variable is set, use the VPN description instead of the host-proto-port combination
+	if ($usevpndescription) {
+		return "{$description}{$filename_addition}";
+	} else {
+		return "{$host}-{$prot}-{$port}{$filename_addition}";
+	}
 }
 
 function openvpn_client_pem_to_pk12($outpath, $outpass, $crtpath, $keypath, $capath = false) {
@@ -180,7 +186,7 @@ function openvpn_client_export_validate_config($srvid, $usrid, $crtid) {
 	return array($settings, $server_cert, $server_ca, $servercn, $user, $cert, $nokeys);
 }
 
-function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usetoken, $nokeys = false, $proxy, $expformat = "baseconf", $outpass = "", $skiptls=false, $doslines=false, $openvpnmanager, $advancedoptions = "") {
+function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usevpndescription, $usetoken, $nokeys = false, $proxy, $expformat = "baseconf", $outpass = "", $skiptls=false, $doslines=false, $openvpnmanager, $advancedoptions = "") {
 	global $config, $input_errors, $g;
 	$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
 
@@ -257,7 +263,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 			$conf .= "socks-proxy {$proxy['ip']} {$proxy['port']} ";
 		if ($proxy['proxy_authtype'] != "none") {
 			if (!isset($proxy['passwdfile']))
-				$proxy['passwdfile'] = openvpn_client_export_prefix($srvid, $usrid, $crtid) . "-proxy";
+				$proxy['passwdfile'] = openvpn_client_export_prefix($srvid, $usrid, $crtid, $usevpndescription) . "-proxy";
 			$conf .= " {$proxy['passwdfile']} {$proxy['proxy_authtype']}";
 		}
 		$conf .= "{$nl}";
@@ -272,7 +278,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 	}
 
 	// add key settings
-	$prefix = openvpn_client_export_prefix($srvid, $usrid, $crtid);
+	$prefix = openvpn_client_export_prefix($srvid, $usrid, $crtid, $usevpndescription);
 	$cafile = "{$prefix}-ca.crt";
 	if($nokeys == false) {
 		if ($expformat == "yealink_t28") {
@@ -488,7 +494,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 	}
 }
 
-function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usetoken, $outpass, $proxy, $openvpnmanager, $advancedoptions, $openvpn_version = "x86-xp") {
+function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usevpndescription, $usetoken, $outpass, $proxy, $openvpnmanager, $advancedoptions, $openvpn_version = "x86-xp") {
 	global $config, $g, $input_errors, $current_openvpn_version, $current_openvpn_version_rev;
 	$uname_p = trim(exec("uname -p"));
 
@@ -538,7 +544,7 @@ function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $veri
 		rename("{$tempdir}/openvpn-postinstall64.exe", "{$tempdir}/openvpn-postinstall.exe");
 
 	// write configuration file
-	$prefix = openvpn_client_export_prefix($srvid, $usrid, $crtid);
+	$prefix = openvpn_client_export_prefix($srvid, $usrid, $crtid, $usevpndescription);
 	$cfgfile = "{$confdir}/{$prefix}-config.ovpn";
 	if (!empty($proxy) && $proxy['proxy_authtype'] != "none") {
 		$proxy['passwdfile'] = "{$prefix}-password";
@@ -546,7 +552,7 @@ function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $veri
 		$pwdfle .= "{$proxy['password']}\r\n";
 		file_put_contents("{$confdir}/{$proxy['passwdfile']}", $pwdfle);
 	}
-	$conf = openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usetoken,  $nokeys, $proxy, "", "baseconf", false, true, $openvpnmanager, $advancedoptions);
+	$conf = openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usevpndescription, $usetoken,  $nokeys, $proxy, "", "baseconf", false, true, $openvpnmanager, $advancedoptions);
 	if (!$conf) {
 		$input_errors[] = "Could not create a config to export.";
 		return false;
@@ -611,7 +617,7 @@ RunProgram="openvpn-postinstall.exe"
 	return $outfile;
 }
 
-function viscosity_openvpn_client_config_exporter($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usetoken, $outpass, $proxy, $openvpnmanager, $advancedoptions) {
+function viscosity_openvpn_client_config_exporter($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usevpndescription, $usetoken, $outpass, $proxy, $openvpnmanager, $advancedoptions) {
 	global $config, $g;
 	$uname_p = trim(exec("uname -p"));
 
@@ -638,7 +644,7 @@ function viscosity_openvpn_client_config_exporter($srvid, $usrid, $crtid, $usead
 	$tempdir = $tempdir . "/Viscosity.visc/";
 
 	// write cofiguration file
-	$prefix = openvpn_client_export_prefix($srvid, $usrid, $crtid);
+	$prefix = openvpn_client_export_prefix($srvid, $usrid, $crtid, $usevpndescription);
 	if (!empty($proxy) && $proxy['proxy_authtype'] != "none") {
 		$proxy['passwdfile'] = "config-password";
 		$pwdfle = "{$proxy['user']}\n";
@@ -646,7 +652,7 @@ function viscosity_openvpn_client_config_exporter($srvid, $usrid, $crtid, $usead
 		file_put_contents("{$tempdir}/{$proxy['passwdfile']}", $pwdfle);
 	}
 
-	$conf = openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usetoken, true, $proxy, "baseconf", $outpass, true, true, $openvpnmanager, $advancedoptions);
+	$conf = openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usevpndescription, $usetoken, true, $proxy, "baseconf", $outpass, true, true, $openvpnmanager, $advancedoptions);
 	if (!$conf)
 		return false;
 

--- a/config/openvpn-client-export/vpn_openvpn_export.php
+++ b/config/openvpn-client-export/vpn_openvpn_export.php
@@ -146,6 +146,7 @@ if (!empty($act)) {
 
 	$verifyservercn = $_GET['verifyservercn'];
 	$randomlocalport = $_GET['randomlocalport'];
+	$usevpndescription = $_GET['usevpndescription'];
 	$usetoken = $_GET['usetoken'];
 	if ($usetoken && (substr($act, 0, 10) == "confinline"))
 		$input_errors[] = "You cannot use Microsoft Certificate Storage with an Inline configuration.";
@@ -180,7 +181,7 @@ if (!empty($act)) {
 		}
 	}
 
-	$exp_name = openvpn_client_export_prefix($srvid, $usrid, $crtid);
+	$exp_name = openvpn_client_export_prefix($srvid, $usrid, $crtid, $usevpndescription);
 
 	if(substr($act, 0, 4) == "conf") {
 		switch ($act) {
@@ -220,17 +221,17 @@ if (!empty($act)) {
 				$exp_name = urlencode($exp_name."-config.ovpn");
 				$expformat = "baseconf";
 		}
-		$exp_path = openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usetoken, $nokeys, $proxy, $expformat, $password, false, false, $openvpnmanager, $advancedoptions);
+		$exp_path = openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usevpndescription, $usetoken, $nokeys, $proxy, $expformat, $password, false, false, $openvpnmanager, $advancedoptions);
 	}
 
 	if($act == "visc") {
 		$exp_name = urlencode($exp_name."-Viscosity.visc.zip");
-		$exp_path = viscosity_openvpn_client_config_exporter($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usetoken, $password, $proxy, $openvpnmanager, $advancedoptions);
+		$exp_path = viscosity_openvpn_client_config_exporter($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usevpndescription, $usetoken, $password, $proxy, $openvpnmanager, $advancedoptions);
 	}
 
 	if(substr($act, 0, 4) == "inst") {
 		$exp_name = urlencode($exp_name."-install.exe");
-		$exp_path = openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usetoken, $password, $proxy, $openvpnmanager, $advancedoptions, substr($act, 5));
+		$exp_path = openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $verifyservercn, $randomlocalport, $usevpndescription, $usetoken, $password, $proxy, $openvpnmanager, $advancedoptions, substr($act, 5));
 	}
 
 	if (!$exp_path) {
@@ -317,6 +318,9 @@ function download_begin(act, i, j) {
 	var randomlocalport = 0;
 	if (document.getElementById("randomlocalport").checked)
 		randomlocalport = 1;
+	var usevpndescription = 0;
+	if (document.getElementById("usevpndescription").checked)
+		usevpndescription = 1;
 	var usetoken = 0;
 	if (document.getElementById("usetoken").checked)
 		usetoken = 1;
@@ -392,6 +396,7 @@ function download_begin(act, i, j) {
 	dlurl += "&useaddr=" + escape(useaddr);
 	dlurl += "&verifyservercn=" + escape(verifyservercn);
 	dlurl += "&randomlocalport=" + escape(randomlocalport);
+	dlurl += "&usevpndescription=" + escape(usevpndescription);
 	dlurl += "&openvpnmanager=" + escape(openvpnmanager);
 	dlurl += "&usetoken=" + escape(usetoken);
 	if (usepass)
@@ -681,6 +686,26 @@ function useproxy_changed(obj) {
 								<tr>
 									<td colspan="2">
 										<span class="vexpl"><br/>NOTE: Not supported on older clients. Automatically disabled for Yealink and Snom configurations.</span>
+									</td>
+								</tr>
+							</table>
+					</tr>
+					<tr>
+						<td width="22%" valign="top" class="vncell">Use VPN description for export</td>
+						<td width="78%" class="vtable">
+							 <table border="0" cellpadding="2" cellspacing="0" summary="use vpn description">
+								<tr>
+									<td valign=top>
+										<input name="usevpndescription" id="usevpndescription" type="checkbox" value="yes" checked="CHECKED" />
+									</td>
+									<td>
+										<span class="vexpl">
+										Use the VPN description (as defined in VPN settings) as the prefix for exported configuration files, rather than an auto-generated combination of hostname, protocol, and port. This makes the client install package more consistent and user-friendly. The username or certificate name will still be appended to the generated filename, e.g. <i><b>acme-inc-wiley.ovpn</b></i></span>
+									</td>
+								</tr>
+								<tr>
+									<td colspan="2">
+										<span class="vexpl"><br/>NOTE: Non-alphanumeric characters will be stripped from the description prior to export.</span>
 									</td>
 								</tr>
 							</table>


### PR DESCRIPTION
…PN description

We use the client-export utility to create VPN configs for our users, and the
default naming convention of <hostname>-<protocol>-<port>-<user> is a little
unfriendly. I modified the web UI and the function which generates the config
to pass a flag (default enabled) which will instead name the VPN