### PR TITLE
zabbix_lts - fix resync problem

### DIFF
--- a/config/zabbix-agent-lts/zabbix-agent-lts.inc
+++ b/config/zabbix-agent-lts/zabbix-agent-lts.inc
@@ -54,7 +54,7 @@ function php_deinstall_zabbix_agent_lts(){
 
    conf_mount_rw();
 
-	sigkillbyname("zabbix_agentd", "TERM");
+   sigkillbyname("zabbix_agentd", "TERM");
    unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/rc.d/zabbix_agentd_lts.sh");
    unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/zabbix22/zabbix_agentd.conf");
    unlink_if_exists("/var/log/zabbix-agent-lts/zabbix_agentd_lts.log");

--- a/config/zabbix-agent-lts/zabbix-agent-lts.inc
+++ b/config/zabbix-agent-lts/zabbix-agent-lts.inc
@@ -257,11 +257,18 @@ EOF;
 						"stop" => "$zagent_stop"
 				)
 		);
-		mwexec("{$zagent_rcfile} restart");	
+
+		// Check if zabbix_agentd is currently running
+		if (!is_process_running("zabbix_agentd")) {
+			mwexec("{$zagent_rcfile} start");
+		}else{
+			sigkillbyname("zabbix_agentd", "HUP");
+		}
+
 	}else{
-		if (file_exists($zagent_rcfile)){
-		mwexec("{$zagent_rcfile} stop");
-		unlink($zagent_rcfile);
+		if (file_exists($zagent_rcfile)) {
+			mwexec("{$zagent_rcfile} stop");
+			unlink($zagent_rcfile);
 		}
 	}
 		

--- a/config/zabbix-agent-lts/zabbix-agent-lts.inc
+++ b/config/zabbix-agent-lts/zabbix-agent-lts.inc
@@ -259,10 +259,20 @@ EOF;
 		);
 
 		// Check if zabbix_agentd is currently running
+		// if it's running, is necessary restart the service
+		// because there are not a HUP signal.
 		if (!is_process_running("zabbix_agentd")) {
 			mwexec("{$zagent_rcfile} start");
 		}else{
-			sigkillbyname("zabbix_agentd", "HUP");
+			mwexec("{$zagent_rcfile} stop");
+			// Check if zabbix_agentd is still running
+			if (is_process_running("zabbix_agentd")) {
+				sigkillbyname("zabbix_agentd", "KILL");
+				sleep(2);
+				unlink_if_exists("/var/run/zabbix-agent-lts/zabbix_agent_lts.pid");
+			}
+			// Start zabbix_agentd
+			mwexec("{$zagent_rcfile} start");
 		}
 
 	}else{

--- a/config/zabbix-agent-lts/zabbix-agent-lts.inc
+++ b/config/zabbix-agent-lts/zabbix-agent-lts.inc
@@ -54,7 +54,7 @@ function php_deinstall_zabbix_agent_lts(){
 
    conf_mount_rw();
 
-   exec("/usr/bin/killall zabbix_agentd");
+	sigkillbyname("zabbix_agentd", "TERM");
    unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/rc.d/zabbix_agentd_lts.sh");
    unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/zabbix22/zabbix_agentd.conf");
    unlink_if_exists("/var/log/zabbix-agent-lts/zabbix_agentd_lts.log");

--- a/config/zabbix-agent-lts/zabbix-agent-lts.inc
+++ b/config/zabbix-agent-lts/zabbix-agent-lts.inc
@@ -258,9 +258,11 @@ EOF;
 				)
 		);
 
-		// Check if zabbix_agentd is currently running
-		// if it's running, is necessary restart the service
-		// because there are not a HUP signal.
+		/*
+			Check if zabbix_agentd is currently running
+			if it's running, is necessary restart the service
+			because there are not a HUP signal.
+		*/
 		if (!is_process_running("zabbix_agentd")) {
 			mwexec("{$zagent_rcfile} start");
 		}else{

--- a/config/zabbix-agent-lts/zabbix-agent-lts.xml
+++ b/config/zabbix-agent-lts/zabbix-agent-lts.xml
@@ -41,7 +41,7 @@
 	<name>zabbixagentlts</name>
 	<title>Services: Zabbix Agent LTS</title>
 	<category>Monitoring</category>
-	<version>0.8.4</version>
+	<version>0.8.5</version>
 	<include_file>/usr/local/pkg/zabbix-agent-lts.inc</include_file>
 	<addedit_string>Zabbix Agent LTS has been created/modified.</addedit_string>
 	<delete_string>Zabbix Agent LTS has been deleted.</delete_string>

--- a/config/zabbix-agent-lts/zabbix-agent-lts.xml
+++ b/config/zabbix-agent-lts/zabbix-agent-lts.xml
@@ -45,7 +45,6 @@
 	<include_file>/usr/local/pkg/zabbix-agent-lts.inc</include_file>
 	<addedit_string>Zabbix Agent LTS has been created/modified.</addedit_string>
 	<delete_string>Zabbix Agent LTS has been deleted.</delete_string>
-	<restart_command>/usr/local/etc/rc.d/zabbix_agentd_lts.sh restart</restart_command>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/zabbix-agent-lts/zabbix-agent-lts.inc</item>
 		<prefix>/usr/local/pkg/</prefix>

--- a/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
+++ b/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
@@ -216,10 +216,20 @@ EOF;
 		);
 
 		// Check if zabbix_proxy is currently running
+		// if it's running, is necessary restart the service
+		// because there are not a HUP signal.
 		if (!is_process_running("zabbix_proxy")) {
 			mwexec("{$zproxy_rcfile} start");
 		}else{
-			sigkillbyname("zabbix_proxy", "HUP");
+			mwexec("{$zproxy_rcfile} stop");
+			// Check if zabbix_proxy is still running
+			if (is_process_running("zabbix_proxy")) {
+				sigkillbyname("zabbix_proxy", "KILL");
+				sleep(2);
+				unlink_if_exists("/var/run/zabbix-proxy-lts/zabbix_proxy_lts.pid");
+			}
+			// Start zabbix_proxy
+			mwexec("{$zproxy_rcfile} start");
 		}
 	
 	}else{

--- a/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
+++ b/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
@@ -214,11 +214,18 @@ EOF;
 			"stop" => $zproxy_stop
 			)
 		);
-		mwexec("{$zproxy_rcfile} restart");
+
+		// Check if zabbix_proxy is currently running
+		if (!is_process_running("zabbix_proxy")) {
+			mwexec("{$zproxy_rcfile} start");
+		}else{
+			sigkillbyname("zabbix_proxy", "HUP");
+		}
+	
 	}else{
-		if (file_exists($zproxy_rcfile)){
-		mwexec("{$zproxy_rcfile} stop");
-		unlink($zproxy_rcfile);
+		if (file_exists($zproxy_rcfile)) {
+			mwexec("{$zproxy_rcfile} stop");
+			unlink($zproxy_rcfile);
 		}
 	}
 	

--- a/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
+++ b/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
@@ -54,7 +54,7 @@ function php_deinstall_zabbix_proxy_lts(){
 
    conf_mount_rw();
 
-	sigkillbyname("zabbix_proxy", "TERM");
+   sigkillbyname("zabbix_proxy", "TERM");
    unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/rc.d/zabbix_proxy_lts.sh");
    unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/zabbix22/zabbix_proxy_lts.conf");
    unlink_if_exists("/var/log/zabbix-proxy-lts/zabbix_proxy_lts.log");

--- a/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
+++ b/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
@@ -215,9 +215,11 @@ EOF;
 			)
 		);
 
-		// Check if zabbix_proxy is currently running
-		// if it's running, is necessary restart the service
-		// because there are not a HUP signal.
+		/*
+			Check if zabbix_proxy is currently running
+			if it's running, is necessary restart the service
+			because there are not a HUP signal.
+		*/
 		if (!is_process_running("zabbix_proxy")) {
 			mwexec("{$zproxy_rcfile} start");
 		}else{

--- a/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
+++ b/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
@@ -54,7 +54,7 @@ function php_deinstall_zabbix_proxy_lts(){
 
    conf_mount_rw();
 
-   exec("/usr/bin/killall zabbix_proxy");
+	sigkillbyname("zabbix_proxy", "TERM");
    unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/rc.d/zabbix_proxy_lts.sh");
    unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/zabbix22/zabbix_proxy_lts.conf");
    unlink_if_exists("/var/log/zabbix-proxy-lts/zabbix_proxy_lts.log");

--- a/config/zabbix-proxy-lts/zabbix-proxy-lts.xml
+++ b/config/zabbix-proxy-lts/zabbix-proxy-lts.xml
@@ -41,7 +41,7 @@
 	<name>zabbixproxylts</name>
 	<title>Services: Zabbix Proxy LTS</title>
 	<category>Monitoring</category>
-	<version>0.8.4</version>
+	<version>0.8.5</version>
 	<include_file>/usr/local/pkg/zabbix-proxy-lts.inc</include_file>
 	<addedit_string>Zabbix Proxy has been created/modified.</addedit_string>
 	<delete_string>Zabbix Proxy has been deleted.</delete_string>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1461,7 +1461,7 @@
 		will result in change of the first version number. More info in http://www.zabbix.com/life_cycle_and_release_policy.php </descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/zabbix-agent-lts/zabbix-agent-lts.xml</config_file>
-		<version>0.8.4</version>
+		<version>0.8.5</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<configurationfile>zabbix-agent-lts.xml</configurationfile>
@@ -1483,7 +1483,7 @@
 		will result in change of the first version number. More info in http://www.zabbix.com/life_cycle_and_release_policy.php </descr>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/zabbix-proxy-lts/zabbix-proxy-lts.xml</config_file>
-		<version>0.8.4</version>
+		<version>0.8.5</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<configurationfile>zabbix-proxy-lts.xml</configurationfile>


### PR DESCRIPTION
- change exec(killall) for sigkillbyname() function on deinstall.
- drop restart_command from xml.
- insert a double-check if process is running on resync function.