### PR TITLE
Suricata 2.1.5 Update

### DIFF
--- a/config/suricata/suricata.xml
+++ b/config/suricata/suricata.xml
@@ -42,7 +42,7 @@
 	<description>Suricata IDS/IPS Package</description>
 	<requirements>None</requirements>
 	<name>suricata</name>
-	<version>2.0.4 pkg v2.1.4</version>
+	<version>2.0.8 pkg v2.1.5</version>
 	<title>Services: Suricata IDS</title>
 	<include_file>/usr/local/pkg/suricata/suricata.inc</include_file>
 	<menu>

--- a/config/suricata/suricata_check_cron_misc.inc
+++ b/config/suricata/suricata_check_cron_misc.inc
@@ -104,6 +104,9 @@ function suricata_check_dir_size_limit($suricataloglimitsize) {
 			// Check for any captured stored files and clean them up
 			unlink_if_exists("{$suricata_log_dir}/files/*");
 
+			// Check for any captured stored TLS certs and clean them up
+			unlink_if_exists("{$suricata_log_dir}/certs/*");
+
 			// This is needed if suricata is run as suricata user
 			mwexec('/bin/chmod 660 /var/log/suricata/*', true);
 		}
@@ -234,6 +237,23 @@ if ($config['installedpackages']['suricata']['config'][0]['enable_log_mgmt'] == 
 			}
 			if ($prune_count > 0)
 				log_error(gettext("[Suricata] File Store cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/files/..."));
+			unset($files);
+		}
+
+		// Prune aged-out TLS Certs Store files if any exist
+		if (is_dir("{$suricata_log_dir}/certs") &&
+		    $config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] > 0) {
+			$now = time();
+			$files = glob("{$suricata_log_dir}/certs/*.*");
+			$prune_count = 0;
+			foreach ($files as $f) {
+				if (($now - filemtime($f)) > ($config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] * 3600)) {
+					$prune_count++;
+					unlink_if_exists($f);
+				}
+			}
+			if ($prune_count > 0)
+				log_error(gettext("[Suricata] TLS Certs Store cleanup job removed {$prune_count} file(s) from {$suricata_log_dir}/certs/..."));
 			unset($files);
 		}
 

--- a/config/suricata/suricata_logs_mgmt.php
+++ b/config/suricata/suricata_logs_mgmt.php
@@ -67,6 +67,7 @@ $pconfig['tls_log_retention'] = $config['installedpackages']['suricata']['config
 $pconfig['unified2_log_limit'] = $config['installedpackages']['suricata']['config'][0]['unified2_log_limit'];
 $pconfig['u2_archive_log_retention'] = $config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention'];
 $pconfig['file_store_retention'] = $config['installedpackages']['suricata']['config'][0]['file_store_retention'];
+$pconfig['tls_certs_store_retention'] = $config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'];
 $pconfig['dns_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['dns_log_limit_size'];
 $pconfig['dns_log_retention'] = $config['installedpackages']['suricata']['config'][0]['dns_log_retention'];
 $pconfig['eve_log_limit_size'] = $config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'];
@@ -112,6 +113,8 @@ if (!isset($pconfig['u2_archive_log_retention']))
 	$pconfig['u2_archive_log_retention'] = "168";
 if (!isset($pconfig['file_store_retention']))
 	$pconfig['file_store_retention'] = "168";
+if (!isset($pconfig['tls_certs_store_retention']))
+	$pconfig['tls_certs_store_retention'] = "168";
 if (!isset($pconfig['eve_log_retention']))
 	$pconfig['eve_log_retention'] = "168";
 if (!isset($pconfig['sid_changes_log_retention']))
@@ -151,6 +154,7 @@ if ($_POST['ResetAll']) {
 	$pconfig['tls_log_retention'] = "336";
 	$pconfig['u2_archive_log_retention'] = "168";
 	$pconfig['file_store_retention'] = "168";
+	$pconfig['tls_certs_store_retention'] = "168";
 	$pconfig['eve_log_retention'] = "168";
 	$pconfig['sid_changes_log_retention'] = "336";
 
@@ -216,6 +220,7 @@ if ($_POST["save"] || $_POST['apply']) {
 		$config['installedpackages']['suricata']['config'][0]['unified2_log_limit'] = $_POST['unified2_log_limit'];
 		$config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention'] = $_POST['u2_archive_log_retention'];
 		$config['installedpackages']['suricata']['config'][0]['file_store_retention'] = $_POST['file_store_retention'];
+		$config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] = $_POST['tls_certs_store_retention'];
 		$config['installedpackages']['suricata']['config'][0]['dns_log_limit_size'] = $_POST['dns_log_limit_size'];
 		$config['installedpackages']['suricata']['config'][0]['dns_log_retention'] = $_POST['dns_log_retention'];
 		$config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'] = $_POST['eve_log_limit_size'];
@@ -585,6 +590,19 @@ if ($savemsg) {
 		</select>&nbsp;<?=gettext("Choose retention period for captured files in File Store. Default is ") . "<strong>" . gettext("7 days."). "</strong>";?><br/><br/>
 		<?=gettext("When file capture and store is enabled, Suricata captures downloaded files from HTTP sessions and stores them, along with metadata, ") . 
 		gettext("for later analysis.  This setting determines how long files remain in the File Store folder before they are automatically deleted.");?>
+	</td>
+</tr>
+<tr>
+	<td class="vncell" width="22%" valign="top"><?=gettext("Captured TLS Certs Retention Period");?></td>
+	<td width="78%" class="vtable"><select name="tls_certs_store_retention" class="formselect" id="tls_certs_store_retention">
+		<?php foreach ($retentions as $k => $p): ?>
+			<option value="<?=$k;?>"
+			<?php if ($k == $pconfig['tls_certs_store_retention']) echo "selected"; ?>>
+				<?=htmlspecialchars($p);?></option>
+		<?php endforeach; ?>
+		</select>&nbsp;<?=gettext("Choose retention period for captured TLS Certs. Default is ") . "<strong>" . gettext("7 days."). "</strong>";?><br/><br/>
+		<?=gettext("When custom rules with tls.store are enabled, Suricata captures Certificates, along with metadata, ") . 
+		gettext("for later analysis.  This setting determines how long files remain in the Certs folder before they are automatically deleted.");?>
 	</td>
 </tr>
 <tr>

--- a/config/suricata/suricata_migrate_config.php
+++ b/config/suricata/suricata_migrate_config.php
@@ -94,6 +94,91 @@ if (empty($config['installedpackages']['suricata']['config'][0]['et_iqrisk_enabl
 	$updated_cfg = true;
 }
 
+/**********************************************************/
+/* Set default log size and retention limits if not set   */
+/**********************************************************/
+if (!isset($config['installedpackages']['suricata']['config'][0]['alert_log_retention']) && $config['installedpackages']['suricata']['config'][0]['alert_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['alert_log_retention'] = "336";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['alert_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['alert_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['alert_log_limit_size'] = "500";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['block_log_retention']) && $config['installedpackages']['suricata']['config'][0]['block_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['block_log_retention'] = "336";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['block_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['block_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['block_log_limit_size'] = "500";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['dns_log_retention']) && $config['installedpackages']['suricata']['config'][0]['dns_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['dns_log_retention'] = "168";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['dns_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['dns_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['dns_log_limit_size'] = "750";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['eve_log_retention']) && $config['installedpackages']['suricata']['config'][0]['eve_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['eve_log_retention'] = "168";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['eve_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['eve_log_limit_size'] = "5000";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['files_json_log_retention']) && $config['installedpackages']['suricata']['config'][0]['files_json_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['files_json_log_retention'] = "168";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['files_json_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['files_json_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['files_json_log_limit_size'] = "1000";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['http_log_retention']) && $config['installedpackages']['suricata']['config'][0]['http_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['http_log_retention'] = "168";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['http_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['http_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['http_log_limit_size'] = "1000";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['stats_log_retention']) && $config['installedpackages']['suricata']['config'][0]['stats_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['stats_log_retention'] = "168";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['stats_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['stats_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['stats_log_limit_size'] = "500";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['tls_log_retention']) && $config['installedpackages']['suricata']['config'][0]['tls_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['tls_log_retention'] = "336";
+	$updated_cfg = true;
+}
+if (!isset($config['installedpackages']['suricata']['config'][0]['tls_log_limit_size']) && $config['installedpackages']['suricata']['config'][0]['tls_log_limit_size'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['tls_log_limit_size'] = "500";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['file_store_retention']) && $config['installedpackages']['suricata']['config'][0]['file_store_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['file_store_retention'] = "168";
+	$updated_cfg = true;
+}
+
+if (!isset($config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention']) && $config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention'] = "168";
+	$updated_cfg = true;
+}
+
 // Now process the interface-specific settings
 foreach ($rule as &$r) {
 
@@ -196,87 +281,88 @@ foreach ($rule as &$r) {
 	}
 
 	/******************************************************************/
-	/* Create default log size and retention limits if not set        */
+	/* Remove per interface default log size and retention limits     */ 
+	/* if they were set by early bug.                                 */
 	/******************************************************************/
-	if (!isset($pconfig['alert_log_retention']) && $pconfig['alert_log_retention'] != '0') {
-		$pconfig['alert_log_retention'] = "336";
+	if (isset($pconfig['alert_log_retention'])) {
+		unset($pconfig['alert_log_retention']);
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['alert_log_limit_size']) && $pconfig['alert_log_limit_size'] != '0') {
-		$pconfig['alert_log_limit_size'] = "500";
-		$updated_cfg = true;
-	}
-
-	if (!isset($pconfig['block_log_retention']) && $pconfig['block_log_retention'] != '0') {
-		$pconfig['block_log_retention'] = "336";
-		$updated_cfg = true;
-	}
-	if (!isset($pconfig['block_log_limit_size']) && $pconfig['block_log_limit_size'] != '0') {
-		$pconfig['block_log_limit_size'] = "500";
+	if (isset($pconfig['alert_log_limit_size'])) {
+		unset($pconfig['alert_log_limit_size']);
 		$updated_cfg = true;
 	}
 
-	if (!isset($pconfig['dns_log_retention']) && $pconfig['dns_log_retention'] != '0') {
-		$pconfig['dns_log_retention'] = "168";
+	if (isset($pconfig['block_log_retention'])) {
+		unset($pconfig['block_log_retention']);
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['dns_log_limit_size']) && $pconfig['dns_log_limit_size'] != '0') {
-		$pconfig['dns_log_limit_size'] = "750";
-		$updated_cfg = true;
-	}
-
-	if (!isset($pconfig['eve_log_retention']) && $pconfig['eve_log_retention'] != '0') {
-		$pconfig['eve_log_retention'] = "168";
-		$updated_cfg = true;
-	}
-	if (!isset($pconfig['eve_log_limit_size']) && $pconfig['eve_log_limit_size'] != '0') {
-		$pconfig['eve_log_limit_size'] = "5000";
+	if (isset($pconfig['block_log_limit_size'])) {
+		unset($pconfig['block_log_limit_size']);
 		$updated_cfg = true;
 	}
 
-	if (!isset($pconfig['files_json_log_retention']) && $pconfig['files_json_log_retention'] != '0') {
-		$pconfig['files_json_log_retention'] = "168";
+	if (isset($pconfig['dns_log_retention'])) {
+		unset($pconfig['dns_log_retention']);
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['files_json_log_limit_size']) && $pconfig['files_json_log_limit_size'] != '0') {
-		$pconfig['files_json_log_limit_size'] = "1000";
-		$updated_cfg = true;
-	}
-
-	if (!isset($pconfig['http_log_retention']) && $pconfig['http_log_retention'] != '0') {
-		$pconfig['http_log_retention'] = "168";
-		$updated_cfg = true;
-	}
-	if (!isset($pconfig['http_log_limit_size']) && $pconfig['http_log_limit_size'] != '0') {
-		$pconfig['http_log_limit_size'] = "1000";
+	if (isset($pconfig['dns_log_limit_size'])) {
+		unset($pconfig['dns_log_limit_size']);
 		$updated_cfg = true;
 	}
 
-	if (!isset($pconfig['stats_log_retention']) && $pconfig['stats_log_retention'] != '0') {
-		$pconfig['stats_log_retention'] = "168";
+	if (isset($pconfig['eve_log_retention'])) {
+		unset($pconfig['eve_log_retention']);
 		$updated_cfg = true;
 	}
-	if (!isset($pconfig['stats_log_limit_size']) && $pconfig['stats_log_limit_size'] != '0') {
-		$pconfig['stats_log_limit_size'] = "500";
-		$updated_cfg = true;
-	}
-
-	if (!isset($pconfig['tls_log_retention']) && $pconfig['tls_log_retention'] != '0') {
-		$pconfig['tls_log_retention'] = "336";
-		$updated_cfg = true;
-	}
-	if (!isset($pconfig['tls_log_limit_size']) && $pconfig['tls_log_limit_size'] != '0') {
-		$pconfig['tls_log_limit_size'] = "500";
+	if (isset($pconfig['eve_log_limit_size'])) {
+		unset($pconfig['eve_log_limit_size']);
 		$updated_cfg = true;
 	}
 
-	if (!isset($pconfig['file_store_retention']) && $pconfig['file_store_retention'] != '0') {
-		$pconfig['file_store_retention'] = "168";
+	if (isset($pconfig['files_json_log_retention'])) {
+		unset($pconfig['files_json_log_retention']);
+		$updated_cfg = true;
+	}
+	if (isset($pconfig['files_json_log_limit_size'])) {
+		unset($pconfig['files_json_log_limit_size']);
 		$updated_cfg = true;
 	}
 
-	if (!isset($pconfig['u2_archive_log_retention']) && $pconfig['u2_archive_log_retention'] != '0') {
-		$pconfig['u2_archive_log_retention'] = "168";
+	if (isset($pconfig['http_log_retention'])) {
+		unset($pconfig['http_log_retention']);
+		$updated_cfg = true;
+	}
+	if (isset($pconfig['http_log_limit_size'])) {
+		unset($pconfig['http_log_limit_size']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['stats_log_retention'])) {
+		unset($pconfig['stats_log_retention']);
+		$updated_cfg = true;
+	}
+	if (isset($pconfig['stats_log_limit_size'])) {
+		unset($pconfig['stats_log_limit_size']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['tls_log_retention'])) {
+		unset($pconfig['tls_log_retention']);
+		$updated_cfg = true;
+	}
+	if (isset($pconfig['tls_log_limit_size'])) {
+		unset($pconfig['tls_log_limit_size']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['file_store_retention'])) {
+		unset($pconfig['file_store_retention']);
+		$updated_cfg = true;
+	}
+
+	if (isset($pconfig['u2_archive_log_retention'])) {
+		unset($pconfig['u2_archive_log_retention']);
 		$updated_cfg = true;
 	}
 

--- a/config/suricata/suricata_migrate_config.php
+++ b/config/suricata/suricata_migrate_config.php
@@ -174,6 +174,11 @@ if (!isset($config['installedpackages']['suricata']['config'][0]['file_store_ret
 	$updated_cfg = true;
 }
 
+if (!isset($config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention']) && $config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] != '0') {
+	$config['installedpackages']['suricata']['config'][0]['tls_certs_store_retention'] = "168";
+	$updated_cfg = true;
+}
+
 if (!isset($config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention']) && $config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention'] != '0') {
 	$config['installedpackages']['suricata']['config'][0]['u2_archive_log_retention'] = "168";
 	$updated_cfg = true;

--- a/config/suricata/suricata_post_install.php
+++ b/config/suricata/suricata_post_install.php
@@ -281,8 +281,8 @@ if (empty($config['installedpackages']['suricata']['config'][0]['forcekeepsettin
 conf_mount_ro();
 
 // Update Suricata package version in configuration
-$config['installedpackages']['suricata']['config'][0]['suricata_config_ver'] = "2.1.4";
-write_config("Suricata pkg v2.1.4: post-install configuration saved.");
+$config['installedpackages']['suricata']['config'][0]['suricata_config_ver'] = "2.1.5";
+write_config("Suricata pkg v2.1.5: post-install configuration saved.");
 
 // Done with post-install, so clear flag
 unset($g['suricata_postinstall']);

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1623,7 +1623,7 @@
 		<website>http://suricata-ids.org/</website>
 		<descr><![CDATA[High Performance Network IDS, IPS and Security Monitoring engine by OISF.]]></descr>
 		<category>Security</category>
-		<version>2.1.4</version>
+		<version>2.1.5</version>
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/suricata/suricata.xml</config_file>
@@ -1635,7 +1635,7 @@
 			<ports_after>security/barnyard2</ports_after>
 		</build_pbi>
 		<build_options>barnyard2_UNSET_FORCE=ODBC PGSQL PRELUDE;barnyard2_SET_FORCE=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;suricata_SET_FORCE=IPFW PORTS_PCAP GEOIP JSON NSS LUAJIT HTP_PORT;suricata_UNSET_FORCE=PRELUDE TESTS SC LUA</build_options>
-		<depends_on_package_pbi>suricata-2.0.6-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>suricata-2.0.8_1-##ARCH##.pbi</depends_on_package_pbi>
 	</package>
 	<package>
 		<name>FTP Client Proxy</name>


### PR DESCRIPTION
Suricata 2.1.5 Update
-----------------------------
This updates the underlying Suricata PBI binary package to v2.0.8_1.  The GUI package is updated to v2.1.5.

New Features
------------------
1. Support for PPPoE connections was back ported from the 2.1-BETA upstream code base.
2. A new retention setting for captured TLS Certs on the LOGS MGMT tab.

Bug Fixes
-------------
1. Log retention settings for the LOGS MGMT tab are global data but were being duplicated for each configured Suricata interface.