### PR TITLE
Allow multiple destinations in ftp proxy bypass

### DIFF
--- a/config/ftpproxy/ftpproxy.inc
+++ b/config/ftpproxy/ftpproxy.inc
@@ -78,8 +78,14 @@ function validate_form_ftpproxy($post, &$input_errors) {
 	if (!empty($post["bypasssrc"]) && !(is_alias($post["bypasssrc"]) || is_subnetv4($post["bypasssrc"]) || is_ipaddr($post["bypasssrc"]))) {
 		$input_errors[] = 'You must specify a valid IP address or alias for Proxy Bypass: Source';
 	}
-	if (!empty($post["bypassdst"]) && !(is_alias($post["bypassdst"]) || is_subnetv4($post["bypassdst"]) || is_ipaddr($post["bypassdst"]))) {
-		$input_errors[] = 'You must specify a valid IP address or alias for Proxy Bypass: Destination';
+	if (!empty($post["bypassdst"])) {
+		$bypassdsts = explode(",", $post['bypassdst']);
+		foreach ($bypassdsts as $bypassdst) {
+			$bypassdst = trim($bypassdst);
+			if(!(is_alias($bypassdst) || is_subnetv4($bypassdst) || is_ipaddr($bypassdst))) {
+				$input_errors[] = "You must specify a valid IP address or alias for Proxy Bypass: Destination - {$bypassdst} is not valid";
+			}
+		}
 	}
 }
 
@@ -128,10 +134,14 @@ function ftpproxy_generate_rules($type) {
 				} elseif (is_alias($cf["bypasssrc"])) {
 					$rules .= "no rdr on {$interface} inet proto tcp from \${$cf['bypasssrc']} to any port 21\n";
 				}
-				if (is_subnetv4($cf["bypassdst"]) || is_ipaddr($cf["bypassdst"])) {
-					$rules .= "no rdr on {$interface} inet proto tcp from any to {$cf['bypassdst']} port 21\n";
-				} elseif (is_alias($cf["bypassdst"])) {
-					$rules .= "no rdr on {$interface} inet proto tcp from any to \${$cf['bypassdst']} port 21\n";
+				$bypassdsts = explode(",", $cf['bypassdst']);
+				foreach ($bypassdsts as $bypassdst) {
+					$bypassdst = trim($bypassdst);
+					if (is_subnetv4($bypassdst) || is_ipaddr($bypassdst)) {
+						$rules .= "no rdr on {$interface} inet proto tcp from any to {$bypassdst} port 21\n";
+					} elseif (is_alias($bypassdst)) {
+						$rules .= "no rdr on {$interface} inet proto tcp from any to \${$bypassdst} port 21\n";
+					}
 				}
 				$rules .= "rdr pass on {$interface} inet proto tcp from any to any port 21 -> 127.0.0.1 port " . ftpproxy_get_port() . "\n";
 			}

--- a/config/ftpproxy/ftpproxy.xml
+++ b/config/ftpproxy/ftpproxy.xml
@@ -62,9 +62,9 @@
 			<type>input</type>
 		</field>
 		<field>
-			<fielddescr>Proxy Bypass: Destination</fielddescr>
+			<fielddescr>Proxy Bypass: Destination(s)</fielddescr>
 			<fieldname>bypassdst</fieldname>
-			<description>Enter an IP address or alias for destination server host(s) which should bypass the proxy.</description>
+			<description>Enter an IP address or alias for destination server host(s) which should bypass the proxy. Comma-separate for multiple destinations.</description>
 			<type>input</type>
 		</field>
 		<field>


### PR DESCRIPTION
In the FTP proxy it is only possible at present to provide a single destination.

This allows multiple destinations to be specified that will bypass the proxy if they are separated by a comma.

They need not all be the same type (one may be an IP address, another an alias for example) and spaces around the commas are ignored.