### PR TITLE
pfBlockerNG v1.09 05-2015-1

### DIFF
--- a/config/pfblockerng/pfblockerng.inc
+++ b/config/pfblockerng/pfblockerng.inc
@@ -263,6 +263,10 @@ function pfblockerng_cron_exists($crontask, $pfb_min, $pfb_hour) {
 				if ($item['minute'] != $pfb_min) {
 					return FALSE;
 				}
+				if ($pfb_hour == 'maxmind' && !empty($item['hour'])) {
+					// Maxmind hour is randomized. Skip comparison.
+					return TRUE;
+				}
 				if ($item['hour'] != $pfb_hour) {
 					return FALSE;
 				}
@@ -2662,7 +2666,7 @@ function sync_package_pfblockerng($cron = "") {
 		$pfb_gwho	= "root";
 
 		// Determine if Cron Task requires updating
-		if (!pfblockerng_cron_exists($pfb_gcmd, $pfb_gmin, $pfb_ghour)) {
+		if (!pfblockerng_cron_exists($pfb_gcmd, $pfb_gmin, 'maxmind')) {
 			install_cron_job($pfb_gcmd, true, $pfb_gmin, $pfb_ghour, $pfb_gmday, $pfb_gmonth, $pfb_gwday, $pfb_gwho);
 		}
 	}

--- a/config/pfblockerng/pfblockerng.inc
+++ b/config/pfblockerng/pfblockerng.inc
@@ -2731,7 +2731,7 @@ function pfblockerng_php_install_command() {
 
 	// Uncompress Country Code File
 	@copy("{$pfb['dbdir']}/countrycodes.tar.bz2", "{$pfb['ccdir']}/countrycodes.tar.bz2");
-	exec("/usr/bin/tar -jx -C {$pfb['ccdif']} -f {$pfb['ccdir']}/countrycodes.tar.bz2");
+	exec("/usr/bin/tar -jx -C {$pfb['ccdir']} -f {$pfb['ccdir']}/countrycodes.tar.bz2");
 	// Download MaxMind Files and Create Country Code files and Build Continent XML Files
 	update_output_window(gettext("Downloading MaxMind Country Databases. This may take a minute..."));
 	exec("/bin/sh /usr/local/pkg/pfblockerng/geoipupdate.sh all >> {$pfb['geolog']} 2>&1");

--- a/config/pfblockerng/pfblockerng.inc
+++ b/config/pfblockerng/pfblockerng.inc
@@ -58,9 +58,6 @@ function pfb_global() {
 		$prefix = "/usr/local";
 	}
 
-	# Collect pfSense Version
-	$pfb['pfsenseversion']	= substr(trim(file_get_contents("/etc/version")),0,3);
-
 	# Folders
 	$pfb['dbdir']		= "{$g['vardb_path']}/pfblockerng";
 	$pfb['aliasdir']	= "{$g['vardb_path']}/aliastables";
@@ -71,7 +68,7 @@ function pfb_global() {
 	$pfb['matchdir']	= "{$pfb['dbdir']}/match";
 	$pfb['permitdir']	= "{$pfb['dbdir']}/permit";
 	$pfb['origdir']		= "{$pfb['dbdir']}/original";
-	$pfb['ccdir']		= $prefix . "/share/GeoIP";
+	$pfb['ccdir']		= "{$prefix}/share/GeoIP";
 
 	# Create Folders if not Exist.
 	$folder_array = array ("{$pfb['dbdir']}","{$pfb['logdir']}","{$pfb['ccdir']}","{$pfb['origdir']}","{$pfb['nativedir']}","{$pfb['denydir']}","{$pfb['matchdir']}","{$pfb['permitdir']}","{$pfb['aliasdir']}");
@@ -80,28 +77,38 @@ function pfb_global() {
 	}
 
 	# Files
-	$pfb['master']	= "{$pfb['dbdir']}/masterfile";
-	$pfb['errlog']	= "{$pfb['logdir']}/error.log";
-	$pfb['geolog']	= "{$pfb['logdir']}/geoip.log";
-	$pfb['log']	= "{$pfb['logdir']}/pfblockerng.log";
-	$pfb['supptxt']	= "{$pfb['dbdir']}/pfbsuppression.txt";
-	$pfb['script']	= 'sh /usr/local/pkg/pfblockerng/pfblockerng.sh';
-	$pfb['aliasarchive'] = $prefix . "/etc/aliastables.tar.bz2";
+	$pfb['master']		= "{$pfb['dbdir']}/masterfile";
+	$pfb['errlog']		= "{$pfb['logdir']}/error.log";
+	$pfb['geolog']		= "{$pfb['logdir']}/geoip.log";
+	$pfb['log']		= "{$pfb['logdir']}/pfblockerng.log";
+	$pfb['supptxt']		= "{$pfb['dbdir']}/pfbsuppression.txt";
+	$pfb['script']		= 'sh /usr/local/pkg/pfblockerng/pfblockerng.sh';
+	$pfb['aliasarchive']	= "{$prefix}/etc/aliastables.tar.bz2";
 
 	# General Variables
-	$pfb['config']	= $config['installedpackages']['pfblockerng']['config'][0];
+	$pfb['config']		= $config['installedpackages']['pfblockerng']['config'][0];
 
 	# Enable/Disable of pfBlockerNG
-	$pfb['enable']	= $pfb['config']['enable_cb'];
+	$pfb['enable']		= $pfb['config']['enable_cb'];
 	# Keep Blocklists on pfBlockerNG Disable
-	$pfb['keep']	= $pfb['config']['pfb_keep'];
+	$pfb['keep']		= $pfb['config']['pfb_keep'];
 	# Enable Suppression
-	$pfb['supp']	= $pfb['config']['suppression'];
+	$pfb['supp']		= $pfb['config']['suppression'];
 	# Max Lines in pfblockerng.log file
-	$pfb['logmax']	= $pfb['config']['log_maxlines'];
-	$pfb['iplocal']	= $config['interfaces']['lan']['ipaddr'];
+	$pfb['logmax']		= $pfb['config']['log_maxlines'];
+	# Lan IP Address
+	$pfb['iplocal']		= $config['interfaces']['lan']['ipaddr'];
 	# Disable Country Database CRON Updates
-	$pfb['cc']	= $pfb['config']['database_cc'];
+	$pfb['cc']		= $pfb['config']['database_cc'];
+
+	# User Defined CRON Start Minute
+	$pfb['min']		= $pfb['config']['pfb_min'];
+	# Start hour of the Scheduler
+	$pfb['hour']		= $pfb['config']['pfb_hour'];
+	# Hour cycle for Scheduler
+	$pfb['interval']	= $pfb['config']['pfb_interval'];
+	# Start hour of the 'Once a day' Schedule
+	$pfb['24hour']		= $pfb['config']['pfb_dailystart'];
 
 	# Set pfBlockerNG to Disabled on 'Re-Install'
 	if (isset($pfb['install']) && $pfb['install']) {
@@ -114,13 +121,24 @@ pfb_global();
 
 # Set Max PHP Memory Setting
 $uname = posix_uname();
-if ($uname['machine'] == 'amd64')
+if ($uname['machine'] == 'amd64') {
 	ini_set('memory_limit', '256M');
+}
 
 
-# Function to decode to Alias Custom Entry Box.
+# Function to decode to Alias Custom entry box.
 function pfbng_text_area_decode($text) {
-	return preg_replace('/\r\n/', "\n",base64_decode($text));
+	$customlist = explode("\r\n", base64_decode($text));
+	foreach ($customlist as $line) {
+		if (substr(trim($line), 0, 1) != '#' && !empty($line)) {
+			if (strpos($line, '#')) {
+				$custom .= trim(strstr($line, '#', TRUE)) . "\n";
+			} else {
+				$custom .= $line . "\n";
+			}
+		}
+	}
+	return $custom;
 }
 
 
@@ -132,7 +150,9 @@ function pfb_log_mgmt() {
 	if ($pfb['logmax'] == "nolimit") {
 		# Skip Log Mgmt
 	} else {
-		exec("/usr/bin/tail -n {$pfb['logmax']} {$pfb['log']} > /tmp/pfblog; /bin/mv -f /tmp/pfblog {$pfb['log']}");
+		if (file_exists($pfb['log'])) {
+			exec("/usr/bin/tail -n {$pfb['logmax']} {$pfb['log']} > /tmp/pfblog; /bin/mv -f /tmp/pfblog {$pfb['log']}");
+		}
 	}
 }
 
@@ -164,9 +184,9 @@ function pfb_logger($log, $type) {
 }
 
 
-# Determine Folder Location for 'List'
-function pfb_determine_list_detail($list) {
-	global $g,$pfb,$pfbarr;
+// Determine 'List' Details
+function pfb_determine_list_detail($list="", $header_url="", $confconfig="", $key="") {
+	global $pfb,$pfbarr,$config;
 	$pfbarr = array();
 
 	if (in_array($list,array('Match_Both','Match_Inbound','Match_Outbound','Alias_Match'))) {
@@ -191,8 +211,174 @@ function pfb_determine_list_detail($list) {
 		$pfbarr['descr'] = " Auto ";
 	}
 
+	//Determine length of Header to format log Output
+	if (strlen($header_url) > 19) {
+		$pfbarr['logtab'] = "";
+	}
+	elseif (strlen($header_url) > 11) {
+		$pfbarr['logtab'] = "\t";
+	}
+	elseif (strlen($header_url) < 4) {
+		$pfbarr['logtab'] = "\t\t\t";
+	}
+	else {
+		$pfbarr['logtab'] = "\t\t";
+	}
+
+	if ($confconfig != "") {
+		// Configure Autoports/Protocol and Auto Destination if required.
+		$autotype = array( 'autoports' => 'aliasports', 'autodest' => 'aliasdest');
+		$aports = ""; $adest = "";
+		$pfbarr['aproto'] = $config['installedpackages'][$confconfig]['config'][$key]['autoproto'];
+		foreach ($autotype as $akey => $atype) {
+			if ($config['installedpackages'][$confconfig]['config'][$key][$akey] == "on" && is_array($config['aliases']['alias'])) {
+				foreach ($config['aliases']['alias'] as $palias) {
+					if ($palias['name'] == $config['installedpackages'][$confconfig]['config'][$key][$atype]) {
+						if (!empty($palias['address'])) {
+							switch($akey) {
+								case "autoports":
+									$pfbarr['aports'] = $config['installedpackages'][$confconfig]['config'][$key][$atype];
+									break;
+								case "autodest":
+									$pfbarr['adest'] = $config['installedpackages'][$confconfig]['config'][$key][$atype];
+									break;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 	return $pfbarr;
 }
+
+
+// Determine if Cron Task requires updating
+function pfblockerng_cron_exists($crontask, $pfb_min, $pfb_hour) {
+	global $config;
+
+	if (is_array($config['cron']['item'])) {
+		foreach ($config['cron']['item'] as $item) {
+			if (strpos($item['command'], $crontask) !== FALSE) {
+				if ($item['minute'] != $pfb_min) {
+					return FALSE;
+				}
+				if ($item['hour'] != $pfb_hour) {
+					return FALSE;
+				}
+				return TRUE;
+			}
+		}
+	}
+	return FALSE;
+}
+
+
+// Calculate the cron task base hour setting
+function pfb_cron_base_hour() {
+	global $pfb;
+
+	if ($pfb['interval'] == 1) {
+		return;
+	}
+
+	if ($pfb['interval'] == 2) {
+		# 2 Hour Schedule Converter
+		$shour = intval(substr($pfb['hour'], 0, 2));
+		$sch2 = strval($shour);
+		for ($i=0; $i<11; $i++) {
+			$shour += 2;
+			if ($shour >= 24)
+				$shour -= 24;
+			$sch2 .= "," . strval($shour);
+		}
+		$sch2 = explode(",", $sch2);
+		sort($sch2);
+		return $sch2;
+	}
+
+	if ($pfb['interval'] == 3) {
+		# 3 Hour Schedule Converter
+		$shour = intval(substr($pfb['hour'], 0, 2));
+		$sch3 = strval($shour);
+		for ($i=0; $i<7; $i++) {
+			$shour += 3;
+			if ($shour >= 24)
+				$shour -= 24;
+			$sch3 .= "," . strval($shour);
+		}
+		$sch3 = explode(",", $sch3);
+		sort($sch3);
+		return $sch3;
+	}
+
+	if ($pfb['interval'] == 4) {
+		# 4 Hour Schedule Converter
+		$shour = intval(substr($pfb['hour'], 0, 2));
+		$sch4 = strval($shour);
+		for ($i=0; $i<5; $i++) {
+			$shour += 4;
+			if ($shour >= 24)
+				$shour -= 24;
+			$sch4 .= "," . strval($shour);
+		}
+		$sch4 = explode(",", $sch4);
+		sort($sch4);
+		return $sch4;
+	}
+
+	if ($pfb['interval'] == 6) {
+		# 6 Hour Schedule Converter
+		$shour = intval(substr($pfb['hour'], 0, 2));
+		$sch6 = strval($shour);
+		for ($i=0; $i<3; $i++) {
+			$shour += 6;
+			if ($shour >= 24)
+				$shour -= 24;
+			$sch6 .= "," . strval($shour);
+		}
+		$sch6 = explode(",", $sch6);
+		sort($sch6);
+		return $sch6;
+	}
+
+	if ($pfb['interval'] == 8) {
+		# 8 Hour Schedule Converter
+		$shour = intval(substr($pfb['hour'], 0, 2));
+		$sch8 = strval($shour);
+		for ($i=0; $i<2; $i++) {
+			$shour += 8;
+			if ($shour >= 24)
+				$shour -= 24;
+			$sch8 .= "," . strval($shour);
+		}
+		$sch8 = explode(",", $sch8);
+		sort($sch8);
+		return $sch8;
+	}
+
+	if ($pfb['interval'] == 12) {
+		# 12 Hour Schedule Converter
+		$shour = intval(substr($pfb['hour'], 0, 2));
+		$sch12 = strval($shour) . ",";
+		$shour += 12;
+		if ($shour >= 24)
+			$shour -= 24;
+		$sch12 .= strval($shour);
+		$sch12 = explode(",", $sch12);
+		sort($sch12);
+		return $sch12;
+	}
+
+	if ($pfb['interval'] == 24) {
+		return array($pfb['24hour']);
+	} 
+
+	// Default to hourly schedule
+	$pfb['interval'] = 1;
+	return;
+}
+
 
 # Create Suppression Alias
 function pfb_create_suppression_alias() {
@@ -212,7 +398,7 @@ function pfb_create_suppression_alias() {
 				"detail"	=> ""
 				);
 	$config['aliases']['alias'] = $new_aliases;
-	write_config();
+	$pfb['cron_mod'] = TRUE;
 }
 
 
@@ -235,7 +421,7 @@ function pfb_create_suppression_file() {
 		if ($pfb['found']) {
 			$pfb_suppress = str_replace(" ", "\n", $config['aliases']['alias'][$pfb_id]['address']);
 			if (!empty($pfb_suppress)) {
-				@file_put_contents("{$pfb['supptxt']}",$pfb_suppress, LOCK_EX);
+				@file_put_contents("{$pfb['supptxt']}", $pfb_suppress, LOCK_EX);
 			} else {
 				unlink_if_exists("{$pfb['supptxt']}");
 			}
@@ -246,8 +432,9 @@ function pfb_create_suppression_file() {
 	}
 
 	// Call Function to Create Suppression Alias.
-	if (!$pfb['found'])
+	if (!$pfb['found']) {
 		pfb_create_suppression_alias();
+	}
 }
 
 
@@ -306,7 +493,7 @@ function ip_range_to_subnet_array_temp2($ip1, $ip2) {
 			// already checked for the edge case where end = start+1 and start ends in 0x1, above, so it's safe
 		}
 
-		// this is the only edge case arising from increment/decrement. 
+		// this is the only edge case arising from increment/decrement.
 		// it happens if the range at start of loop is exactly 2 adjacent ips, that spanned the 1->0 gap. (we will have enumerated both by now)
 		
 		if (strcmp($ip2bin, $ip1bin) < 0)
@@ -393,8 +580,10 @@ function pfb_aliastables($mode) {
 		}
 	}
 
-	if ($msg != "")
+	if ($msg != "") {
 		pfb_logger("{$msg}","1");
+		$pfb['cron_mod'] = TRUE;
+	}
 }
 
 
@@ -403,6 +592,7 @@ function sync_package_pfblockerng($cron = "") {
 
 	global $g,$config,$pfb,$pfbarr;
 	pfb_global();
+	$pfb['cron_mod'] = FALSE;	// Flag to check for mods to the config.xml file.
 
 	# Detect Boot Process or Update via CRON
 	if (isset($_POST) && $cron == "") {
@@ -433,10 +623,12 @@ function sync_package_pfblockerng($cron = "") {
 	pfb_aliastables("conf");
 
 	# Collect pfSense Max Table Size Entry
-	$pfb['table_limit'] = ($config['system']['maximumtableentries'] != "" ? $config['system']['maximumtableentries'] : "2000000");
-
-	# If Table limit not defined, set Default to 2M
-	$config['system']['maximumtableentries'] = "{$pfb['table_limit']}";
+	if (empty($config['system']['maximumtableentries'])) {
+		# If Table limit not defined, set Default to 2M
+		$config['system']['maximumtableentries'] = "2000000";
+		$pfb['cron_mod'] = TRUE;
+	}
+	$pfb['table_limit'] = $config['system']['maximumtableentries'];
 
 	# Collect local web gui configuration
 	$pfb['weblocal'] = ($config['system']['webgui']['protocol'] != "" ? $config['system']['webgui']['protocol'] : "http");
@@ -454,10 +646,6 @@ function sync_package_pfblockerng($cron = "") {
 	$pfb['deny_action_inbound'] = ($pfb['config']['inbound_deny_action'] != "" ? $pfb['config']['inbound_deny_action'] : "block");
 	$pfb['deny_action_outbound'] = ($pfb['config']['outbound_deny_action'] != "" ? $pfb['config']['outbound_deny_action'] : "reject");
 
-	# Validation check to see if the Original pfBlocker package is Enabled
-	$pfb['validate']= $pfb['config']['pfblocker_cb'];
-	# User Defined CRON Start Minute
-	$pfb['min']	= $pfb['config']['pfb_min'];
 	# Reloads Existing Blocklists without Downloading New Lists
 	$pfb['reuse']	= $pfb['config']['pfb_reuse'];
 	# Enable OpenVPN AutoRules
@@ -505,17 +693,6 @@ function sync_package_pfblockerng($cron = "") {
 	$pfb['dupcheck'] = FALSE;
 	## $pfb['save'] is used to determine if User pressed "Save" Button to avoid Collision with CRON.
 	## This is defined in each pfBlockerNG XML Files
-
-	# Validation Check to ensure pfBlocker and pfBlockerNG are not running at the same time.
-	if ($pfb['validate'] == "") {
-		# Collect pfBlocker Enabled Status from config file
-		$pfb['validate_chk'] = $config['installedpackages']['pfblocker']['config'][0]['enable_cb'];
-		if ($pfb['validate_chk'] == "on") {
-			$log = "\n The Package 'pfBlocker' is currently Enabled. Either Disable pfBlocker, or 'Disable Validation Check' in pfBlockerNG \n";
-			pfb_logger("{$log}","1");
-			return;
-		}
-	}
 
 
 	#################################
@@ -690,9 +867,11 @@ function sync_package_pfblockerng($cron = "") {
 		# Sort pfBlockerNG Interface order to pfSense Interface Order
 		$sort_interfaces = array_intersect($ifaces, $selected_interfaces);
 		// If OpenVPN Interfaces are not in dropdown menu
-		if ($pfb['openvpn'] == "on" && $config['openvpn']['openvpn-server'] || $pfb['openvpn'] == "on" && $config['openvpn']['openvpn-client'])
-			if (!in_array("openvpn",$sort_interfaces))
+		if ($pfb['openvpn'] == "on" && $config['openvpn']['openvpn-server'] || $pfb['openvpn'] == "on" && $config['openvpn']['openvpn-client']) {
+			if (!in_array("openvpn",$sort_interfaces)) {
 				array_push($sort_interfaces, "openvpn");
+			}
+		}
 		$implode_interfaces = ltrim(implode(",",$sort_interfaces), ",");
 		# CSV String for Outbound Interfaces for 'pfB_' Match Rules
 		$pfb['outbound_floating'] = $implode_interfaces;
@@ -706,9 +885,11 @@ function sync_package_pfblockerng($cron = "") {
 			$base_rule = $base_rule_reg;
 			$pfb['outbound_interfaces'] = explode(",",$pfb['config']['outbound_interface']);
 			// If OpenVPN Interfaces are not in dropdown menu
-			if ($pfb['openvpn'] == "on" && $config['openvpn']['openvpn-server'] || $pfb['openvpn'] == "on" && $config['openvpn']['openvpn-client'])
-				if (!in_array("openvpn",$sort_interfaces))
+			if ($pfb['openvpn'] == "on" && $config['openvpn']['openvpn-server'] || $pfb['openvpn'] == "on" && $config['openvpn']['openvpn-client']) {
+				if (!in_array("openvpn",$sort_interfaces)) {
 					array_push($pfb['outbound_interfaces'], "openvpn");
+				}
+			}
 		}
 	} else {
 		# Define Empty Variable/Array
@@ -725,8 +906,9 @@ function sync_package_pfblockerng($cron = "") {
 	$pfb['sync_master'] = TRUE;
 
 	# Don't execute this function when pfBlockerNG is Disabled and 'Keep Blocklists' is enabled.
-	if ($pfb['enable'] == "" && $pfb['keep'] == "on")
+	if ($pfb['enable'] == "" && $pfb['keep'] == "on") {
 		$pfb['sync_master'] = FALSE;
+	}
 
 	if ($pfb['sync_master']) {
 		$pfb['existing']['match']['type']	= "match";
@@ -816,6 +998,7 @@ function sync_package_pfblockerng($cron = "") {
 								if ($row['format'] == "et") {
 									unlink_if_exists("{$pfb['denydir']}/{$aliasname}.txt");
 									$config['installedpackages']['pfblockerngreputation']['config'][0]['et_update'] = "disabled";
+									$pfb['cron_mod'] = TRUE;
 									break;
 								}
 							}
@@ -848,6 +1031,7 @@ function sync_package_pfblockerng($cron = "") {
 							unlink_if_exists("{$pfbfolder}/{$pfb_alias}.txt");
 							# Uncheck 'Enabled' in List 'Custom_update' Setting
 							$config['installedpackages'][$ip_type]['config'][$count]['custom_update'] = "disabled";
+							$pfb['cron_mod'] = TRUE;
 						}
 					}
 				}
@@ -901,10 +1085,10 @@ function sync_package_pfblockerng($cron = "") {
 								# This variable ($f_result) used in next section below.
 								$f_result = implode($results);
 								if (!empty($results)) {
-									foreach ($results as $pfb_results) {
-										$log = "[ Removing List(s) : {$pfb_results} ]\n";
+									foreach ($results as $pfb_result) {
+										$log = "[ Removing List : {$pfb_result} ]\n";
 										pfb_logger("{$log}","1");
-										unlink_if_exists("{$pfbfolder}/{$pfb_results}.txt");
+										unlink_if_exists("{$pfbfolder}/{$pfb_result}.txt");
 									}
 									$pfb['summary'] = TRUE;
 									$pfb['remove'] = TRUE;
@@ -912,12 +1096,12 @@ function sync_package_pfblockerng($cron = "") {
 								break;
 						}
 
-						# Allow Rebuilding of Changed Aliase to purge 'SKIP' Lists (when pfBlockerNG is Enabled)
+						# Allow rebuilding of changed Alias to purge 'SKIP' Lists (when pfBlockerNG is enabled)
 						$list_type = array ("pfblockernglistsv4" => "_v4", "pfblockernglistsv6" => "_v6");
 						foreach ($list_type as $ip_type => $vtype) {
 							if ($f_result != "" && $pfb['enable'] == "on") {
 								foreach ($results as $removed_header) {
-									if ($config['installedpackages'][$ip_type]['config'] != "" && $pfb['enable'] == "on") {
+									if ($config['installedpackages'][$ip_type]['config'] != "") {
 										foreach ($config['installedpackages'][$ip_type]['config'] as $list) {
 											$alias = "pfB_" . preg_replace("/\W/","",$list['aliasname']);
 											if (is_array($list['row'])) {
@@ -964,12 +1148,13 @@ function sync_package_pfblockerng($cron = "") {
 	}
 
 
-	#########################################
-	#	Create Suppression Txt File	#
-	#########################################
+	#################################################
+	#	Create IP Suppression Txt File		#
+	#################################################
 
-	if ($pfb['enable'] == "on" && $pfb['supp'] == "on")
+	if ($pfb['enable'] == "on" && $pfb['supp'] == "on") {
 		pfb_create_suppression_file();
+	}
 
 
 	#################################
@@ -979,17 +1164,22 @@ function sync_package_pfblockerng($cron = "") {
 	foreach ($continents as $continent => $pfb_alias) {
 		if (is_array($config['installedpackages']['pfblockerng' . strtolower(preg_replace('/ /','',$continent))]['config'])) {
 			$continent_config = $config['installedpackages']['pfblockerng' . strtolower(preg_replace('/ /','',$continent))]['config'][0];
+			$cc_name = 'pfblockerng' . strtolower(preg_replace('/ /','',$continent));
 			if ($continent_config['action'] != "Disabled" && $pfb['enable'] == "on") {
-
-				# Determine Folder Location for Alias (return array $pfbarr)
-				pfb_determine_list_detail($continent_config['action']);
-				$pfb['skip']	= $pfbarr['skip'];
-				$pfb_descr	= $pfbarr['descr'];
-				$pfbfolder	= $pfbarr['folder'];
 
 				// Determine if Continent Lists require Action (IPv4 and IPv6)
 				$cont_type = array ("countries4" => "_v4", "countries6" => "_v6");
 				foreach ($cont_type as $c_type => $vtype) {
+
+					# Determine 'List' details (return array $pfbarr)
+					pfb_determine_list_detail($continent_config['action'], "{$pfb_alias}{$vtype}", $cc_name, "0");
+					$pfb['skip']	= $pfbarr['skip'];
+					$pfb_descr	= $pfbarr['descr'];
+					$pfbfolder	= $pfbarr['folder'];
+					$log_tab	= $pfbarr['logtab'];
+					$aports		= $pfbarr['aports'];
+					$adest		= $pfbarr['adest'];
+					$aproto		= $pfbarr['aproto'];
 
 					$continent = "";
 					if ($continent_config[$c_type] != "") {
@@ -1001,9 +1191,9 @@ function sync_package_pfblockerng($cron = "") {
 							}
 						}
 
-						if (file_exists($pfb['origdir'] . '/' . $pfb_alias . $vtype . '.orig'))
+						if (file_exists($pfb['origdir'] . '/' . $pfb_alias . $vtype . '.orig')) {
 							$continent_existing = preg_replace('/\s/', '', file ($pfb['origdir'] . '/' . $pfb_alias . $vtype . '.orig'));
-
+						}
 						// Collect New Continent Data for comparison. Cleanup Array for Comparison
 						$continent_new = preg_split ('/$\R?^/m', $continent);
 						$line = count ( $continent_new ) - 1;
@@ -1024,22 +1214,14 @@ function sync_package_pfblockerng($cron = "") {
 
 						// Compare Existing (Original File) and New Continent Data
 						if ($continent_new === $continent_existing && !empty($pfctlck) && file_exists($pfbfolder . '/' . $pfb_alias . $vtype . '.txt') && $pfb['reuse'] == "") {
-							# Format Log into clean Tab Spaces
-							$string_final = "{$pfb_alias}{$vtype}";
-							if (strlen($string_final) > 10) {
-								$log_tab = "\t";
-							} else {
-								$log_tab = "\t\t";
-							}
-
 							if (!$pfb['save']) {
-								$log = "\n[ {$pfb_alias}{$vtype} ] {$log_tab} exists, Reloading File [ NOW ]\n";
+								$log = "\n[ {$pfb_alias}{$vtype} ]{$log_tab} exists, Reloading File [ NOW ]";
 								pfb_logger("{$log}","1");
 							}
 						} else {
 							// Do not proceed with Changes on User 'Save'
 							if (!$pfb['save']) {
-								$log = "\n[ {$pfb_alias}{$vtype} ] {$log_tab} Changes Found... Updating \n";
+								$log = "\n[ {$pfb_alias}{$vtype} ]{$log_tab} Changes Found... Updating \n";
 								pfb_logger("{$log}","1");
 
 								# Test to Skip d-dup and p-dup functions when changes are found.
@@ -1061,11 +1243,12 @@ function sync_package_pfblockerng($cron = "") {
 									@file_put_contents($pfb['aliasdir'] . '/' . $pfb_alias . $vtype . '.txt',$continent, LOCK_EX);
 								}
 
-								# Check if File Exists and is >0 in Size and Save alias file
+								# Check if File Exists and is > 0 in Size and Save alias file
 								$file_chk = "0";
 								$cont_chk = "{$pfbfolder}/{$pfb_alias}{$vtype}.txt";
-								if (file_exists($cont_chk) && @filesize($cont_chk) >0)
+								if (file_exists($cont_chk) && @filesize($cont_chk) > 0) {
 									$file_chk = exec ("/usr/bin/grep -cv '^#\|^$' {$cont_chk}");
+								}
 
 								if ($file_chk == "0" || $file_chk == "1") {
 									$new_file = "1.1.1.1\n";
@@ -1076,7 +1259,6 @@ function sync_package_pfblockerng($cron = "") {
 								}
 							}
 						}
-
 
 						if (file_exists($pfbfolder . '/' . $pfb_alias . $vtype . '.txt')) {
 							#Create alias config
@@ -1105,7 +1287,7 @@ function sync_package_pfblockerng($cron = "") {
 										$rule['direction'] = "any";
 									$rule['descr']= "{$pfb_alias}{$vtype}{$pfb['suffix']}";
 									$rule['source'] = array("any" => "");
-									$rule['destination'] = array ("address" => "{$pfb_alias}{$vtype}");
+									$rule['destination'] = array("address" => "{$pfb_alias}{$vtype}");
 									if ($pfb['config']['enable_log'] == "on" || $pfb_contlog == "enabled")
 										$rule['log'] = "";
 									$deny_outbound[] = $rule;
@@ -1120,7 +1302,19 @@ function sync_package_pfblockerng($cron = "") {
 										$rule['direction'] = "any";
 									$rule['descr'] = "{$pfb_alias}{$vtype}{$pfb['suffix']}";
 									$rule['source'] = array("address" => "{$pfb_alias}{$vtype}");
-									$rule['destination'] = array ("any" => "");
+									if (!empty($adest) && !empty($aports)) {
+										$rule['destination'] = array("address" => "{$adest}", "port" => "{$aports}");
+									} elseif (!empty($adest) && empty($aports)) {
+										$rule['destination'] = array("address" => "{$adest}");
+									} elseif (empty($adest) && !empty($aports)) {
+										$rule['destination'] = array("any" => "", "port" => "{$aports}");
+									} else {
+										$rule['destination'] = array("any" => "");
+									}
+									if (!empty($adest) && $continent_config['autonot'] == "on")
+										$rule['destination']['not'] = "";
+									if (!empty($aproto))
+										$rule['protocol'] = "{$aproto}";
 									if ($pfb['config']['enable_log'] == "on" || $pfb_contlog == "enabled")
 										$rule['log'] = "";
 									$deny_inbound[] = $rule;
@@ -1150,7 +1344,19 @@ function sync_package_pfblockerng($cron = "") {
 										$rule['direction'] = "any";
 									$rule['descr'] = "{$pfb_alias}{$vtype}{$pfb['suffix']}";
 									$rule['source'] = array("address"=> "{$pfb_alias}{$vtype}");
-									$rule['destination'] = array ("any" => "");
+									if (!empty($adest) && !empty($aports)) {
+										$rule['destination'] = array("address" => "{$adest}", "port" => "{$aports}");
+									} elseif (!empty($adest) && empty($aports)) {
+										$rule['destination'] = array("address" => "{$adest}");
+									} elseif (empty($adest) && !empty($aports)) {
+										$rule['destination'] = array("any" => "", "port" => "{$aports}");
+									} else {
+										$rule['destination'] = array("any" => "");
+									}
+									if (!empty($adest) && $continent_config['autonot'] == "on")
+										$rule['destination']['not'] = "";
+									if (!empty($aproto))
+										$rule['protocol'] = "{$aproto}";
 									if ($pfb['config']['enable_log'] == "on" || $pfb_contlog == "enabled")
 										$rule['log'] = "";
 									$permit_inbound[] = $rule;
@@ -1163,8 +1369,8 @@ function sync_package_pfblockerng($cron = "") {
 										$rule['ipprotocol'] = "inet6";
 									$rule['direction'] = "any";
 									$rule['descr'] = "{$pfb_alias}{$vtype}{$pfb['suffix']}";
-									$rule['source'] = array ("any" => "");
-									$rule['destination'] = array ("address" => "{$pfb_alias}{$vtype}");
+									$rule['source'] = array("any" => "");
+									$rule['destination'] = array("address" => "{$pfb_alias}{$vtype}");
 									if ($pfb['config']['enable_log'] == "on" || $pfb_contlog == "enabled")
 										$rule['log'] = "";
 									$match_outbound[] = $rule;
@@ -1178,7 +1384,19 @@ function sync_package_pfblockerng($cron = "") {
 									$rule['direction'] = "any";
 									$rule['descr'] = "{$pfb_alias}{$vtype}{$pfb['suffix']}";
 									$rule['source'] = array ("address" => "{$pfb_alias}{$vtype}");
-									$rule['destination'] = array ( "any" => "");
+									if (!empty($adest) && !empty($aports)) {
+										$rule['destination'] = array("address" => "{$adest}", "port" => "{$aports}");
+									} elseif (!empty($adest) && empty($aports)) {
+										$rule['destination'] = array("address" => "{$adest}");
+									} elseif (empty($adest) && !empty($aports)) {
+										$rule['destination'] = array("any" => "", "port" => "{$aports}");
+									} else {
+										$rule['destination'] = array("any" => "");
+									}
+									if (!empty($adest) && $continent_config['autonot'] == "on")
+										$rule['destination']['not'] = "";
+									if (!empty($aproto))
+										$rule['protocol'] = "{$aproto}";
 									if ($pfb['config']['enable_log'] == "on" || $pfb_contlog == "enabled")
 										$rule['log'] = "";
 									$match_inbound[] = $rule;
@@ -1207,7 +1425,7 @@ function sync_package_pfblockerng($cron = "") {
 	# IPv4 REGEX Definitions
 	$pfb['range']	= '/((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))-((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))/';
 	$pfb['block']	= '/(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[ 0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.([0]{1})\s+/';
-	$pfb['cidr']	= '/(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)?\/[0-9]{2}/';
+	$pfb['cidr']	= '/(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)?\/([0-9]{2}|[0-9]{1})/';
 	$pfb['single']	= '/(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\s+/';
 	$pfb['s_html']	= '/(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/';
 
@@ -1215,8 +1433,8 @@ function sync_package_pfblockerng($cron = "") {
 	$pfb_ipreg = array();
 	$pfb_ipreg[0] = '/\b0+(?=\d)/';					# Remove any Leading Zeros in each Octet
 	$pfb_ipreg[1] = '/\s/';						# Remove any Whitespaces
-	$pfb_ipreg[2] = '/127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/';	# Remove any Loopback Addresses 127/8
-	$pfb_ipreg[3] = '/0\.0\.0\.0\/32/';				# Remove 0.0.0.0/32
+	$pfb_ipreg[2] = '/\/32/';					# Remove any /32 CIDR
+	$pfb_ipreg[3] = '/127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/';	# Remove any Loopback Addresses 127/8
 	$pfb_ipreg[4] = '/0\.0\.0\.0/';					# Remove 0.0.0.0
 
 	# IPv6 REGEX Definitions  -- ** Still Needs some Adjustment on Regex Definition for IPv6 **
@@ -1244,23 +1462,17 @@ function sync_package_pfblockerng($cron = "") {
 					foreach ($list['row'] as $row) {
 						if ($row['url'] != "" && $row['state'] != "Disabled") {
 
-							# Determine Folder Location for Alias (return array $pfbarr)
-							pfb_determine_list_detail($list['action']);
-							$pfb['skip']	= $pfbarr['skip'];
-							$pfbfolder	= $pfbarr['folder'];
-
 							if ($vtype == "_v4") {
 								$header_url = "{$row['header']}";
 							} else {
 								$header_url = "{$row['header']}_v6";
 							}
 
-							# Format Log into clean Tab Spaces
-							if (strlen($header_url) > 10) {
-								$log_tab = "\t";
-							} else {
-								$log_tab = "\t\t";
-							}
+							# Determine 'List' details (return array $pfbarr)
+							pfb_determine_list_detail($list['action'], $header_url, "", "");
+							$pfb['skip']	= $pfbarr['skip'];
+							$pfbfolder	= $pfbarr['folder'];
+							$log_tab	= $pfbarr['logtab'];
 
 							// Empty Header Field Validation Check
 							if (empty($header_url) || preg_match("/\W/",$header_url)) {
@@ -1274,28 +1486,30 @@ function sync_package_pfblockerng($cron = "") {
 
 							if (file_exists($pfbfolder . '/' . $header_url . '.txt') && $pfb['reuse'] == "") {
 								if ($row['state'] == "Hold") {
-									$log = "\n[ {$header_url} ] {$log_tab} Static Hold [ NOW ]\n";
+									$log = "\n[ {$header_url} ]{$log_tab} Static Hold [ NOW ]";
 								} else {
-									$log = "\n[ {$header_url} ] {$log_tab} exists, Reloading File [ NOW ]\n";
+									$log = "\n[ {$header_url} ]{$log_tab} exists, Reloading File [ NOW ]";
 								}
 								pfb_logger("{$log}","1");
 							} else {
 								if ($pfb['reuse'] == "on" && file_exists($pfb['origdir'] . '/' . $header_url . '.orig')) {
-									$log = "\n[ {$header_url} ] {$log_tab} Using Previously Downloaded File [ NOW ]\n";
+									$log = "\n[ {$header_url} ]{$log_tab} Using Previously Downloaded File [ NOW ]";
 								} else {
-									$log = "\n[ {$header_url} ] {$log_tab} Downloading New File [ NOW ]\n";
-								}  
+									$log = "\n[ {$header_url} ]{$log_tab} Downloading New File [ NOW ]";
+								}
 								pfb_logger("{$log}","1");
 
-								# Perform Remote URL Date/Time Stamp checks
-								$host = @parse_url($row['url']);
 								$list_url = "{$row['url']}";
-								if ($row['format'] != "rsync" || $row['format'] != "html") {
-									if ($host['host'] == "127.0.0.1" || $host['host'] == $pfb['iplocal'] || empty($host['host'])) {
-										$remote_tds = "local";
-									} else {
-										$remote_tds = @implode(preg_grep("/Last-Modified/", get_headers($list_url)));
-										$remote_tds = preg_replace("/^Last-Modified: /","", $remote_tds);
+								if (!$pfb['reuse'] == "on") {
+									# Perform Remote URL Date/Time Stamp checks
+									$host = @parse_url($row['url']);
+									if ($row['format'] != "rsync" || $row['format'] != "html") {
+										if ($host['host'] == "127.0.0.1" || $host['host'] == $pfb['iplocal'] || empty($host['host'])) {
+											$remote_tds = "local";
+										} else {
+											$remote_tds = @implode(preg_grep("/Last-Modified/", get_headers($list_url)));
+											$remote_tds = preg_replace("/^Last-Modified: /","", $remote_tds);
+										}
 									}
 								}
 
@@ -1344,7 +1558,7 @@ function sync_package_pfblockerng($cron = "") {
 										$url_zip = "{$row['url']}";
 										if (!$file_zip = @file_get_contents($url_zip)) {
 											$error = error_get_last();
-											$log = "\n [ {$header_url} ] {$error['message']} \n";
+											$log = "\n [ {$header_url} ] {$error['message']}\n";
 											pfb_logger("{$log}","2");
 										} else {
 											@file_put_contents($file_dwn, $file_zip, LOCK_EX);
@@ -1421,7 +1635,7 @@ function sync_package_pfblockerng($cron = "") {
 										$return = 0;
 									} else {
 										$url_html = "{$row['url']}";
-										exec ("/usr/bin/fetch -v -o {$file_dwn} -T 20 {$url_html}",$output,$return);
+										exec ("/usr/bin/fetch -v -o {$file_dwn} -T 20 '{$url_html}'",$output,$return);
 									}
 									if ($return == 0)
 										$url_list = @file($file_dwn);
@@ -1497,8 +1711,17 @@ function sync_package_pfblockerng($cron = "") {
 									else {
 										foreach ($url_list as $line) {
 											if (!preg_match("/^#/", $line)) {
+												# Network range 192.168.0.0-192.168.0.254
+												if (preg_match($pfb['range'],$line,$matches)) {
+													$a_cidr = ip_range_to_subnet_array_temp2($matches[1],$matches[2]);
+													if (!empty($a_cidr)) {
+														foreach ($a_cidr as $cidr) {
+															$new_file .= preg_replace($pfb_ipreg,'',$cidr) . "\n";
+														}
+													}
+												}
 												# CIDR format 192.168.0.0/16
-												if (preg_match($pfb['cidr'],$line,$matches)) {
+												elseif (preg_match($pfb['cidr'],$line,$matches)) {
 													$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
 												}
 												# Single ip addresses
@@ -1517,10 +1740,11 @@ function sync_package_pfblockerng($cron = "") {
 									$url_chk = "{$pfb['origdir']}/{$header_url}.orig";
 								}
 
-								# Check if File Exists and is >0 in Size
+								# Check if File Exists and is > 0 in Size
 								$file_chk = "";
-								if (file_exists($url_chk) && @filesize($url_chk) >0)
+								if (file_exists($url_chk) && @filesize($url_chk) > 0) {
 									$file_chk = exec ("/usr/bin/grep -cv '^#\|^$' {$url_chk}");
+								}
 
 								if ($file_chk == "0") {
 									$new_file = "1.1.1.1\n";
@@ -1552,12 +1776,13 @@ function sync_package_pfblockerng($cron = "") {
 									# PFCTL - Update Only Aliases that have been updated only.
 									$pfb_alias_lists[] = "{$alias}";
 									# Launch d-dup and p-dup functions when changes are found.
-									if ($pfb['skip'] && $vtype == "_v4")
+									if ($pfb['skip'] && $vtype == "_v4") {
 										$pfb['dupcheck'] = TRUE;
+									}
 									# Enable Suppression Process due to Updates
-									if ($pfb['supp'] == "on" && $vtype == "_v4")
+									if ($pfb['supp'] == "on" && $vtype == "_v4") {
 										$pfb['supp_update'] = TRUE;
-
+									}
 								} else {
 									# Log FAILED Downloads and Check if Firewall or Snort/Suricata is Blocking Host
 									$log = "\n [ {$alias} {$header_url} ] Download FAIL [ NOW ]\n";
@@ -1632,27 +1857,21 @@ function sync_package_pfblockerng($cron = "") {
 							$aliascustom = "{$list['aliasname']}_custom_v6";
 						}
 
-						# Format Log into clean Tab Spaces
-						if (strlen($aliascustom) > 10) {
-							$log_tab = "\t";
-						} else {
-							$log_tab = "\t\t";
-						}
-
 						# Collect Active Alias List (Used for pfctl Update when 'Reputation' is enabled.
 						$pfb_alias_lists_all[] = "{$alias}";
 
-						# Determine Folder Location for Alias (return array $pfbarr)
-						pfb_determine_list_detail($list['action']);
-						$pfb['skip'] = $pfbarr['skip'];
-						$pfbfolder   = $pfbarr['folder'];
+						# Determine 'List' details (return array $pfbarr)
+						pfb_determine_list_detail($list['action'], $aliascustom, "", "");
+						$pfb['skip']	= $pfbarr['skip'];
+						$pfbfolder	= $pfbarr['folder'];
+						$log_tab	= $pfbarr['logtab'];
 
 						if (file_exists($pfbfolder . '/' . $aliascustom . '.txt') && $pfb['reuse'] == "") {
-							$log = "\n[ {$aliascustom} ] {$log_tab} exists, Reloading File [ NOW ]\n";
+							$log = "\n[ {$aliascustom} ]{$log_tab} exists, Reloading File [ NOW ]";
 							pfb_logger("{$log}","1");
 						} else {
 							$url_list = array();
-							$log = "\n[ {$aliascustom} ] {$log_tab} Loading Custom File [ NOW ]\n";
+							$log = "\n[ {$aliascustom} ]{$log_tab} Loading Custom File [ NOW ]\n";
 							pfb_logger("{$log}","1");
 
 							$custom_list = pfbng_text_area_decode($list['custom']) . "\n";
@@ -1663,22 +1882,22 @@ function sync_package_pfblockerng($cron = "") {
 							if (!empty($url_list)) {
 								foreach ($url_list as $line) {
 									if ($vtype == "_v4") {
-										# CIDR format 192.168.0.0/16
-										if (preg_match($pfb['cidr'],$line,$matches)) {
-											$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
-										}
-										# Single ip addresses
-										elseif (preg_match($pfb['s_html'],$line,$matches)) {
-											$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
-										}
 										# Network range 192.168.0.0-192.168.0.254
-										elseif (preg_match($pfb['range'],$line,$matches)) {
+										if (preg_match($pfb['range'],$line,$matches)) {
 											$a_cidr = ip_range_to_subnet_array_temp2($matches[1],$matches[2]);
 											if (!empty($a_cidr)) {
 												foreach ($a_cidr as $cidr) {
 													$new_file .= preg_replace($pfb_ipreg, '',$cidr) . "\n";
 												}
 											}
+										}
+										# CIDR format 192.168.0.0/16
+										elseif (preg_match($pfb['cidr'],$line,$matches)) {
+											$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
+										}
+										# Single ip addresses
+										elseif (preg_match($pfb['s_html'],$line,$matches)) {
+											$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
 										}
 									} else {
 										# IPv6 Regex
@@ -1695,8 +1914,9 @@ function sync_package_pfblockerng($cron = "") {
 								# Collect Updated lists for Suppression Process
 								@file_put_contents($pfbfolder . '/'. $aliascustom . '.txt',$new_file, LOCK_EX);
 								# Enable Suppression Process due to Updates
-								if ($pfb['supp'] == "on" && $vtype == "_v4")
+								if ($pfb['supp'] == "on" && $vtype == "_v4") {
 									$pfb['supp_update'] = TRUE;
+								}
 								if ($pfb['rep'] == "on" && $pfb['skip'] && $vtype == "_v4") {
 									# Script to Call p24 Process
 									exec ("{$pfb['script']} p24 {$aliascustom} {$pfb['max']} {$pfb['dedup']} {$pfb['ccexclude']} {$pfb['ccwhite']} {$pfb['ccblack']} >> {$pfb['log']}  2>&1");
@@ -1739,24 +1959,29 @@ function sync_package_pfblockerng($cron = "") {
 	foreach ($list_type as $ip_type => $vtype) {
 		if ($config['installedpackages'][$ip_type]['config'] != "" && $pfb['enable'] == "on") {
 			$runonce = 0;
-			foreach ($config['installedpackages'][$ip_type]['config'] as $list) {
+			foreach ($config['installedpackages'][$ip_type]['config'] as $key => $list) {
 				$alias = "pfB_" . preg_replace("/\W/","",$list['aliasname']);
 
-				# Determine Folder Location for Alias (return array $pfbarr)
-				pfb_determine_list_detail($list['action']);
+				# Determine 'List' details (return array $pfbarr)
+				pfb_determine_list_detail($list['action'], "", $ip_type, $key);
 				$pfb['skip']	= $pfbarr['skip'];
 				$pfb_descr	= $pfbarr['descr'];
 				$pfbfolder	= $pfbarr['folder'];
+				$aports		= $pfbarr['aports'];
+				$adest		= $pfbarr['adest'];
+				$aproto		= $pfbarr['aproto'];
 
 				// Re-Save Only Aliases that have been updated only.
 				// When 'Reputation' is used, all Aliases need to be Updated.
 				$final_alias = array();
 				if ($pfb['dedup'] == "on" || $pfb['pdup'] == "on") {
-					if (!empty($pfb_alias_lists_all))
+					if (!empty($pfb_alias_lists_all)) {
 						$final_alias = array_unique($pfb_alias_lists_all);
+					}
 				} else {
-					if (!empty($pfb_alias_lists))
+					if (!empty($pfb_alias_lists)) {
 						$final_alias = array_unique($pfb_alias_lists);
+					}
 				}
 
 				if ($list['action'] != "Disabled") {
@@ -1862,7 +2087,19 @@ function sync_package_pfblockerng($cron = "") {
 									$rule['direction'] = "any";
 									$rule['descr'] = "{$alias}{$pfb['suffix']}";
 								$rule['source'] = array("address" => "{$alias}");
-								$rule['destination'] = array ("any" => "");
+								if (!empty($adest) && !empty($aports)) {
+									$rule['destination'] = array ("address" => "{$adest}", "port" => "{$aports}");
+								} elseif (!empty($adest) && empty($aports)) {
+									$rule['destination'] = array ("address" => "{$adest}");
+								} elseif (empty($adest) && !empty($aports)) {
+									$rule['destination'] = array ("any" => "", "port" => "{$aports}");
+								} else {
+									$rule['destination'] = array ("any" => "");
+								}
+								if (!empty($adest) && $list['autonot'] == "on")
+									$rule['destination']['not'] = "";
+								if (!empty($aproto))
+									$rule['protocol'] = "{$aproto}";
 								if ($pfb['config']['enable_log'] == "on" || $alias_log == "enabled")
 									$rule['log'] = "";
 								$deny_inbound[] = $rule;
@@ -1892,7 +2129,19 @@ function sync_package_pfblockerng($cron = "") {
 									$rule['direction'] = "any";
 								$rule['descr'] = "{$alias}{$pfb['suffix']}";
 								$rule['source'] = array ("address" => "{$alias}");
-								$rule['destination'] = array ("any" => "");
+								if (!empty($adest) && !empty($aports)) {
+									$rule['destination'] = array ("address" => "{$adest}", "port" => "{$aports}");
+								} elseif (!empty($adest) && empty($aports)) {
+									$rule['destination'] = array ("address" => "{$adest}");
+								} elseif (empty($adest) && !empty($aports)) {
+									$rule['destination'] = array ("any" => "", "port" => "{$aports}");
+								} else {
+									$rule['destination'] = array ("any" => "");
+								}
+								if (!empty($adest) && $list['autonot'] == "on")
+									$rule['destination']['not'] = "";
+								if (!empty($aproto))
+									$rule['protocol'] = "{$aproto}";
 								if ($pfb['config']['enable_log'] == "on" || $alias_log == "enabled")
 									$rule['log'] = "";
 								$permit_inbound[] = $rule;
@@ -1920,7 +2169,19 @@ function sync_package_pfblockerng($cron = "") {
 								$rule['direction'] = "any";
 								$rule['descr'] = "{$alias}{$pfb['suffix']}";
 								$rule['source'] = array ("address" => "{$alias}");
-								$rule['destination'] = array ("any" => "");
+								if (!empty($adest) && !empty($aports)) {
+									$rule['destination'] = array ("address" => "{$adest}", "port" => "{$aports}");
+								} elseif (!empty($adest) && empty($aports)) {
+									$rule['destination'] = array ("address" => "{$adest}");
+								} elseif (empty($adest) && !empty($aports)) {
+									$rule['destination'] = array ("any" => "", "port" => "{$aports}");
+								} else {
+									$rule['destination'] = array ("any" => "");
+								}
+								if (!empty($adest) && $list['autonot'] == "on")
+									$rule['destination']['not'] = "";
+								if (!empty($aproto))
+									$rule['protocol'] = "{$aproto}";
 								if ($pfb['config']['enable_log'] == "on" || $alias_log == "enabled")
 									$rule['log'] = "";
 								$match_inbound[] = $rule;
@@ -1949,7 +2210,7 @@ function sync_package_pfblockerng($cron = "") {
 	#update pfsense alias table
 	if (is_array($config['aliases']['alias'])) {
 		foreach ($config['aliases']['alias'] as $cbalias) {
-			if (preg_match("/pfB_/",$cbalias['name'])) {
+			if (substr($cbalias['name'], 0, 4) == 'pfB_') {
 				#mark pfctl aliastable for cleaning
 				if (!in_array($cbalias['name'], $aliases_list)) {
 					$aliases_list[] = $cbalias['name']; #mark aliastable for cleaning
@@ -1976,6 +2237,7 @@ function sync_package_pfblockerng($cron = "") {
 	#apply new alias table to xml
 	if ($message == "") {
 		$config['aliases']['alias'] = $new_aliases;
+		$pfb['cron_mod'] = TRUE;
 	}
 	# UNSET Variables
 	unset($new_aliases, $cbalias);
@@ -2241,25 +2503,24 @@ function sync_package_pfblockerng($cron = "") {
 			# Save New Rule Order to Config
 			$config['filter']['rule'] = $new_rules;
 		}
-		$log = "\n {$message} \n";
-		pfb_logger("{$log}","1");
+		if (!empty($message)) {
+			$log = "\n {$message}\n";
+			pfb_logger("{$log}","1");
+		}
 
 		# UNSET arrays 
 		unset ($cb_rules,$permit_inbound,$permit_outbound,$deny_inbound,$deny_outbound,$match_inbound,$match_outbound);
 		unset ($other_rules,$fother_rules,$permit_rules,$fpermit_rules,$match_rules,$fmatch_rules);
 	}
 
+	// Set flag to Update config file.
+	if ($pfb['autorules'] && $rules != $new_rules) {
+		$pfb['cron_mod'] = TRUE;
+	}
 
 	#################################
-	#	Closing Processes	#
+	#	pfSense Integration	#
 	#################################
-
-	#uncheck Reusing Existing Downloads Check box
-	if (!$pfb['save'] && $pfb['enable'] == "on")
-		$config['installedpackages']['pfblockerng']['config'][0]['pfb_reuse'] = "";
-
-	# Save all Changes to pfSense config file
-	write_config();
 
 	# If 'Rule Changes' are found, utilize the 'filter_configure()' function, if not, utilize 'pfctl replace' command
 	if ($pfb['autorules'] && $rules != $new_rules || $pfb['enable'] == "" || $pfb['remove']) {
@@ -2269,7 +2530,7 @@ function sync_package_pfblockerng($cron = "") {
 			$log = "\n===[  Aliastables / Rules  ]================================\n\n";
 			pfb_logger("{$log}","1");
 
-			$log = "Firewall Rule Changes Found, Applying Filter Reload \n";
+			$log = "Firewall Rule Changes Found, Applying Filter Reload\n";
 			pfb_logger("{$log}","1");
 		}
 
@@ -2289,37 +2550,45 @@ function sync_package_pfblockerng($cron = "") {
 		# Don't Execute on User 'Save'
 		if (!$pfb['save']) {
 
-			$log = "\n===[  Aliastables / Rules  ]================================\n\n";
+			$log = "\n\n===[  Aliastables / Rules  ]================================\n\n";
 			pfb_logger("{$log}","1");
 
-			$log = "No Changes to Firewall Rules, Skipping Filter Reload \n";
+			$log = "No Changes to Firewall Rules, Skipping Filter Reload\n";
 			pfb_logger("{$log}","1");
 
 			// Re-Save Only Aliases that have been updated only.
 			// When 'Reputation' is used, all Aliases Need to be Updated.
 			$final_alias = array();
 			if ($pfb['dedup'] == "on" || $pfb['pdup'] == "on") {
-				if (!empty($pfb_alias_lists_all))
+				if (!empty($pfb_alias_lists_all)) {
 					$final_alias = array_unique($pfb_alias_lists_all);
+				}
 			} else {
-				if (!empty($pfb_alias_lists))
+				if (!empty($pfb_alias_lists)) {
 					$final_alias = array_unique($pfb_alias_lists);
+				}
 			}
 
 			if (!empty($final_alias)) {
 				foreach ($final_alias as $final) {
-					$log = "\n Updating: {$final} \n";
+					$log = "\n Updating: {$final}\n";
 					pfb_logger("{$log}","1");
 					$result_pfctl = "";
-					exec ("/sbin/pfctl -t " . escapeshellarg($final) . " -T replace -f " . $pfb['aliasdir'] . "/" . escapeshellarg($final) . ".txt 2>&1", $result_pfctl);
-					$log = implode($result_pfctl);
+					if (file_exists("{$pfb['aliasdir']}/{$final}.txt")) {
+						exec ("/sbin/pfctl -t " . escapeshellarg($final) . " -T replace -f " . $pfb['aliasdir'] . "/" . escapeshellarg($final) . ".txt 2>&1", $result_pfctl);
+						$log = implode($result_pfctl);
+					}
+					else {
+						$log = "Aliastable file not found\n";
+					}
 					pfb_logger("{$log}","1");
 				}
+				pfb_logger("\n","1");
 
 				// Call function for NanoBSD/Ramdisk processes.
 				pfb_aliastables("update");
 			} else {
-				$log = "\nNo Changes to Aliases, Skipping pfctl Update \n";
+				$log = "No Changes to Aliases, Skipping pfctl Update\n";
 				pfb_logger("{$log}","1");
 			}
 		}
@@ -2329,6 +2598,7 @@ function sync_package_pfblockerng($cron = "") {
 
 	#sync config
 	pfblockerng_sync_on_changes();
+
 
 	#################################
 	#	FINAL REPORTING		#
@@ -2340,8 +2610,8 @@ function sync_package_pfblockerng($cron = "") {
 		exec ("{$pfb['script']} closing {$pfb['dup']} >> {$pfb['log']} 2>&1");
 	}
 
-	if ($pfb['enable'] == "on" && !$pfb['save']) {
-		$log = "\n\n UPDATE PROCESS ENDED [ NOW ]\n";
+	if ($pfb['enable'] == "on" && !$pfb['save'] || $pfb['summary']) {
+		$log = "\n UPDATE PROCESS ENDED [ NOW ]\n";
 		pfb_logger("{$log}","1");
 	}
 
@@ -2350,32 +2620,40 @@ function sync_package_pfblockerng($cron = "") {
 	#	Define/Apply CRON Jobs		#
 	#########################################
 
-	# Clear any existing pfBlockerNG Cron Jobs
-	install_cron_job("pfblockerng.php cron", false);
-
-	# Replace Cron job with any User Changes to $pfb_min
+	// Replace Cron job with any User Changes to $pfb_min
 	if ($pfb['enable'] == "on") {
-		# Define pfBlockerNG CRON Job
+		// Define pfBlockerNG CRON Job
 		$pfb_cmd	= "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron >> {$pfb['log']} 2>&1";
-		# $pfb['min'] ( User Defined Variable. Variable defined at start of Script )
-		$pfb_hour	= "*";
+		// $pfb['min'] ( User Defined Variable. Variable defined at start of Script )
+
+		// Define Cron hour (Cron Interval & Start Hour)
+		if ($pfb['interval'] == 1) {
+			$pfb_hour = "*";
+		} elseif ($pfb['interval'] == 24) {
+			$pfb_hour = $pfb['24hour'];
+		} else {
+			$pfb_hour = implode(",", pfb_cron_base_hour());
+		}
+
 		$pfb_mday	= "*";
 		$pfb_month	= "*";
 		$pfb_wday	= "*";
 		$pfb_who	= "root";
 
-		install_cron_job($pfb_cmd, true, $pfb['min'], $pfb_hour, $pfb_mday, $pfb_month, $pfb_wday, $pfb_who);
+		// Determine if Cron Task requires updating
+		if (!pfblockerng_cron_exists($pfb_cmd, $pfb['min'], $pfb_hour)) {
+			install_cron_job($pfb_cmd, true, $pfb['min'], $pfb_hour, $pfb_mday, $pfb_month, $pfb_wday, $pfb_who);
+		}
+	}
+	else {
+		// Clear any existing pfBlockerNG Cron Jobs
+		install_cron_job("pfblockerng.php cron", false);
 	}
 
-	# Clear any existing pfBlockerNG MaxMind CRON Job
-	install_cron_job("pfblockerng.php dc", false);
-
 	if ($pfb['enable'] == "on") {
-		# Define pfBlockerNG MaxMind CRON Job
+		// Define pfBlockerNG MaxMind CRON Job
 		$pfb_gcmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php dc >> {$pfb['geolog']} 2>&1";
-
-		# MaxMind GeoIP Cron Hour is randomized between 0-23 Hour to minimize effect on MaxMind Website
-
+		// MaxMind GeoIP Cron Hour is randomized between 0-23 Hour to minimize effect on MaxMind Website
 		$pfb_gmin	= "0";
 		$pfb_ghour	= rand(0,23);
 		$pfb_gmday	= "1,2,3,4,5,6,7";
@@ -2383,32 +2661,61 @@ function sync_package_pfblockerng($cron = "") {
 		$pfb_gwday	= "2";
 		$pfb_gwho	= "root";
 
-		install_cron_job($pfb_gcmd, true, $pfb_gmin, $pfb_ghour, $pfb_gmday, $pfb_gmonth, $pfb_gwday, $pfb_gwho);
+		// Determine if Cron Task requires updating
+		if (!pfblockerng_cron_exists($pfb_gcmd, $pfb_gmin, $pfb_ghour)) {
+			install_cron_job($pfb_gcmd, true, $pfb_gmin, $pfb_ghour, $pfb_gmday, $pfb_gmonth, $pfb_gwday, $pfb_gwho);
+		}
+	}
+	else {
+		// Clear any existing pfBlockerNG Cron Jobs
+		install_cron_job("pfblockerng.php dc", false);
+	}
+
+
+	#################################
+	#	Closing Processes	#
+	#################################
+
+	// uncheck Reusing Existing Downloads Check box
+	if (!$pfb['save'] && $pfb['enable'] == "on" && $pfb['reuse'] == "on") {
+		$config['installedpackages']['pfblockerng']['config'][0]['pfb_reuse'] = "";
+		$pfb['cron_mod'] = TRUE;
+	}
+
+	// Only save config.xml changes if changes are found.
+	// Temporay to ensure all conditions are defined before fully enabling this feature
+	if ($pfb['cron_mod'] || !$pfb['cron_mod']) {
+		write_config("pfBlockerNG: Save settings");
 	}
 }
 
 
 function pfblockerng_validate_input($post, &$input_errors) {
 	global $config;
+
 	foreach ($post as $key => $value) {
-		if (empty($value))
-			continue;
-		if ($key == "message_size_limit" && !is_numeric($value))
-			$input_errors[] = "Message size limit must be numeric.";
-		if ($key == "process_limit" && !is_numeric($value))
-			$input_errors[] = "Process limit must be numeric.";
-		if ($key == "freq" && (!preg_match("/^\d+(h|m|d)$/",$value) || $value == 0))
-			$input_errors[] = "A valid number with a time reference is required for the field 'Frequency'";
-		if (substr($key, 0, 2) == "dc" && !is_hostname($value))
-			$input_errors[] = "{$value} is not a valid host name.";
-		if (substr($key, 0, 6) == "domain" && is_numeric(substr($key, 6))) {
-			if (!is_domain($value))
-				$input_errors[] = "{$value} is not a valid domain name.";
-		} else if (substr($key, 0, 12) == "mailserverip" && is_numeric(substr($key, 12))) {
-			if (empty($post['domain' . substr($key, 12)]))
-				$input_errors[] = "Domain for {$value} cannot be blank.";
-			if (!is_ipaddr($value) && !is_hostname($value))
-				$input_errors[] = "{$value} is not a valid IP address or host name.";
+
+		if (substr($key, 0, 3) == "url" && is_numeric( substr($key, 3, (strlen($key) - 3))) ) {
+			if (empty($value)) {
+				$input_url_empty = TRUE;
+				continue;
+			}
+			if (substr($value, 0, 1) == ' ') {
+				$input_errors[] = "Leading whitespace not allowed in URL field";
+			}
+		}
+
+		if (substr($key, 0, 6) == "header" && is_numeric( substr($key, 6, (strlen($key) - 6))) ) {
+			if ($input_url_empty && empty($value)) {
+				$input_url_empty = FALSE;
+				continue;
+			}
+			if ($input_url_empty && !empty($value)) {
+				$input_errors[] = "No URL Defined.";
+			}
+			if (substr($value, 0, 1) == ' ' || empty($value)) {
+				$input_errors[] = "Header field must be defined.";
+			}
 		}
 	}
 }
@@ -2423,7 +2730,8 @@ function pfblockerng_php_install_command() {
 	@rmdir_recursive("{$pfb['dbdir']}/cc");
 
 	# Uncompress Country Code File
-	exec("/usr/bin/tar -jx -C {$pfb['ccdir']} -f {$pfb['dbdir']}/countrycodes.tar.bz2");
+	@copy("{$pfb['dbdir']}/countrycodes.tar.bz2", "{$pfb['ccdir']}/countrycodes.tar.bz2");
+	exec("/usr/bin/tar -jx -C {$pfb['ccdif']} -f {$pfb['ccdir']}/countrycodes.tar.bz2");
 	# Download MaxMind Files and Create Country Code files and Build Continent XML Files
 	update_output_window(gettext("Downloading MaxMind Country Databases. This may take a minute..."));
 	exec("/bin/sh /usr/local/pkg/pfblockerng/geoipupdate.sh all >> {$pfb['geolog']} 2>&1");
@@ -2525,7 +2833,6 @@ function pfblockerng_php_deinstall_command() {
 		foreach ($widgetlist as $key => $widget) {
 			if (strstr($widget, "pfblockerng-container")) {
 				unset($widgetlist[$key]);
-				break;
 			}
 		}
 		$config['widgets']['sequence'] = implode(",", $widgetlist);
@@ -2540,9 +2847,9 @@ function pfblockerng_sync_on_changes() {
 	// Create Array of Sync Settings and exit if Sync is Disabled.
 	if (is_array($config['installedpackages']['pfblockerngsync']['config'][0])) {
 		$pfb_sync = $config['installedpackages']['pfblockerngsync']['config'][0];
-		if ($pfb_sync['varsynconchanges'] == "disabled" || $pfb_sync['varsynconchanges'] == "")
+		if ($pfb_sync['varsynconchanges'] == "disabled" || $pfb_sync['varsynconchanges'] == "") {
 			return;
-
+		}
 		$synctimeout = $pfb_sync['varsynctimeout'];
 	} else {
 		return;
@@ -2553,15 +2860,15 @@ function pfblockerng_sync_on_changes() {
 	if (is_array($config['installedpackages']['pfblockerngsync']['config'])) {
 		switch ($pfb_sync['varsynconchanges']) {
 			case "manual":
-				if (is_array($pfb_sync[row])) {
-					$rs = $pfb_sync[row];
+				if (is_array($pfb_sync['row'])) {
+					$rs = $pfb_sync['row'];
 				} else {
-					log_error("[pfBlockerNG] XMLRPC sync is enabled but there are no replication targets configured.");
+					log_error("[pfBlockerNG] Manual XMLRPC sync is enabled but there are no replication targets configured.");
 					return;
 				}
 				break;
 			case "auto":
-				if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])){
+				if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])) {
 					$system_carp = $config['installedpackages']['carpsettings']['config'][0];
 					$rs[0]['varsyncipaddress'] = $system_carp['synchronizetoip'];
 					$rs[0]['varsyncusername'] = $system_carp['username'];
@@ -2575,11 +2882,11 @@ function pfblockerng_sync_on_changes() {
 					}
 
 					if ($system_carp['synchronizetoip'] == "") {
-						log_error("[pfBlockerNG] XMLRPC sync is enabled but there are no replication targets configured.");
+						log_error("[pfBlockerNG] XMLRPC sync is enabled but there is no sync IP address configured.");
 						return;
 					}
 				} else {
-					log_error("[pfBlockerNG] XMLRPC sync is enabled but there are no replication targets configured.");
+					log_error("[pfBlockerNG] Auto XMLRPC sync is enabled but there are no replication targets configured.");
 					return;
 				}
 				break;
@@ -2605,8 +2912,9 @@ function pfblockerng_sync_on_changes() {
 					pfblockerng_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout);
 				}
 			}
-			if ($success)
+			if ($success) {
 				log_error("[pfBlockerNG] XMLRPC sync completed successfully.");
+			}
 		}
 	}
 }
@@ -2639,9 +2947,9 @@ function pfblockerng_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $p
 	}
 
 	/* Test key variables and set defaults if empty */
-	if (empty($synctimeout))
+	if (empty($synctimeout)) {
 		$synctimeout = 150;
-
+	}
 	$url = "{$protocol}://{$sync_to_ip}";
 
 	if ($port == "") { $port = $config['system']['webgui']['port']; };
@@ -2656,26 +2964,37 @@ function pfblockerng_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $p
 	/* xml will hold the sections to sync */
 	$xml = array();
 	// If User Disabled, remove 'General Tab Customizations' from Sync
-	if ($config['installedpackages']['pfblockerngsync']['config'][0]['syncinterfaces'] == "")
-		$xml['pfblockerng']		= $config['installedpackages']['pfblockerng'];
-	$xml['pfblockerngreputation']		= $config['installedpackages']['pfblockerngreputation'];
-	$xml['pfblockernglistsv4']		= $config['installedpackages']['pfblockernglistsv4'];
-	$xml['pfblockernglistsv6']		= $config['installedpackages']['pfblockernglistsv6'];
-	$xml['pfblockerngtopspammers']		= $config['installedpackages']['pfblockerngtopspammers'];
-	$xml['pfblockerngafrica']		= $config['installedpackages']['pfblockerngafrica'];
-	$xml['pfblockerngantartica']		= $config['installedpackages']['pfblockerngantartica'];
-	$xml['pfblockerngasia']			= $config['installedpackages']['pfblockerngasia'];
-	$xml['pfblockerngeurope']		= $config['installedpackages']['pfblockerngeurope'];
-	$xml['pfblockerngnorthamerica']		= $config['installedpackages']['pfblockerngnorthamerica'];
-	$xml['pfblockerngoceania']		= $config['installedpackages']['pfblockerngoceania'];
-	$xml['pfblockerngsouthamerica']		= $config['installedpackages']['pfblockerngsouthamerica'];
-	$xml['pfblockerngproxyandsatellite']	= $config['installedpackages']['pfblockerngproxyandsatellite'];
+	if ($config['installedpackages']['pfblockerngsync']['config'][0]['syncinterfaces'] == "") {
+		if (is_array($config['installedpackages']['pfblockerng']))
+			$xml['pfblockerng']		= $config['installedpackages']['pfblockerng'];
+	}
+	if (is_array($config['installedpackages']['pfblockerngreputation']))
+		$xml['pfblockerngreputation']		= $config['installedpackages']['pfblockerngreputation'];
+	if (is_array($config['installedpackages']['pfblockernglistsv4']))
+		$xml['pfblockernglistsv4']		= $config['installedpackages']['pfblockernglistsv4'];
+	if (is_array($config['installedpackages']['pfblockernglistsv6']))
+		$xml['pfblockernglistsv6']		= $config['installedpackages']['pfblockernglistsv6'];
+	if (is_array($config['installedpackages']['pfblockerngtopspammers']))
+		$xml['pfblockerngtopspammers']		= $config['installedpackages']['pfblockerngtopspammers'];
+	if (is_array($config['installedpackages']['pfblockerngafrica']))
+		$xml['pfblockerngafrica']		= $config['installedpackages']['pfblockerngafrica'];
+	if (is_array($config['installedpackages']['pfblockerngantartica']))
+		$xml['pfblockerngantartica']		= $config['installedpackages']['pfblockerngantartica'];
+	if (is_array($config['installedpackages']['pfblockerngasia']))
+		$xml['pfblockerngasia']			= $config['installedpackages']['pfblockerngasia'];
+	if (is_array($config['installedpackages']['pfblockerngeurope']))
+		$xml['pfblockerngeurope']		= $config['installedpackages']['pfblockerngeurope'];
+	if (is_array($config['installedpackages']['pfblockerngnorthamerica']))
+		$xml['pfblockerngnorthamerica']		= $config['installedpackages']['pfblockerngnorthamerica'];
+	if (is_array($config['installedpackages']['pfblockerngoceania']))
+		$xml['pfblockerngoceania']		= $config['installedpackages']['pfblockerngoceania'];
+	if (is_array($config['installedpackages']['pfblockerngsouthamerica']))
+		$xml['pfblockerngsouthamerica']		= $config['installedpackages']['pfblockerngsouthamerica'];
+	if (is_array($config['installedpackages']['pfblockerngproxyandsatellite']))
+		$xml['pfblockerngproxyandsatellite']	= $config['installedpackages']['pfblockerngproxyandsatellite'];
 
 	/* assemble xmlrpc payload */
-	$params = array(
-			XML_RPC_encode($password),
-			XML_RPC_encode($xml)
-		);
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($xml));
 
 	/* set a few variables needed for sync code borrowed from filter.inc */
 	log_error("[pfBlockerNG] XMLRPC syncing to {$url}:{$port}.");

--- a/config/pfblockerng/pfblockerng.inc
+++ b/config/pfblockerng/pfblockerng.inc
@@ -46,7 +46,7 @@ require_once("pfsense-utils.inc");
 require_once("globals.inc");
 require_once("services.inc");
 
-# [ $pfb ] pfBlockerNG Global Array for Paths and Variables. This needs to be called to get the Updated Settings.
+// [ $pfb ] pfBlockerNG Global Array for Paths and Variables. This needs to be called to get the Updated Settings.
 function pfb_global() {
 	global $g,$config,$pfb;
 
@@ -58,7 +58,7 @@ function pfb_global() {
 		$prefix = "/usr/local";
 	}
 
-	# Folders
+	// Folders
 	$pfb['dbdir']		= "{$g['vardb_path']}/pfblockerng";
 	$pfb['aliasdir']	= "{$g['vardb_path']}/aliastables";
 	$pfb['logdir']		= "{$g['varlog_path']}/pfblockerng";
@@ -70,13 +70,13 @@ function pfb_global() {
 	$pfb['origdir']		= "{$pfb['dbdir']}/original";
 	$pfb['ccdir']		= "{$prefix}/share/GeoIP";
 
-	# Create Folders if not Exist.
+	// Create Folders if not Exist.
 	$folder_array = array ("{$pfb['dbdir']}","{$pfb['logdir']}","{$pfb['ccdir']}","{$pfb['origdir']}","{$pfb['nativedir']}","{$pfb['denydir']}","{$pfb['matchdir']}","{$pfb['permitdir']}","{$pfb['aliasdir']}");
 	foreach ($folder_array as $folder) {
 		safe_mkdir ("{$folder}",0755);
 	}
 
-	# Files
+	// Files
 	$pfb['master']		= "{$pfb['dbdir']}/masterfile";
 	$pfb['errlog']		= "{$pfb['logdir']}/error.log";
 	$pfb['geolog']		= "{$pfb['logdir']}/geoip.log";
@@ -85,32 +85,32 @@ function pfb_global() {
 	$pfb['script']		= 'sh /usr/local/pkg/pfblockerng/pfblockerng.sh';
 	$pfb['aliasarchive']	= "{$prefix}/etc/aliastables.tar.bz2";
 
-	# General Variables
+	// General Variables
 	$pfb['config']		= $config['installedpackages']['pfblockerng']['config'][0];
 
-	# Enable/Disable of pfBlockerNG
+	// Enable/Disable of pfBlockerNG
 	$pfb['enable']		= $pfb['config']['enable_cb'];
-	# Keep Blocklists on pfBlockerNG Disable
+	// Keep Blocklists on pfBlockerNG Disable
 	$pfb['keep']		= $pfb['config']['pfb_keep'];
-	# Enable Suppression
+	// Enable Suppression
 	$pfb['supp']		= $pfb['config']['suppression'];
-	# Max Lines in pfblockerng.log file
+	// Max Lines in pfblockerng.log file
 	$pfb['logmax']		= $pfb['config']['log_maxlines'];
-	# Lan IP Address
+	// Lan IP Address
 	$pfb['iplocal']		= $config['interfaces']['lan']['ipaddr'];
-	# Disable Country Database CRON Updates
+	// Disable Country Database CRON Updates
 	$pfb['cc']		= $pfb['config']['database_cc'];
 
-	# User Defined CRON Start Minute
+	// User Defined CRON Start Minute
 	$pfb['min']		= $pfb['config']['pfb_min'];
-	# Start hour of the Scheduler
+	// Start hour of the Scheduler
 	$pfb['hour']		= $pfb['config']['pfb_hour'];
-	# Hour cycle for Scheduler
+	// Hour cycle for Scheduler
 	$pfb['interval']	= $pfb['config']['pfb_interval'];
-	# Start hour of the 'Once a day' Schedule
+	// Start hour of the 'Once a day' Schedule
 	$pfb['24hour']		= $pfb['config']['pfb_dailystart'];
 
-	# Set pfBlockerNG to Disabled on 'Re-Install'
+	// Set pfBlockerNG to Disabled on 'Re-Install'
 	if (isset($pfb['install']) && $pfb['install']) {
 		$pfb['enable'] = "";
 		$pfb['install'] = FALSE;
@@ -119,14 +119,14 @@ function pfb_global() {
 
 pfb_global();
 
-# Set Max PHP Memory Setting
+// Set Max PHP Memory Setting
 $uname = posix_uname();
 if ($uname['machine'] == 'amd64') {
 	ini_set('memory_limit', '256M');
 }
 
 
-# Function to decode to Alias Custom entry box.
+// Function to decode to Alias Custom entry box.
 function pfbng_text_area_decode($text) {
 	$customlist = explode("\r\n", base64_decode($text));
 	foreach ($customlist as $line) {
@@ -142,13 +142,13 @@ function pfbng_text_area_decode($text) {
 }
 
 
-# Manage Log File Line Limit
+// Manage Log File Line Limit
 function pfb_log_mgmt() {
 	global $pfb;
 	pfb_global();
 
 	if ($pfb['logmax'] == "nolimit") {
-		# Skip Log Mgmt
+		// Skip Log Mgmt
 	} else {
 		if (file_exists($pfb['log'])) {
 			exec("/usr/bin/tail -n {$pfb['logmax']} {$pfb['log']} > /tmp/pfblog; /bin/mv -f /tmp/pfblog {$pfb['log']}");
@@ -157,13 +157,13 @@ function pfb_log_mgmt() {
 }
 
 
-# Record Log Messsages to pfBlockerNG Log File and/or Error Log File.
+// Record Log Messsages to pfBlockerNG Log File and/or Error Log File.
 function pfb_logger($log, $type) {
 	global $g,$pfb,$pfbarr;
 
 	$now = date("m/d/y G:i:s", time());
 
-	# Only log timestamp if new
+	// Only log timestamp if new
 	if (preg_match("/NOW/", $log)) {
 		if ($now == $pfb['pnow']) {
 			$log = str_replace("[ NOW ]", "", "{$log}");
@@ -199,7 +199,7 @@ function pfb_determine_list_detail($list="", $header_url="", $confconfig="", $ke
 		$pfbarr['skip']		= FALSE;
 		$pfbarr['folder']	= "{$pfb['nativedir']}";
 	} else {
-		# Deny
+		// Deny
 		$pfbarr['skip']		= TRUE;
 		$pfbarr['folder']	= "{$pfb['denydir']}";
 	}
@@ -211,7 +211,7 @@ function pfb_determine_list_detail($list="", $header_url="", $confconfig="", $ke
 		$pfbarr['descr'] = " Auto ";
 	}
 
-	//Determine length of Header to format log Output
+	// Determine length of Header to format log Output
 	if (strlen($header_url) > 19) {
 		$pfbarr['logtab'] = "";
 	}
@@ -283,7 +283,7 @@ function pfb_cron_base_hour() {
 	}
 
 	if ($pfb['interval'] == 2) {
-		# 2 Hour Schedule Converter
+		// 2 Hour Schedule Converter
 		$shour = intval(substr($pfb['hour'], 0, 2));
 		$sch2 = strval($shour);
 		for ($i=0; $i<11; $i++) {
@@ -298,7 +298,7 @@ function pfb_cron_base_hour() {
 	}
 
 	if ($pfb['interval'] == 3) {
-		# 3 Hour Schedule Converter
+		// 3 Hour Schedule Converter
 		$shour = intval(substr($pfb['hour'], 0, 2));
 		$sch3 = strval($shour);
 		for ($i=0; $i<7; $i++) {
@@ -313,7 +313,7 @@ function pfb_cron_base_hour() {
 	}
 
 	if ($pfb['interval'] == 4) {
-		# 4 Hour Schedule Converter
+		// 4 Hour Schedule Converter
 		$shour = intval(substr($pfb['hour'], 0, 2));
 		$sch4 = strval($shour);
 		for ($i=0; $i<5; $i++) {
@@ -328,7 +328,7 @@ function pfb_cron_base_hour() {
 	}
 
 	if ($pfb['interval'] == 6) {
-		# 6 Hour Schedule Converter
+		// 6 Hour Schedule Converter
 		$shour = intval(substr($pfb['hour'], 0, 2));
 		$sch6 = strval($shour);
 		for ($i=0; $i<3; $i++) {
@@ -343,7 +343,7 @@ function pfb_cron_base_hour() {
 	}
 
 	if ($pfb['interval'] == 8) {
-		# 8 Hour Schedule Converter
+		// 8 Hour Schedule Converter
 		$shour = intval(substr($pfb['hour'], 0, 2));
 		$sch8 = strval($shour);
 		for ($i=0; $i<2; $i++) {
@@ -358,7 +358,7 @@ function pfb_cron_base_hour() {
 	}
 
 	if ($pfb['interval'] == 12) {
-		# 12 Hour Schedule Converter
+		// 12 Hour Schedule Converter
 		$shour = intval(substr($pfb['hour'], 0, 2));
 		$sch12 = strval($shour) . ",";
 		$shour += 12;
@@ -380,7 +380,7 @@ function pfb_cron_base_hour() {
 }
 
 
-# Create Suppression Alias
+// Create Suppression Alias
 function pfb_create_suppression_alias() {
 	global $config;
 
@@ -402,7 +402,7 @@ function pfb_create_suppression_alias() {
 }
 
 
-# Create Suppression file from Alias
+// Create Suppression file from Alias
 function pfb_create_suppression_file() {
 	global $config,$pfb;
 
@@ -426,7 +426,7 @@ function pfb_create_suppression_file() {
 				unlink_if_exists("{$pfb['supptxt']}");
 			}
 		} else {
-			# Delete Suppression File if Alias is Empty.
+			// Delete Suppression File if Alias is Empty.
 			unlink_if_exists("{$pfb['supptxt']}");
 		}
 	}
@@ -587,14 +587,14 @@ function pfb_aliastables($mode) {
 }
 
 
-# Main pfBlockerNG Function
+// Main pfBlockerNG Function
 function sync_package_pfblockerng($cron = "") {
 
 	global $g,$config,$pfb,$pfbarr;
 	pfb_global();
 	$pfb['cron_mod'] = FALSE;	// Flag to check for mods to the config.xml file.
 
-	# Detect Boot Process or Update via CRON
+	// Detect Boot Process or Update via CRON
 	if (isset($_POST) && $cron == "") {
 		if (!preg_match("/\w+/",$_POST['__csrf_magic'])) {
 			log_error("[pfBlockerNG] Sync terminated during boot process.");
@@ -608,7 +608,7 @@ function sync_package_pfblockerng($cron = "") {
 		$pfb['save'] = TRUE;
 	}
 
-	# Start of pfBlockerNG Logging to 'pfblockerng.log'
+	// Start of pfBlockerNG Logging to 'pfblockerng.log'
 	if ($pfb['enable'] == "on" && !$pfb['save']) {
 		$log = " UPDATE PROCESS START [ NOW ]\n";
 		pfb_logger("{$log}","1");
@@ -622,15 +622,15 @@ function sync_package_pfblockerng($cron = "") {
 	// Call function for NanoBSD/Ramdisk processes.
 	pfb_aliastables("conf");
 
-	# Collect pfSense Max Table Size Entry
+	// Collect pfSense Max Table Size Entry
 	if (empty($config['system']['maximumtableentries'])) {
-		# If Table limit not defined, set Default to 2M
+		// If Table limit not defined, set Default to 2M
 		$config['system']['maximumtableentries'] = "2000000";
 		$pfb['cron_mod'] = TRUE;
 	}
 	$pfb['table_limit'] = $config['system']['maximumtableentries'];
 
-	# Collect local web gui configuration
+	// Collect local web gui configuration
 	$pfb['weblocal'] = ($config['system']['webgui']['protocol'] != "" ? $config['system']['webgui']['protocol'] : "http");
 	$pfb['port'] = $config['system']['webgui']['port'];
 	if ($pfb['port'] == "") {
@@ -642,57 +642,57 @@ function sync_package_pfblockerng($cron = "") {
 	}
 	$pfb['weblocal'] .= "://127.0.0.1:{$pfb['port']}/pfblockerng/pfblockerng.php";
 
-	# Define Inbound/Outbound Action is not user selected.
+	// Define Inbound/Outbound Action is not user selected.
 	$pfb['deny_action_inbound'] = ($pfb['config']['inbound_deny_action'] != "" ? $pfb['config']['inbound_deny_action'] : "block");
 	$pfb['deny_action_outbound'] = ($pfb['config']['outbound_deny_action'] != "" ? $pfb['config']['outbound_deny_action'] : "reject");
 
-	# Reloads Existing Blocklists without Downloading New Lists
+	// Reloads Existing Blocklists without Downloading New Lists
 	$pfb['reuse']	= $pfb['config']['pfb_reuse'];
-	# Enable OpenVPN AutoRules
+	// Enable OpenVPN AutoRules
 	$pfb['openvpn']	= $pfb['config']['openvpn_action'];
-	# Enable/Disable Floating Auto-Rules
+	// Enable/Disable Floating Auto-Rules
 	$pfb['float']	= $pfb['config']['enable_float'];
-	# Enable Remove of Duplicate IPs utilizing Grepcidr
+	// Enable Remove of Duplicate IPs utilizing Grepcidr
 	$pfb['dup']	= $pfb['config']['enable_dup'];
-	# Order of the Auto-Rules
+	// Order of the Auto-Rules
 	$pfb['order']	= $pfb['config']['pass_order'];
-	# Suffix used for Auto-Rules
+	// Suffix used for Auto-Rules
 	$pfb['suffix']	= $pfb['config']['autorule_suffix'];
 
-	# Reputation Variables
+	// Reputation Variables
 	$pfb['config_rep'] = $config['installedpackages']['pfblockerngreputation']['config'][0];
 
-	# Enable/Disable Reputation
+	// Enable/Disable Reputation
 	$pfb['rep']	= $pfb['config_rep']['enable_rep'];
-	# Enable/Disable 'pDup'
+	// Enable/Disable 'pDup'
 	$pfb['pdup']	= $pfb['config_rep']['enable_pdup'];
-	# Enable/Disable 'dDup'
+	// Enable/Disable 'dDup'
 	$pfb['dedup']	= ($pfb['config_rep']['enable_dedup'] != "" ? $pfb['config_rep']['enable_dedup'] : "x");
-	# 'Max' variable setting for Reputation
+	// 'Max' variable setting for Reputation
 	$pfb['max']	= ($pfb['config_rep']['p24_max_var'] != "" ? $pfb['config_rep']['p24_max_var'] : "x");
-	# 'dMax' variable setting for Reputation
+	// 'dMax' variable setting for Reputation
 	$pfb['dmax']	= ($pfb['config_rep']['p24_dmax_var'] != "" ? $pfb['config_rep']['p24_dmax_var'] : "x");
-	# 'pMax' variable setting for Reputation
+	// 'pMax' variable setting for Reputation
 	$pfb['pmax']	= ($pfb['config_rep']['p24_pmax_var'] != "" ? $pfb['config_rep']['p24_pmax_var'] : "x");
-	# Action for Whitelist Country Category
+	// Action for Whitelist Country Category
 	$pfb['ccwhite']	= $pfb['config_rep']['ccwhite'];
-	# Action for Blacklist Country Category
+	// Action for Blacklist Country Category
 	$pfb['ccblack']	= $pfb['config_rep']['ccblack'];
-	# List of Countries in the Whitelist Category
+	// List of Countries in the Whitelist Category
 	$pfb['ccexclude']= ($pfb['config_rep']['ccexclude'] != "" ? $pfb['config_rep']['ccexclude'] : "x");
-	# Emerging Threats IQRisk Block Categories
+	// Emerging Threats IQRisk Block Categories
 	$pfb['etblock']	= ($pfb['config_rep']['etblock'] != "" ? $pfb['config_rep']['etblock'] : "x");
-	# Emerging Threats IQRisk Match Categories
+	// Emerging Threats IQRisk Match Categories
 	$pfb['etmatch']	= ($pfb['config_rep']['etmatch'] != "" ? $pfb['config_rep']['etmatch'] : "x");
-	# Perform a Force Update on ET Categories
+	// Perform a Force Update on ET Categories
 	$pfb['etupdate']= $pfb['config_rep']['et_update'];
 
-	# Variables
+	// Variables
 
-	# Starting Variable to Skip rep, pdup and dedeup functions if no changes are required
+	// Starting Variable to Skip rep, pdup and dedeup functions if no changes are required
 	$pfb['dupcheck'] = FALSE;
-	## $pfb['save'] is used to determine if User pressed "Save" Button to avoid Collision with CRON.
-	## This is defined in each pfBlockerNG XML Files
+	// $pfb['save'] is used to determine if User pressed "Save" Button to avoid Collision with CRON.
+	// This is defined in each pfBlockerNG XML Files
 
 
 	#################################
@@ -710,8 +710,8 @@ function sync_package_pfblockerng($cron = "") {
 				"Proxy and Satellite"	=> "pfB_PS"
 				);
 
-	#create rules vars and arrays
-	# Array used to Collect Changes to Aliases to be saved to Config
+	// create rules vars and arrays
+	// Array used to Collect Changes to Aliases to be saved to Config
 	$new_aliases		= array();
 	$new_aliases_list	= array();
 	$continent_existing	= array();
@@ -720,14 +720,14 @@ function sync_package_pfblockerng($cron = "") {
 	$permit_outbound	= array();
 	$deny_inbound		= array();
 	$deny_outbound		= array();
-	# An Array of all Aliases (Active and non-Active)
+	// An Array of all Aliases (Active and non-Active)
 	$aliases_list		= array();
-	# This is an Array of Aliases that Have Updated Lists via CRON/Force Update when 'Reputation' disabled.
+	// This is an Array of Aliases that Have Updated Lists via CRON/Force Update when 'Reputation' disabled.
 	$pfb_alias_lists	= array();
-	# This is an Array of All Active Aliases used when 'Reputation' enabled
+	// This is an Array of All Active Aliases used when 'Reputation' enabled
 	$pfb_alias_lists_all = array();
 
-	# Base Rule Array
+	// Base Rule Array
 	$base_rule_reg = array( "id"		=> "",
 				"tag"		=> "",
 				"tagged"	=> "",
@@ -740,7 +740,7 @@ function sync_package_pfblockerng($cron = "") {
 				"os"		=> ""
 				);
 
-	# Floating Rules, Base Rule Array
+	// Floating Rules, Base Rule Array
 	$base_rule_float = array("id"		=> "",
 				"tag"		=> "",
 				"tagged"	=> "",
@@ -760,8 +760,8 @@ function sync_package_pfblockerng($cron = "") {
 	#	Configure Rule Suffix		#
 	#########################################
 
-	# Discover if any Rules are AutoRules (If no AutoRules found, $pfb['autorules'] is FALSE, Skip Rules Re-Order )
-	# To configure Auto Rule Suffix. pfBlockerNG must be disabled to change Suffix and to avoid Duplicate Rules
+	// Discover if any Rules are AutoRules (If no AutoRules found, $pfb['autorules'] is FALSE, Skip Rules Re-Order )
+	// To configure Auto Rule Suffix. pfBlockerNG must be disabled to change Suffix and to avoid Duplicate Rules
 	$pfb['autorules'] = FALSE;
 	$pfb['found'] = FALSE;
 	foreach ($continents as $continent => $pfb_alias) {
@@ -787,16 +787,16 @@ function sync_package_pfblockerng($cron = "") {
 		}
 	}
 
-	#Configure Auto Rule Suffix. pfBlockerNG must be disabled to change Suffix and to avoid Duplicate Rules
-	# Count Number of Rules with 'pfB_'
+	// Configure Auto Rule Suffix. pfBlockerNG must be disabled to change Suffix and to avoid Duplicate Rules
+	// Count Number of Rules with 'pfB_'
 	$count = 0;
 	if (is_array($config['filter']['rule'])) {
 		foreach ($config['filter']['rule'] as $rule) {
-			# Collect any pre-existing Suffix
+			// Collect any pre-existing Suffix
 			if (preg_match("/pfB_\w+(\s.*)/",$rule['descr'], $pfb_suffix_real) && $count == 0) {
 				$pfb_suffix_match = $pfb_suffix_real[1];
 			}
-			# Query for Existing pfB Rules
+			// Query for Existing pfB Rules
 			if (preg_match("/pfB_/",$rule['descr'])) {
 				$count++;
 				break;
@@ -804,7 +804,7 @@ function sync_package_pfblockerng($cron = "") {
 		}
 	}
 
-	# Change Suffix only if No pfB Rules Found and Auto Rules are Enabled.
+	// Change Suffix only if No pfB Rules Found and Auto Rules are Enabled.
 	if ($pfb['autorules'] && $count == 0) {
 		switch ($pfb['suffix']) {
 			case "autorule":
@@ -819,10 +819,10 @@ function sync_package_pfblockerng($cron = "") {
 		}
 	} else {
 		if ($pfb['autorules']) {
-			# Use existing Suffix Match
+			// Use existing Suffix Match
 			$pfb['suffix'] = $pfb_suffix_match;
 		} else {
-			# Leave Rule Suffix 'Blank'
+			// Leave Rule Suffix 'Blank'
 			$pfb['suffix'] = "";
 		}
 	}
@@ -832,39 +832,39 @@ function sync_package_pfblockerng($cron = "") {
 	#	Configure INBOUND/OUTBOUND INTERFACES		#
 	#########################################################
 
-	# Collect pfSense Interface Order
+	// Collect pfSense Interface Order
 	$ifaces = get_configured_interface_list();
 
 	if (!empty($pfb['config']['inbound_interface'])) {
-		# Sort Interface Array to match pfSense Interface order to allow Floating Rules to populate.
+		// Sort Interface Array to match pfSense Interface order to allow Floating Rules to populate.
 		$selected_interfaces = explode(",",$pfb['config']['inbound_interface']);
-		# Sort pfBlockerNG Interface order to pfSense Interface Order
+		// Sort pfBlockerNG Interface order to pfSense Interface Order
 		$sort_interfaces = array_intersect($ifaces, $selected_interfaces);
 		$implode_interfaces = ltrim(implode(",",$sort_interfaces), ",");
-		# CSV String for Inbound Interfaces for 'pfB_' Match Rules 
+		// CSV String for Inbound Interfaces for 'pfB_' Match Rules 
 		$pfb['inbound_floating'] = $implode_interfaces;
 		$pfb['inbound_interfaces_float'] = explode(" ",$implode_interfaces);
 
-		# Assign Inbound Base Rule/Interfaces
+		// Assign Inbound Base Rule/Interfaces
 		if ($pfb['float'] == "on") {
-			# Define Base Firewall Floating Rules Settings
+			// Define Base Firewall Floating Rules Settings
 			$base_rule = $base_rule_float;
 			$pfb['inbound_interfaces'] = $pfb['inbound_interfaces_float'];
 		} else {
-			# Define Base Firewall Rules Settings
+			// Define Base Firewall Rules Settings
 			$base_rule = $base_rule_reg;
 			$pfb['inbound_interfaces'] = explode(",",$pfb['config']['inbound_interface']);
 		}
 	} else {
-		# Define Empty Variable/Array
+		// Define Empty Variable/Array
 		$pfb['inbound_interfaces_float'] = "";
 		$pfb['inbound_interfaces'] = array();
 	}
 
 	if (!empty($pfb['config']['outbound_interface'])) {
-		# Sort Interface Array to match pfSense Interface order to allow Floating Rules to populate.
+		// Sort Interface Array to match pfSense Interface order to allow Floating Rules to populate.
 		$selected_interfaces = explode(",",$pfb['config']['outbound_interface']);
-		# Sort pfBlockerNG Interface order to pfSense Interface Order
+		// Sort pfBlockerNG Interface order to pfSense Interface Order
 		$sort_interfaces = array_intersect($ifaces, $selected_interfaces);
 		// If OpenVPN Interfaces are not in dropdown menu
 		if ($pfb['openvpn'] == "on" && $config['openvpn']['openvpn-server'] || $pfb['openvpn'] == "on" && $config['openvpn']['openvpn-client']) {
@@ -873,11 +873,11 @@ function sync_package_pfblockerng($cron = "") {
 			}
 		}
 		$implode_interfaces = ltrim(implode(",",$sort_interfaces), ",");
-		# CSV String for Outbound Interfaces for 'pfB_' Match Rules
+		// CSV String for Outbound Interfaces for 'pfB_' Match Rules
 		$pfb['outbound_floating'] = $implode_interfaces;
 		$pfb['outbound_interfaces_float'] = explode(" ",$implode_interfaces);
 
-		# Assign Outbound Base Rule/Interfaces
+		// Assign Outbound Base Rule/Interfaces
 		if ($pfb['float'] == "on") {
 			$base_rule = $base_rule_float;
 			$pfb['outbound_interfaces'] = $pfb['outbound_interfaces_float'];
@@ -892,7 +892,7 @@ function sync_package_pfblockerng($cron = "") {
 			}
 		}
 	} else {
-		# Define Empty Variable/Array
+		// Define Empty Variable/Array
 		$pfb['outbound_interfaces_float'] = "";
 		$pfb['outbound_interfaces'] = array();
 	}
@@ -902,10 +902,10 @@ function sync_package_pfblockerng($cron = "") {
 	#	Clear Removed Lists from Masterfiles	#
 	#################################################
 
-	# Process to keep Masterfiles in Sync with Valid Lists from config.conf file.
+	// Process to keep Masterfiles in Sync with Valid Lists from config.conf file.
 	$pfb['sync_master'] = TRUE;
 
-	# Don't execute this function when pfBlockerNG is Disabled and 'Keep Blocklists' is enabled.
+	// Don't execute this function when pfBlockerNG is Disabled and 'Keep Blocklists' is enabled.
 	if ($pfb['enable'] == "" && $pfb['keep'] == "on") {
 		$pfb['sync_master'] = FALSE;
 	}
@@ -936,7 +936,7 @@ function sync_package_pfblockerng($cron = "") {
 					$cont_type = array ("countries4" => "_v4", "countries6" => "_v6");
 					foreach ($cont_type as $c_type => $vtype) {
 						if ($continent_config[$c_type] != "") {
-							# Set Parameters for 'Match', 'Permit', 'Native' and 'Deny'
+							// Set Parameters for 'Match', 'Permit', 'Native' and 'Deny'
 							if (in_array($continent_config['action'],array('Match_Both','Match_Inbound','Match_Outbound','Alias_Match'))) {
 								$pfb['existing']['match'][] = "{$pfb_alias}{$vtype}";
 							} elseif (in_array($continent_config['action'],array('Permit_Both','Permit_Inbound','Permit_Outbound','Alias_Permit'))){
@@ -952,7 +952,7 @@ function sync_package_pfblockerng($cron = "") {
 			}
 		}
 
-		# Find all Enabled IPv4/IPv6 Lists
+		// Find all Enabled IPv4/IPv6 Lists
 		$list_type = array ("pfblockernglistsv4" => "_v4", "pfblockernglistsv6" => "_v6");
 		foreach ($list_type as $ip_type => $vtype) {
 			if ($config['installedpackages'][$ip_type]['config'] != "" && $pfb['enable'] == "on") {
@@ -964,9 +964,9 @@ function sync_package_pfblockerng($cron = "") {
 							} else {
 								$pfb_alias = "{$row['header']}_v6";
 							}
-							# Collect Enabled Lists
+							// Collect Enabled Lists
 							if ($row['url'] != "" && $row['state'] != "Disabled") {
-								# Set Parameters for 'Match', 'Permit', 'Native' and 'Deny'
+								// Set Parameters for 'Match', 'Permit', 'Native' and 'Deny'
 								if (in_array($list['action'],array('Match_Both','Match_Inbound','Match_Outbound','Alias_Match'))) {
 									$pfb['existing']['match'][] = "{$pfb_alias}";
 								} elseif (in_array($list['action'],array('Permit_Both','Permit_Inbound','Permit_Outbound','Alias_Permit'))) {
@@ -983,7 +983,7 @@ function sync_package_pfblockerng($cron = "") {
 			}
 		}
 
-		# Find all Enabled IPv4 'Custom List' Header Names and Check if 'Emerging Threats Update' and 'Custom List Update' Needs Force Updating
+		// Find all Enabled IPv4 'Custom List' Header Names and Check if 'Emerging Threats Update' and 'Custom List Update' Needs Force Updating
 		$list_type = array ("pfblockernglistsv4" => "_v4", "pfblockernglistsv6" => "_v6");
 		foreach ($list_type as $ip_type => $vtype) {
 			if ($config['installedpackages'][$ip_type]['config'] != "" && $pfb['enable'] == "on") {
@@ -991,7 +991,7 @@ function sync_package_pfblockerng($cron = "") {
 				foreach ($config['installedpackages'][$ip_type]['config'] as $list) {
 					if (is_array($list['row']) && $list['action'] != "Disabled") {
 						$count++;
-						# Check if 'Emerging Threats Update' Needs Updating before next CRON Event.
+						// Check if 'Emerging Threats Update' Needs Updating before next CRON Event.
 						if (is_array($list['row']) && $row['state'] != "Disabled" && $pfb['etupdate'] == "enabled" && $vtype == "_v4") {
 							foreach ($list['row'] as $row) {
 								$aliasname = $row['header'];
@@ -1005,14 +1005,14 @@ function sync_package_pfblockerng($cron = "") {
 						}
 					}
 
-					# Collect Enabled Custom List Box Aliases
+					// Collect Enabled Custom List Box Aliases
 					if (pfbng_text_area_decode($list['custom']) != "") {
 						if ($vtype == "_v4") {
 							$pfb_alias = "{$list['aliasname']}_custom";
 						} else {
 							$pfb_alias = "{$list['aliasname']}_custom_v6";
 						}
-						# Determine Folder Location for 'List'
+						// Determine Folder Location for 'List'
 						if (in_array($list['action'],array('Match_Both','Match_Inbound','Match_Outbound','Alias_Match'))) {
 							$pfb['existing']['match'][] = "{$pfb_alias}";
 							$pfbfolder = "{$pfb['matchdir']}";
@@ -1026,10 +1026,10 @@ function sync_package_pfblockerng($cron = "") {
 							$pfb['existing']['deny'][] = "{$pfb_alias},";	// Add Trailing ','
 							$pfbfolder = "{$pfb['denydir']}";
 						}
-						# Determine if 'Custom List' Needs Force Updating before next CRON Event.
+						// Determine if 'Custom List' Needs Force Updating before next CRON Event.
 						if ($list['custom_update'] == "enabled") {
 							unlink_if_exists("{$pfbfolder}/{$pfb_alias}.txt");
-							# Uncheck 'Enabled' in List 'Custom_update' Setting
+							// Uncheck 'Enabled' in List 'Custom_update' Setting
 							$config['installedpackages'][$ip_type]['config'][$count]['custom_update'] = "disabled";
 							$pfb['cron_mod'] = TRUE;
 						}
@@ -1038,7 +1038,7 @@ function sync_package_pfblockerng($cron = "") {
 			}
 		}
 
-		# Collect all .txt file Names for each List Type
+		// Collect all .txt file Names for each List Type
 		$list_types = array('match' => $pfb['matchdir'], 'permit' => $pfb['permitdir'], 'deny' => $pfb['denydir'], 'native' => $pfb['nativedir']);
 		foreach ($list_types as $type => $pfbfolder) {
 			$pfb_files = glob("$pfbfolder/*.txt");
@@ -1052,12 +1052,12 @@ function sync_package_pfblockerng($cron = "") {
 			}
 		}
 
-		# Flag to execute pfctl and Rules Ordering
+		// Flag to execute pfctl and Rules Ordering
 		$pfb['remove'] = FALSE;
-		# Execute Final Summary as a List was Removed
+		// Execute Final Summary as a List was Removed
 		$pfb['summary'] = FALSE;
 
-		# Process to Remove Lists from Masterfile/DB Folder if they do not Exist
+		// Process to Remove Lists from Masterfile/DB Folder if they do not Exist
 		if (isset($pfb['existing'])) {
 			foreach ($pfb['existing'] as $pfb_exist) {
 				$existing_type = $pfb_exist['type'];
@@ -1072,7 +1072,7 @@ function sync_package_pfblockerng($cron = "") {
 								if ($f_result != "") {
 									$log = "[ Removing List(s) : {$f_result} ]\n";
 									pfb_logger("{$log}","1");
-									# Script to Remove un-associated Lists
+									// Script to Remove un-associated Lists
 									exec ("{$pfb['script']} remove x x x {$f_result} >> {$pfb['log']} 2>&1");
 									$pfb['summary'] = TRUE;
 									$pfb['remove'] = TRUE;
@@ -1082,7 +1082,7 @@ function sync_package_pfblockerng($cron = "") {
 							case "permit":
 							case "native":
 								$results = array_diff($pfb_act, $pfb_exist);
-								# This variable ($f_result) used in next section below.
+								// This variable ($f_result) used in next section below.
 								$f_result = implode($results);
 								if (!empty($results)) {
 									foreach ($results as $pfb_result) {
@@ -1096,7 +1096,7 @@ function sync_package_pfblockerng($cron = "") {
 								break;
 						}
 
-						# Allow rebuilding of changed Alias to purge 'SKIP' Lists (when pfBlockerNG is enabled)
+						// Allow rebuilding of changed Alias to purge 'SKIP' Lists (when pfBlockerNG is enabled)
 						$list_type = array ("pfblockernglistsv4" => "_v4", "pfblockernglistsv6" => "_v6");
 						foreach ($list_type as $ip_type => $vtype) {
 							if ($f_result != "" && $pfb['enable'] == "on") {
@@ -1110,7 +1110,7 @@ function sync_package_pfblockerng($cron = "") {
 													if ($row['header'] == $removed) {
 														$pfb['summary'] = TRUE;
 														$pfb['remove'] = TRUE;
-														# Add Alias to Update Array
+														// Add Alias to Update Array
 														$pfb_alias_lists[] = "{$alias}";
 														$pfb_alias_lists_all[] = "{$alias}";
 													}
@@ -1131,7 +1131,7 @@ function sync_package_pfblockerng($cron = "") {
 	#	Clear Match/Pass/ET/Original Files/Folders	#
 	#########################################################
 
-	# When pfBlockerNG is Disabled and 'Keep Blocklists' is Disabled.
+	// When pfBlockerNG is Disabled and 'Keep Blocklists' is Disabled.
 	if ($pfb['enable'] == "" && $pfb['keep'] == "" && !$pfb['install']) {
 		$log = "\n  Removing DB Files/Folders \n";
 		pfb_logger("{$log}","1");
@@ -1171,7 +1171,7 @@ function sync_package_pfblockerng($cron = "") {
 				$cont_type = array ("countries4" => "_v4", "countries6" => "_v6");
 				foreach ($cont_type as $c_type => $vtype) {
 
-					# Determine 'List' details (return array $pfbarr)
+					// Determine 'List' details (return array $pfbarr)
 					pfb_determine_list_detail($continent_config['action'], "{$pfb_alias}{$vtype}", $cc_name, "0");
 					$pfb['skip']	= $pfbarr['skip'];
 					$pfb_descr	= $pfbarr['descr'];
@@ -1200,16 +1200,16 @@ function sync_package_pfblockerng($cron = "") {
 						$match = $continent_new[$line];
 						$continent_new[$line] = rtrim($match, "\n");
 
-						# Check if pfBlockerNG pfctl Continent Tables are Empty (pfBlockerNG was Disabled w/ "keep", then Re-enabled)
+						// Check if pfBlockerNG pfctl Continent Tables are Empty (pfBlockerNG was Disabled w/ "keep", then Re-enabled)
 						$pfctlck = exec ("/sbin/pfctl -vvsTables | grep -A1 {$pfb_alias}{$vtype} | awk '/Addresses/ {s+=$2}; END {print s}'");
 						if (empty($pfctlck) && file_exists($pfbfolder . '/' . $pfb_alias . $vtype . '.txt')) {
 							$file_cont = file_get_contents($pfbfolder . '/' . $pfb_alias . $vtype . '.txt');
 							@file_put_contents($pfb['aliasdir'] . '/' . $pfb_alias . $vtype . '.txt',$file_cont, LOCK_EX);
-							# PFCTL - Update Only Aliases that have been updated. ('Reputation' Disabled)
+							// PFCTL - Update Only Aliases that have been updated. ('Reputation' Disabled)
 							$pfb_alias_lists[] = "{$pfb_alias}{$vtype}";
 						}
 
-						# Collect Active Alias Lists (Used for pfctl Update when 'Reputation' is enabled).
+						// Collect Active Alias Lists (Used for pfctl Update when 'Reputation' is enabled).
 						$pfb_alias_lists_all[] = "{$pfb_alias}{$vtype}";
 
 						// Compare Existing (Original File) and New Continent Data
@@ -1224,7 +1224,7 @@ function sync_package_pfblockerng($cron = "") {
 								$log = "\n[ {$pfb_alias}{$vtype} ]{$log_tab} Changes Found... Updating \n";
 								pfb_logger("{$log}","1");
 
-								# Test to Skip d-dup and p-dup functions when changes are found.
+								// Test to Skip d-dup and p-dup functions when changes are found.
 								$pfb['dupcheck'] = TRUE;
 
 								$pfb_alias_lists[] = "{$pfb_alias}{$vtype}";
@@ -1243,7 +1243,7 @@ function sync_package_pfblockerng($cron = "") {
 									@file_put_contents($pfb['aliasdir'] . '/' . $pfb_alias . $vtype . '.txt',$continent, LOCK_EX);
 								}
 
-								# Check if File Exists and is > 0 in Size and Save alias file
+								// Check if File Exists and is > 0 in Size and Save alias file
 								$file_chk = "0";
 								$cont_chk = "{$pfbfolder}/{$pfb_alias}{$vtype}.txt";
 								if (file_exists($cont_chk) && @filesize($cont_chk) > 0) {
@@ -1261,7 +1261,7 @@ function sync_package_pfblockerng($cron = "") {
 						}
 
 						if (file_exists($pfbfolder . '/' . $pfb_alias . $vtype . '.txt')) {
-							#Create alias config
+							// Create alias config
 							$new_aliases_list[] = "{$pfb_alias}{$vtype}";
 
 							$pfb_contlog = $continent_config['aliaslog'];
@@ -1275,7 +1275,7 @@ function sync_package_pfblockerng($cron = "") {
 										"detail"	=> "DO NOT EDIT THIS ALIAS"
 										);
 
-							#Create rule if action permits
+							// Create rule if action permits
 							switch ($continent_config['action']) {
 								case "Deny_Both":
 								case "Deny_Outbound":
@@ -1403,42 +1403,42 @@ function sync_package_pfblockerng($cron = "") {
 									break;
 							}
 						} else {
-							#unlink continent list if any
+							// unlink continent list if any
 							unlink_if_exists($pfb['aliasdir'] . '/' . $pfb_alias . $vtype . '.txt');
 						}
 					}
 				}
 			}
-			#mark pfctl aliastable for cleanup
+			// mark pfctl aliastable for cleanup
 			if (!in_array($pfb_alias, $aliases_list)) {
 				$aliases_list[] = "{$pfb_alias}{$vtype}";
 			}
 		}
 	}
-	# UNSET variables
+	// UNSET variables
 	unset ($continent, $continent_existing, $continent_new);
 
 	#################################################
 	#	Download and Collect IPv4/IPv6 lists	#
 	#################################################
 
-	# IPv4 REGEX Definitions
+	// IPv4 REGEX Definitions
 	$pfb['range']	= '/((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))-((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))/';
 	$pfb['block']	= '/(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[ 0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.([0]{1})\s+/';
 	$pfb['cidr']	= '/(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)?\/([0-9]{2}|[0-9]{1})/';
 	$pfb['single']	= '/(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\s+/';
 	$pfb['s_html']	= '/(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/';
 
-	# IPv4 preg_replace Regex Filter array
+	// IPv4 preg_replace Regex Filter array
 	$pfb_ipreg = array();
-	$pfb_ipreg[0] = '/\b0+(?=\d)/';					# Remove any Leading Zeros in each Octet
-	$pfb_ipreg[1] = '/\s/';						# Remove any Whitespaces
-	$pfb_ipreg[2] = '/\/32/';					# Remove any /32 CIDR
-	$pfb_ipreg[3] = '/127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/';	# Remove any Loopback Addresses 127/8
-	$pfb_ipreg[4] = '/0\.0\.0\.0/';					# Remove 0.0.0.0
+	$pfb_ipreg[0] = '/\b0+(?=\d)/';					// Remove any Leading Zeros in each Octet
+	$pfb_ipreg[1] = '/\s/';						// Remove any Whitespaces
+	$pfb_ipreg[2] = '/\/32/';					// Remove any /32 CIDR
+	$pfb_ipreg[3] = '/127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/';	// Remove any Loopback Addresses 127/8
+	$pfb_ipreg[4] = '/0\.0\.0\.0/';					// Remove 0.0.0.0
 
-	# IPv6 REGEX Definitions  -- ** Still Needs some Adjustment on Regex Definition for IPv6 **
-	# https://mebsd.com/coding-snipits/php-regex-ipv6-with-preg_match.html
+	// IPv6 REGEX Definitions  -- ** Still Needs some Adjustment on Regex Definition for IPv6 **
+	// https://mebsd.com/coding-snipits/php-regex-ipv6-with-preg_match.html
 	$pattern1 = '([A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}';
 	$pattern2 = '[A-Fa-f0-9]{1,4}::([A-Fa-f0-9]{1,4}:){0,5}[A-Fa-f0-9]{1,4}';
 	$pattern3 = '([A-Fa-f0-9]{1,4}:){2}:([A-Fa-f0-9]{1,4}:){0,4}[A-Fa-f0-9]{1,4}';
@@ -1457,7 +1457,7 @@ function sync_package_pfblockerng($cron = "") {
 		if ($config['installedpackages'][$ip_type]['config'] != "") {
 			foreach ($config['installedpackages'][$ip_type]['config'] as $list) {
 				if ($list['action'] != "Disabled" && $pfb['enable'] == "on" && !$pfb['save'] && is_array($list['row'])) {
-					# Capture Alias Name
+					// capture Alias Name
 					$alias = "pfB_" . preg_replace("/\W/","",$list['aliasname']);
 					foreach ($list['row'] as $row) {
 						if ($row['url'] != "" && $row['state'] != "Disabled") {
@@ -1468,7 +1468,7 @@ function sync_package_pfblockerng($cron = "") {
 								$header_url = "{$row['header']}_v6";
 							}
 
-							# Determine 'List' details (return array $pfbarr)
+							// Determine 'List' details (return array $pfbarr)
 							pfb_determine_list_detail($list['action'], $header_url, "", "");
 							$pfb['skip']	= $pfbarr['skip'];
 							$pfbfolder	= $pfbarr['folder'];
@@ -1481,7 +1481,7 @@ function sync_package_pfblockerng($cron = "") {
 								continue;
 							}
 
-							# Collect Active Alias List (Used for pfctl Update when 'Reputation' is enabled.
+							// Collect Active Alias List (Used for pfctl Update when 'Reputation' is enabled.
 							$pfb_alias_lists_all[] = "{$alias}";
 
 							if (file_exists($pfbfolder . '/' . $header_url . '.txt') && $pfb['reuse'] == "") {
@@ -1501,7 +1501,7 @@ function sync_package_pfblockerng($cron = "") {
 
 								$list_url = "{$row['url']}";
 								if (!$pfb['reuse'] == "on") {
-									# Perform Remote URL Date/Time Stamp checks
+									// Perform Remote URL Date/Time Stamp checks
 									$host = @parse_url($row['url']);
 									if ($row['format'] != "rsync" || $row['format'] != "html") {
 										if ($host['host'] == "127.0.0.1" || $host['host'] == $pfb['iplocal'] || empty($host['host'])) {
@@ -1517,7 +1517,7 @@ function sync_package_pfblockerng($cron = "") {
 								if ($row['format'] == "gz" || $row['format'] == "gz_2") {
 									$file_dwn = "{$pfb['origdir']}/{$header_url}.gz";
 									if ($pfb['reuse'] == "on" && file_exists($file_dwn)) {
-										# File Exists/Reuse
+										// File Exists/Reuse
 									} else {
 										$url_gz = "{$row['url']}";
 										$file_gz = @file_get_contents($url_gz);
@@ -1531,11 +1531,11 @@ function sync_package_pfblockerng($cron = "") {
 									$url_list = @gzfile($file_dwn);
 								}
 
-								# IBlock Large Files mixed with IPs and Domains. PHP mem of 256M can't handle very large Files.
+								// IBlock Large Files mixed with IPs and Domains. PHP mem of 256M can't handle very large Files.
 								if ($row['format'] == "gz_lg") {
 									$file_dwn = "{$pfb['origdir']}/{$header_url}.gz";
 									if ($pfb['reuse'] == "on" && file_exists($file_dwn)) {
-										# File Exists/Reuse
+										// File Exists/Reuse
 									} else {
 										$url_gz = "{$row['url']}";
 										$file_gz = @file_get_contents($url_gz);
@@ -1553,7 +1553,7 @@ function sync_package_pfblockerng($cron = "") {
 								elseif ($row['format'] == "zip") {
 									$file_dwn = "{$pfb['origdir']}/{$header_url}.zip";
 									if ($pfb['reuse'] == "on" && file_exists($file_dwn)) {
-										# File Exists/Reuse
+										// File Exists/Reuse
 									} else {
 										$url_zip = "{$row['url']}";
 										if (!$file_zip = @file_get_contents($url_zip)) {
@@ -1576,9 +1576,9 @@ function sync_package_pfblockerng($cron = "") {
 
 								elseif ($row['format'] == "et") {
 									$file_dwn = "{$pfb['origdir']}/{$header_url}.gz";
-									# Script to Call ET IQRISK Process
+									// Script to Call ET IQRISK Process
 									if ($pfb['reuse'] == "on" && file_exists($file_dwn)) {
-										# File Exists/Reuse
+										// File Exists/Reuse
 									} else {
 										$url_et = "{$row['url']}";
 										$file_et = @file_get_contents($url_et);
@@ -1595,9 +1595,9 @@ function sync_package_pfblockerng($cron = "") {
 
 								elseif ($row['format'] == "xlsx") {
 									$file_dwn = "{$pfb['origdir']}/{$header_url}.zip";
-									# Script to Call XLSX Process
+									// Script to Call XLSX Process
 									if ($pfb['reuse'] == "on" && file_exists($file_dwn)) {
-										# File Exists/Reuse
+										// File Exists/Reuse
 									} else {
 										$url_xlsx = "{$row['url']}";
 										$file_xlsx = @file_get_contents($url_xlsx);
@@ -1631,7 +1631,7 @@ function sync_package_pfblockerng($cron = "") {
 								elseif ($row['format'] == "html" || $row['format'] == "block") {
 									$file_dwn = "{$pfb['origdir']}/{$header_url}.raw";
 									if ($pfb['reuse'] == "on" && file_exists($file_dwn)) {
-										# File Exists/Reuse
+										// File Exists/Reuse
 										$return = 0;
 									} else {
 										$url_html = "{$row['url']}";
@@ -1644,7 +1644,7 @@ function sync_package_pfblockerng($cron = "") {
 								elseif ($row['format'] == "rsync") {
 									$file_dwn = "{$pfb['origdir']}/{$header_url}.orig";
 									if ($pfb['reuse'] == "on" && file_exists($file_dwn)) {
-										# File Exists/Reuse
+										// File Exists/Reuse
 									} else {
 										$url_rsync = "{$row['url']}";
 										exec ("/usr/local/bin/rsync --timeout=5 {$url_rsync} {$file_dwn}");
@@ -1652,13 +1652,13 @@ function sync_package_pfblockerng($cron = "") {
 									$url_list = @file($file_dwn);
 								}
 
-								#extract range lists
+								// extract range lists
 								$new_file = "";
 								if (!empty($url_list)) {
 									if ($row['format'] == "gz" && $vtype == "_v4") {
 										foreach ($url_list as $line) {
 											if (!preg_match("/^#/", $line)) {
-												# Network range 192.168.0.0-192.168.0.254
+												// Network range 192.168.0.0-192.168.0.254
 												if (preg_match($pfb['range'],$line,$matches)) {
 													$a_cidr = ip_range_to_subnet_array_temp2($matches[1],$matches[2]);
 													if (!empty($a_cidr)) {
@@ -1674,7 +1674,7 @@ function sync_package_pfblockerng($cron = "") {
 									elseif ($row['format'] == "block" && $vtype == "_v4") {
 										foreach ($url_list as $line) {
 											if (!preg_match("/^#/", $line)) {
-												# Block Type '218.77.79.0	218.77.79.255   24'
+												// Block Type '218.77.79.0	218.77.79.255   24'
 												if (preg_match($pfb['block'],$line,$matches)) {
 													$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "/24\n";
 												}
@@ -1685,11 +1685,11 @@ function sync_package_pfblockerng($cron = "") {
 									elseif ($row['format'] == "html" && $vtype == "_v4") {
 										foreach ($url_list as $line) {
 											if (!preg_match("/^#/", $line)) {
-												# CIDR format 192.168.0.0/16
+												// CIDR format 192.168.0.0/16
 												if (preg_match($pfb['cidr'],$line,$matches)) {
 													$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
 												}
-												# Single ip addresses
+												// Single ip addresses
 												elseif (preg_match($pfb['s_html'],$line,$matches)) {
 													$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
 												}
@@ -1700,7 +1700,7 @@ function sync_package_pfblockerng($cron = "") {
 									elseif ($vtype == "_v6") {
 										foreach ($url_list as $line) {
 											if (!preg_match("/^#/", $line)) {
-												# IPv6 Regex Match
+												// IPv6 Regex Match
 												if (preg_match($pfb['ipv6'],$line,$matches)) {
 													$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
 												}
@@ -1711,7 +1711,7 @@ function sync_package_pfblockerng($cron = "") {
 									else {
 										foreach ($url_list as $line) {
 											if (!preg_match("/^#/", $line)) {
-												# Network range 192.168.0.0-192.168.0.254
+												// Network range 192.168.0.0-192.168.0.254
 												if (preg_match($pfb['range'],$line,$matches)) {
 													$a_cidr = ip_range_to_subnet_array_temp2($matches[1],$matches[2]);
 													if (!empty($a_cidr)) {
@@ -1720,11 +1720,11 @@ function sync_package_pfblockerng($cron = "") {
 														}
 													}
 												}
-												# CIDR format 192.168.0.0/16
+												// CIDR format 192.168.0.0/16
 												elseif (preg_match($pfb['cidr'],$line,$matches)) {
 													$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
 												}
-												# Single ip addresses
+												// Single ip addresses
 												elseif (preg_match($pfb['single'],$line,$matches)) {
 													$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
 												}
@@ -1733,14 +1733,14 @@ function sync_package_pfblockerng($cron = "") {
 									}
 								}
 
-								# Check to see if Blocklist actually Failed Download or has no IPs listed.
+								// Check to see if Blocklist actually Failed Download or has no IPs listed.
 								if ($row['format'] == "html" || $row['format'] == "block") {
 									$url_chk = $file_dwn;
 								} else {
 									$url_chk = "{$pfb['origdir']}/{$header_url}.orig";
 								}
 
-								# Check if File Exists and is > 0 in Size
+								// Check if File Exists and is > 0 in Size
 								$file_chk = "";
 								if (file_exists($url_chk) && @filesize($url_chk) > 0) {
 									$file_chk = exec ("/usr/bin/grep -cv '^#\|^$' {$url_chk}");
@@ -1755,42 +1755,42 @@ function sync_package_pfblockerng($cron = "") {
 
 								if ($new_file != "") {
 									if ($row['format'] == "gz" || $row['format'] == "gz_2" || $row['format'] == "html" || $row['format'] == "block") {
-										# Re-Save these formats as original file
+										// Re-Save these formats as original file
 										$url_other = $new_file;
 										@file_put_contents($pfb['origdir'] . '/' . $header_url . '.orig',$url_other, LOCK_EX);
 									}
 
-									# Save List to '.txt' format in appropriate Folder
+									// Save List to '.txt' format in appropriate Folder
 									@file_put_contents($pfbfolder . '/' .$header_url . '.txt',$new_file, LOCK_EX);
 
 									if ($pfb['rep'] == "on" && $pfb['skip'] && $vtype == "_v4") {
-										# Script to Call p24 Process
+										// Script to Call p24 Process
 										exec ("{$pfb['script']} p24 {$header_url} {$pfb['max']} {$pfb['dedup']} {$pfb['ccexclude']} {$pfb['ccwhite']} {$pfb['ccblack']} >> {$pfb['log']} 2>&1");
 									}
 
 									if ($pfb['dup'] == "on" && $pfb['skip'] && $vtype == "_v4") {
-										# Script to call Duplication Check Process
+										// Script to call Duplication Check Process
 										exec ("{$pfb['script']} duplicate {$header_url} >> {$pfb['log']} 2>&1");
 									}
 
-									# PFCTL - Update Only Aliases that have been updated only.
+									// PFCTL - Update Only Aliases that have been updated only.
 									$pfb_alias_lists[] = "{$alias}";
-									# Launch d-dup and p-dup functions when changes are found.
+									// Launch d-dup and p-dup functions when changes are found.
 									if ($pfb['skip'] && $vtype == "_v4") {
 										$pfb['dupcheck'] = TRUE;
 									}
-									# Enable Suppression Process due to Updates
+									// Enable Suppression Process due to Updates
 									if ($pfb['supp'] == "on" && $vtype == "_v4") {
 										$pfb['supp_update'] = TRUE;
 									}
 								} else {
-									# Log FAILED Downloads and Check if Firewall or Snort/Suricata is Blocking Host
+									// Log FAILED Downloads and Check if Firewall or Snort/Suricata is Blocking Host
 									$log = "\n [ {$alias} {$header_url} ] Download FAIL [ NOW ]\n";
 									pfb_logger("{$log}","2");
 
-									# Rebuild Previous List File from contents of Masterfile
+									// Rebuild Previous List File from contents of Masterfile
 									if ($pfb['skip'] && $vtype == "_v4") {
-										# Search with trailing Whitespace to match exact Header in Masterfile
+										// Search with trailing Whitespace to match exact Header in Masterfile
 										$header_url2 = $header_url . "[[:space:]]";
 										$file_chk = exec ("/usr/bin/grep {$header_url2} {$pfb['master']} | grep -c ^");
 
@@ -1800,17 +1800,17 @@ function sync_package_pfblockerng($cron = "") {
 											exec ("/usr/bin/grep {$header_url2} {$pfb['master']} | cut -d' ' -f2 > {$pfbfolder}/{$header_url}.txt");
 										}
 									}
-									# A "Space" string Variable
+									// A "Space" string Variable
 									$sp = " ";
 									$ip = @gethostbyname($host['host']);
 									$ip2 = preg_replace("/(\d{1,3})\.(\d{1,3}).(\d{1,3}).(\d{1,3})/", "\"^$1\.$2\.$3\.\"", $ip);
 
-									# Only Perform these Checks if they are not "localfiles"
+									// Only Perform these Checks if they are not "localfiles"
 									if ($host['host'] == "127.0.0.1" || $host['host'] == $pfb['iplocal'] || empty($host['host'])) {
 										$log = " [ {$alias} {$header_url} ] Local File Failure \n";
 										pfb_logger("{$log}","2");
 									} else {
-										# only perform these steps if an 'IP' is found.
+										// only perform these steps if an 'IP' is found.
 										if (!empty($ip)) {
 											// Query for Exact IP Match
 											$result_b1 = array();
@@ -1821,7 +1821,7 @@ function sync_package_pfblockerng($cron = "") {
 											// Query Snort/Suricata snort2c IP Block Table
 											$snort_pfb = exec("/sbin/pfctl -t snort2c -T show | grep {$ip}");
 
-											# If an exact IP Match is not found report any First Three IP Octets.
+											// If an exact IP Match is not found report any First Three IP Octets.
 											if (!empty($result_b1)) {
 												$final_b1 = implode("\n ", $result_b1);
 												$log = " [ {$alias} {$header_url}, {$ip} ] Firewall IP Block Found in : \n{$sp}{$final_b1}\n";
@@ -1843,12 +1843,12 @@ function sync_package_pfblockerng($cron = "") {
 										}	
 									}
 								}
-								# UNSET variables
+								// UNSET variables
 								unset ($file_gz,$file_zip,$file_et,$file_xlsx,$url_other,$url_list);
 							}
 						}
 					}
-					#check custom network list
+					// check custom network list
 					if (pfbng_text_area_decode($list['custom']) != "") {
 
 						if ($vtype == "_v4") {
@@ -1857,10 +1857,10 @@ function sync_package_pfblockerng($cron = "") {
 							$aliascustom = "{$list['aliasname']}_custom_v6";
 						}
 
-						# Collect Active Alias List (Used for pfctl Update when 'Reputation' is enabled.
+						// Collect Active Alias List (Used for pfctl Update when 'Reputation' is enabled.
 						$pfb_alias_lists_all[] = "{$alias}";
 
-						# Determine 'List' details (return array $pfbarr)
+						// Determine 'List' details (return array $pfbarr)
 						pfb_determine_list_detail($list['action'], $aliascustom, "", "");
 						$pfb['skip']	= $pfbarr['skip'];
 						$pfbfolder	= $pfbarr['folder'];
@@ -1882,7 +1882,7 @@ function sync_package_pfblockerng($cron = "") {
 							if (!empty($url_list)) {
 								foreach ($url_list as $line) {
 									if ($vtype == "_v4") {
-										# Network range 192.168.0.0-192.168.0.254
+										// Network range 192.168.0.0-192.168.0.254
 										if (preg_match($pfb['range'],$line,$matches)) {
 											$a_cidr = ip_range_to_subnet_array_temp2($matches[1],$matches[2]);
 											if (!empty($a_cidr)) {
@@ -1891,16 +1891,16 @@ function sync_package_pfblockerng($cron = "") {
 												}
 											}
 										}
-										# CIDR format 192.168.0.0/16
+										// CIDR format 192.168.0.0/16
 										elseif (preg_match($pfb['cidr'],$line,$matches)) {
 											$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
 										}
-										# Single ip addresses
+										// Single ip addresses
 										elseif (preg_match($pfb['s_html'],$line,$matches)) {
 											$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
 										}
 									} else {
-										# IPv6 Regex
+										// IPv6 Regex
 										if (preg_match($pfb['ipv6'],$line,$matches)) {
 											$new_file .= preg_replace($pfb_ipreg, '',$matches[0]) . "\n";
 										}
@@ -1909,20 +1909,20 @@ function sync_package_pfblockerng($cron = "") {
 
 							}
 							if ($new_file != "") {	
-								# PFCTL - Collect Only Aliases that have been updated only.
+								// PFCTL - Collect Only Aliases that have been updated only.
 								$pfb_alias_lists[] = "{$alias}";
-								# Collect Updated lists for Suppression Process
+								// Collect Updated lists for Suppression Process
 								@file_put_contents($pfbfolder . '/'. $aliascustom . '.txt',$new_file, LOCK_EX);
-								# Enable Suppression Process due to Updates
+								// Enable Suppression Process due to Updates
 								if ($pfb['supp'] == "on" && $vtype == "_v4") {
 									$pfb['supp_update'] = TRUE;
 								}
 								if ($pfb['rep'] == "on" && $pfb['skip'] && $vtype == "_v4") {
-									# Script to Call p24 Process
+									// Script to Call p24 Process
 									exec ("{$pfb['script']} p24 {$aliascustom} {$pfb['max']} {$pfb['dedup']} {$pfb['ccexclude']} {$pfb['ccwhite']} {$pfb['ccblack']} >> {$pfb['log']}  2>&1");
 								}
 								if ($pfb['dup'] == "on" && $pfb['skip'] && $vtype == "_v4") {
-									# Script to call Duplication Check Process
+									// Script to call Duplication Check Process
 									exec ("{$pfb['script']} duplicate {$aliascustom} >> {$pfb['log']} 2>&1");
 								}
 							} else {
@@ -1941,13 +1941,13 @@ function sync_package_pfblockerng($cron = "") {
 	#	REPUTATION PROCESSES	#
 	#################################
 
-	# IP Reputation processes (pdup and ddup)
+	// IP Reputation processes (pdup and ddup)
 	if ($pfb['pdup'] == "on" && $pfb['dupcheck'] && !$pfb['save'] && $pfb['enable'] == "on") {
-		# Script to run pdup process
+		// Script to run pdup process
 		exec ("{$pfb['script']} pdup x {$pfb['pmax']}  >> {$pfb['log']} 2>&1");
 	}
 	if ($pfb['dedup'] == "on" && $pfb['dupcheck'] && !$pfb['save'] && $pfb['enable'] == "on") {
-		# Script to run dedup process
+		// Script to run dedup process
 		exec ("{$pfb['script']} dedup x {$pfb['dmax']} {$pfb['dedup']} {$pfb['ccexclude']} {$pfb['ccwhite']} {$pfb['ccblack']} >> {$pfb['log']} 2>&1");
 	}
 
@@ -1962,7 +1962,7 @@ function sync_package_pfblockerng($cron = "") {
 			foreach ($config['installedpackages'][$ip_type]['config'] as $key => $list) {
 				$alias = "pfB_" . preg_replace("/\W/","",$list['aliasname']);
 
-				# Determine 'List' details (return array $pfbarr)
+				// Determine 'List' details (return array $pfbarr)
 				pfb_determine_list_detail($list['action'], "", $ip_type, $key);
 				$pfb['skip']	= $pfbarr['skip'];
 				$pfb_descr	= $pfbarr['descr'];
@@ -1985,7 +1985,7 @@ function sync_package_pfblockerng($cron = "") {
 				}
 
 				if ($list['action'] != "Disabled") {
-					#remove empty lists files if any
+					// remove empty lists files if any
 					if (is_array($list['row'])) {
 						$update = 0;
 						${$alias} = "";
@@ -1998,20 +1998,20 @@ function sync_package_pfblockerng($cron = "") {
 								}
 								$pfctlck = exec ("/sbin/pfctl -vvsTables | grep -A1 {$alias} | awk '/Addresses/ {s+=$2}; END {print s}'");
 
-								# Update Alias if List File Exists and its been updated or if the Alias URL Table is Empty.
+								// Update Alias if List File Exists and its been updated or if the Alias URL Table is Empty.
 								if (file_exists($pfbfolder . "/" . $header_url . ".txt") && in_array($alias, $final_alias) || file_exists($pfbfolder . "/" . $header_url . ".txt") && empty($pfctlck)) {
-									# Script to run Suppression process (Print Header Only)
+									// Script to run Suppression process (Print Header Only)
 									if ($pfb['supp'] == "on" && $vtype == "_v4" && $runonce == 0 && $pfb['supp_update']) {
 										exec ("{$pfb['script']} suppress x x x suppressheader >> {$pfb['log']} 2>&1");
 										$runonce++;
 									}
-									# Script to run Suppression Process (Body)
+									// Script to run Suppression Process (Body)
 									if ($pfb['supp'] == "on" && $vtype == "_v4" && $pfb['supp_update']) {
 										if ($pfb['dup'] == "on" || !$pfb['skip']) {
-											# Execute if Duplication Process is Enabled or List is Permit or Match
+											// Execute if Duplication Process is Enabled or List is Permit or Match
 											exec ("{$pfb['script']} suppress x x x {$header_url}\|{$pfbfolder}/ >> {$pfb['log']} 2>&1");
 										} else {
-											# Execute if Duplication Process is Disabled
+											// Execute if Duplication Process is Disabled
 											exec ("{$pfb['script']} suppress x x off {$header_url}\|{$pfbfolder}/ >> {$pfb['log']} 2>&1");
 										}
 									}
@@ -2022,14 +2022,14 @@ function sync_package_pfblockerng($cron = "") {
 						}
 					}
 
-					#check custom network list
+					// check custom network list
 					if ($vtype == "_v4") {
 						$aliasname = "{$list['aliasname']}_custom";
 					} else {
 						$aliasname = "{$list['aliasname']}_custom_v6";
 					}
 
-					# Update Alias if List File Exists and its been updated or if the Alias URL Table is Empty.
+					// Update Alias if List File Exists and its been updated or if the Alias URL Table is Empty.
 					$pfctlck = exec ("/sbin/pfctl -vvsTables | grep -A1 {$alias} | awk '/Addresses/ {s+=$2}; END {print s}'");
 
 					if (pfbng_text_area_decode($list['custom']) != "") {
@@ -2038,7 +2038,7 @@ function sync_package_pfblockerng($cron = "") {
 							$update++;
 						}
 					}
-					# Determine Validity of Alias URL Tables/Rules. ie: Don't create Empty URL Tables or Aliases
+					// Determine Validity of Alias URL Tables/Rules. ie: Don't create Empty URL Tables or Aliases
 					if (${$alias} == "" && empty($pfctlck)) {
 						unlink_if_exists($pfb['aliasdir'] . '/' . $alias. '.txt');
 					} else {
@@ -2048,7 +2048,7 @@ function sync_package_pfblockerng($cron = "") {
 						}
 
 						$alias_log = $list['aliaslog'];
-						#create alias
+						// create alias
 						$new_aliases_list[] = "{$alias}";
 
 						$new_aliases[] = array(	"name"		=> "{$alias}",
@@ -2060,7 +2060,7 @@ function sync_package_pfblockerng($cron = "") {
 									"detail"	=> "DO NOT EDIT THIS ALIAS"
 									);
 
-						#Create rule if action permits
+						// Create rule if action permits
 						switch ($list['action']) {
 							case "Deny_Both":
 							case "Deny_Outbound":
@@ -2188,18 +2188,18 @@ function sync_package_pfblockerng($cron = "") {
 								break;
 						}
 					}
-					#mark pfctl aliastable for cleanup
+					// mark pfctl aliastable for cleanup
 					if (!in_array($alias, $aliases_list)) {
 						$aliases_list[] = "{$alias}";
 					}
 				} else {
-					#unlink previous pfblockerNG alias list if any
+					// unlink previous pfblockerNG alias list if any
 					unlink_if_exists($pfb['aliasdir'] . '/' . $alias . '.txt');
 				}
 			}
 		}
 	}
-	# Clear Variables
+	// Clear Variables
 	${$alias} = "";
 
 
@@ -2207,39 +2207,39 @@ function sync_package_pfblockerng($cron = "") {
 	#	UPDATE pfSense ALIAS TABLES	#
 	#########################################
 
-	#update pfsense alias table
+	// update pfsense alias table
 	if (is_array($config['aliases']['alias'])) {
 		foreach ($config['aliases']['alias'] as $cbalias) {
 			if (substr($cbalias['name'], 0, 4) == 'pfB_') {
-				#mark pfctl aliastable for cleaning
+				// mark pfctl aliastable for cleaning
 				if (!in_array($cbalias['name'], $aliases_list)) {
-					$aliases_list[] = $cbalias['name']; #mark aliastable for cleaning
+					$aliases_list[] = $cbalias['name'];	// mark aliastable for cleaning
 				}
-				#remove previous aliastable file if alias is not defined any more
+				// remove previous aliastable file if alias is not defined any more
 				if (!in_array($cbalias['name'], $new_aliases_list)) {
 					unlink_if_exists($pfb['aliasdir'] . '/' . $cbalias['name'] . ".txt");
 				}
 			} else {
 				$new_aliases[] = $cbalias;
 
-				# Check Table Size
+				// Check Table Size
 				if (file_exists($pfb['aliasdir'] . '/' . $alias . '.txt') && $message == "") {
 					preg_match("/(\d+)/",exec("/usr/bin/grep -c ^ " . $pfb['aliasdir'] . '/' . $alias . '.txt'),$matches);
 				}
 				if (($matches[1] * 2.1) >= $pfb['table_limit']) {
-					#alias table too large
+					// alias table too large
 					$message = "{$alias} alias table is too large. Reduce networks in list or increase 'Firewall Maximum Table Entries' value to at least " . (int)($matches[1] * 2.1) . ' in "system - advanced - Firewall/NAT" . ';
 				}
 			}
 		}
 	}
 
-	#apply new alias table to xml
+	// apply new alias table to xml
 	if ($message == "") {
 		$config['aliases']['alias'] = $new_aliases;
 		$pfb['cron_mod'] = TRUE;
 	}
-	# UNSET Variables
+	// UNSET Variables
 	unset($new_aliases, $cbalias);
 
 
@@ -2247,7 +2247,7 @@ function sync_package_pfblockerng($cron = "") {
 	#	Assign Rules	#
 	#########################
 
-	# Only Execute if AutoRules are defined or if an Alias has been removed.
+	// Only Execute if AutoRules are defined or if an Alias has been removed.
 	if ($pfb['autorules'] || $pfb['enable'] == "" || $pfb['remove']) {
 		if (count($deny_inbound) > 0 || count($permit_inbound) > 0 || count($match_inbound) > 0) {
 			if ($pfb['inbound_interfaces'] == "") {
@@ -2269,9 +2269,9 @@ function sync_package_pfblockerng($cron = "") {
 			$fmatch_rules	= array();
 			$fother_rules	= array();
 
-			# Collect All Existing Rules
+			// Collect All Existing Rules
 			$rules = $config['filter']['rule'];
-			# Collect Existing pfSense Rules 'Pass', 'Match' and 'Other' pfSense rules into new Arrays.
+			// Collect Existing pfSense Rules 'Pass', 'Match' and 'Other' pfSense rules into new Arrays.
 			if (!empty($rules)) {
 				foreach ($rules as $rule) {
 					if (!preg_match("/pfB_.*" . $pfb['suffix'] . "/",$rule['descr'])) {
@@ -2345,7 +2345,7 @@ function sync_package_pfblockerng($cron = "") {
 				}
 			}
 
-			# Define Inbound Interface Rules
+			// Define Inbound Interface Rules
 			if (!empty($pfb['inbound_interfaces'])) {
 				$counter = 0;
 				foreach ($pfb['inbound_interfaces'] as $inbound_interface) {
@@ -2361,7 +2361,7 @@ function sync_package_pfblockerng($cron = "") {
 								$new_rules[] = $cb_rules;
 						}
 					}
-					# Match Inbound Rules defined as Floating Only.
+					// Match Inbound Rules defined as Floating Only.
 					if (!empty($match_inbound) && $counter == 0) {
 						foreach ($match_inbound as $cb_rules) {
 							$cb_rules['interface'] = $pfb['inbound_floating'];
@@ -2406,7 +2406,7 @@ function sync_package_pfblockerng($cron = "") {
 				}
 			}
 
-			# Define Outbound Interface Rules
+			// Define Outbound Interface Rules
 			if (!empty($pfb['outbound_interfaces'])) {
 				$counter = 0;
 				foreach ($pfb['outbound_interfaces'] as $outbound_interface) {
@@ -2422,7 +2422,7 @@ function sync_package_pfblockerng($cron = "") {
 								$new_rules[] = $cb_rules;
 						}
 					}
-					# Match Outbound Rules defined as Floating Only.
+					// Match Outbound Rules defined as Floating Only.
 					if (!empty($match_outbound) && $counter == 0) {
 						foreach ($match_outbound as $cb_rules) {
 							$cb_rules['interface'] = $pfb['outbound_floating'];
@@ -2500,7 +2500,7 @@ function sync_package_pfblockerng($cron = "") {
 				}
 			}
 
-			# Save New Rule Order to Config
+			// Save New Rule Order to Config
 			$config['filter']['rule'] = $new_rules;
 		}
 		if (!empty($message)) {
@@ -2508,7 +2508,7 @@ function sync_package_pfblockerng($cron = "") {
 			pfb_logger("{$log}","1");
 		}
 
-		# UNSET arrays 
+		// UNSET arrays 
 		unset ($cb_rules,$permit_inbound,$permit_outbound,$deny_inbound,$deny_outbound,$match_inbound,$match_outbound);
 		unset ($other_rules,$fother_rules,$permit_rules,$fpermit_rules,$match_rules,$fmatch_rules);
 	}
@@ -2522,7 +2522,7 @@ function sync_package_pfblockerng($cron = "") {
 	#	pfSense Integration	#
 	#################################
 
-	# If 'Rule Changes' are found, utilize the 'filter_configure()' function, if not, utilize 'pfctl replace' command
+	// If 'Rule Changes' are found, utilize the 'filter_configure()' function, if not, utilize 'pfctl replace' command
 	if ($pfb['autorules'] && $rules != $new_rules || $pfb['enable'] == "" || $pfb['remove']) {
 		require_once("filter.inc");
 
@@ -2534,20 +2534,20 @@ function sync_package_pfblockerng($cron = "") {
 			pfb_logger("{$log}","1");
 		}
 
-		# Remove all pfBlockerNG Alias tables
+		// Remove all pfBlockerNG Alias tables
 		if (!empty($aliases_list)) {
 			foreach ($aliases_list as $table) {
 				exec ("/sbin/pfctl -t " . escapeshellarg($table) . " -T kill 2>&1", $pfb_null);
 			}
 		}
 
-		#load filter file which will create the pfctl tables
+		// load filter file which will create the pfctl tables
 		filter_configure();
 
 		// Call function for NanoBSD/Ramdisk processes.
 		pfb_aliastables("update");
 	} else {
-		# Don't Execute on User 'Save'
+		// Don't Execute on User 'Save'
 		if (!$pfb['save']) {
 
 			$log = "\n\n===[  Aliastables / Rules  ]================================\n\n";
@@ -2593,10 +2593,10 @@ function sync_package_pfblockerng($cron = "") {
 			}
 		}
 	}
-	# UNSET Variables
+	// UNSET Variables
 	unset($rules, $new_rules);
 
-	#sync config
+	// sync config
 	pfblockerng_sync_on_changes();
 
 
@@ -2604,9 +2604,9 @@ function sync_package_pfblockerng($cron = "") {
 	#	FINAL REPORTING		#
 	#################################
 
-	# Only run with CRON or Force Invoked Process
+	// Only run with CRON or Force Invoked Process
 	if ((!$pfb['save'] && $pfb['dupcheck'] && $pfb['enable'] == "on") || $pfb['summary']) {
-		# Script to run Final Script Processes.
+		// Script to run Final Script Processes.
 		exec ("{$pfb['script']} closing {$pfb['dup']} >> {$pfb['log']} 2>&1");
 	}
 
@@ -2729,10 +2729,10 @@ function pfblockerng_php_install_command() {
 	// Remove previously used CC folder location if exists
 	@rmdir_recursive("{$pfb['dbdir']}/cc");
 
-	# Uncompress Country Code File
+	// Uncompress Country Code File
 	@copy("{$pfb['dbdir']}/countrycodes.tar.bz2", "{$pfb['ccdir']}/countrycodes.tar.bz2");
 	exec("/usr/bin/tar -jx -C {$pfb['ccdif']} -f {$pfb['ccdir']}/countrycodes.tar.bz2");
-	# Download MaxMind Files and Create Country Code files and Build Continent XML Files
+	// Download MaxMind Files and Create Country Code files and Build Continent XML Files
 	update_output_window(gettext("Downloading MaxMind Country Databases. This may take a minute..."));
 	exec("/bin/sh /usr/local/pkg/pfblockerng/geoipupdate.sh all >> {$pfb['geolog']} 2>&1");
 
@@ -2749,7 +2749,7 @@ function pfblockerng_php_install_command() {
 	@unlink_if_exists("{$pfb['dbdir']}/GeoIPv6.csv");
 	@unlink_if_exists("{$pfb['dbdir']}/country_continent.csv");
 
-	# Add Widget to Dashboard
+	// Add Widget to Dashboard
 	update_output_window(gettext("Adding pfBlockerNG Widget to Dashboard."));
 	if ($pfb['keep'] == "on" && !empty($pfb['widgets'])) {
 		// Restore previous Widget setting if "Keep" is enabled.
@@ -2771,16 +2771,16 @@ function pfblockerng_php_deinstall_command() {
 	require_once("config.inc");
 	global $config,$pfb;
 
-	# Set these two variables to Disable pfBlockerNG on De-Install
+	// Set these two variables to Disable pfBlockerNG on De-Install
 	$pfb['save'] = TRUE;
 	$pfb['install'] = TRUE;
 	sync_package_pfblockerng();
 	rmdir_recursive("/usr/local/pkg/pfblockerng");
 	rmdir_recursive("/usr/local/www/pfblockerng");
 
-	# Maintain pfBlockerNG Settings and Database Files if $pfb['keep'] is ON.
+	// Maintain pfBlockerNG Settings and Database Files if $pfb['keep'] is ON.
 	if ($pfb['keep'] != "on") {
-		# Remove pfBlockerNG Log and DB Folder
+		// Remove pfBlockerNG Log and DB Folder
 		rmdir_recursive("{$pfb['dbdir']}");
 		rmdir_recursive("{$pfb['logdir']}");
 
@@ -2793,7 +2793,7 @@ function pfblockerng_php_deinstall_command() {
 			}
 		}
 
-		# Remove Settings from Config
+		// Remove Settings from Config
 		if (is_array($config['installedpackages']['pfblockerng']))
 			unset($config['installedpackages']['pfblockerng']);
 		if (is_array($config['installedpackages']['pfblockerngglobal']))
@@ -2826,7 +2826,7 @@ function pfblockerng_php_deinstall_command() {
 			unset($config['installedpackages']['pfblockerngproxyandsatellite']);
 	}
 
-	# Remove Widget (code from Snort deinstall)
+	// Remove Widget (code from Snort deinstall)
 	$pfb['widgets'] = $config['widgets']['sequence'];
 	if (!empty($pfb['widgets'])) {
 		$widgetlist = explode(",", $pfb['widgets']);

--- a/config/pfblockerng/pfblockerng.php
+++ b/config/pfblockerng/pfblockerng.php
@@ -146,7 +146,7 @@ function ip_range_to_subnet_array_temp($ip1, $ip2) {
 	return $out;
 }
 
-# Set php Memory Limit
+// Set php Memory Limit
 $uname = posix_uname();
 if ($uname['machine'] == "amd64") {
 	ini_set('memory_limit', '256M');
@@ -226,7 +226,7 @@ if ($argv[1] == 'update') {
 }
 
 if ($argv[1] == 'dc') {
-	# (Options - 'bu' Binary Update for Reputation/Alerts Page, 'all' for Country update and 'bu' options.
+	// (Options - 'bu' Binary Update for Reputation/Alerts Page, 'all' for Country update and 'bu' options.
 	if ($pfb['cc'] == "") {
 		exec("/bin/sh /usr/local/pkg/pfblockerng/geoipupdate.sh all >> {$pfb['geolog']} 2>&1");
 	} else {
@@ -275,7 +275,7 @@ if ($argv[1] == 'cron') {
 								$header_url = "{$row['header']}_v6";
 							}
 
-							# Determine Folder Location for Alias (return array $pfbarr)
+							// Determine Folder Location for Alias (return array $pfbarr)
 							pfb_determine_list_detail($list['action'], "", "", "");
 							$pfbfolder = $pfbarr['folder'];
 
@@ -289,7 +289,7 @@ if ($argv[1] == 'cron') {
 								continue;
 							}
 
-							# Check if List file exists, if not found run Update
+							// Check if List file exists, if not found run Update
 							if (!file_exists($pfbfolder . '/' . $header_url . '.txt')) {
 								$log = "  Updates Found\n";
 								pfb_logger("{$log}","1");
@@ -353,7 +353,7 @@ if ($argv[1] == 'cron') {
 		pfb_logger("{$log}","1");
 	}
 
-	# Call Log Mgmt Function
+	// Call Log Mgmt Function
 	// If Update GUI 'Manual view' is selected. Last output will be missed. So sleep for 5 secs.
 	sleep(5);
 	pfb_log_mgmt();
@@ -368,7 +368,7 @@ function pfblockerng_uc_countries() {
 	$maxmind_cc4	= "{$pfb['dbdir']}/GeoIPCountryWhois.csv";
 	$maxmind_cc6	= "{$pfb['dbdir']}/GeoIPv6.csv";
 	
-	# Create Folders if not Exist
+	// Create Folders if not Exist
 	$folder_array = array ("{$pfb['dbdir']}","{$pfb['logdir']}","{$pfb['ccdir']}");
 	foreach ($folder_array as $folder) {
 		safe_mkdir ("{$folder}",0755);
@@ -386,7 +386,7 @@ function pfblockerng_uc_countries() {
 		return;
 	}
 
-	# Save Date/Time Stamp to MaxMind version file
+	// Save Date/Time Stamp to MaxMind version file
 	$maxmind_ver	= "MaxMind GeoLite Date/Time Stamps \n\n";
 	$remote_tds	= @implode(preg_grep("/Last-Modified/", get_headers("http://geolite.maxmind.com/download/geoip/database/GeoIPCountryCSV.zip")));
 	$maxmind_ver	.= "MaxMind_v4 \t" . $remote_tds . "\n";

--- a/config/pfblockerng/pfblockerng.php
+++ b/config/pfblockerng/pfblockerng.php
@@ -668,6 +668,7 @@ $xml = <<<EOF
 	<version>1.0</version>
 	<title>pfBlockerNG: {$cont}</title>
 	<include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
+	<addedit_string>pfBlockerNG: Save {$cont} settings</addedit_string>
 	<menu>
 		<name>pfBlockerNG: {$cont_name}</name>
 		<tooltiptext>Configure pfBlockerNG</tooltiptext>
@@ -1064,6 +1065,7 @@ $xmlrep = <<<EOF
 	<version>1.0</version>
 	<title>pfBlockerNG: IPv4 Reputation</title>
 	<include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
+	<addedit_string>pfBlockerNG: Save Reputation Settings</addedit_string>
 	<menu>
 		<name>pfBlockerNG</name>
 		<tooltiptext>Configure pfblockerNG</tooltiptext>

--- a/config/pfblockerng/pfblockerng.php
+++ b/config/pfblockerng/pfblockerng.php
@@ -148,8 +148,9 @@ function ip_range_to_subnet_array_temp($ip1, $ip2) {
 
 # Set php Memory Limit
 $uname = posix_uname();
-if ($uname['machine'] == "amd64")
+if ($uname['machine'] == "amd64") {
 	ini_set('memory_limit', '256M');
+}
 
 function pfb_update_check($header_url, $list_url, $url_format, $pfbfolder) {
 	global $pfb;
@@ -220,7 +221,6 @@ function pfb_update_check($header_url, $list_url, $url_format, $pfbfolder) {
 	}
 }
 
-
 if ($argv[1] == 'update') {
 	sync_package_pfblockerng("cron");
 }
@@ -251,85 +251,13 @@ if ($argv[1] == 'gc') {
 }
 
 if ($argv[1] == 'cron') {
+
+	// Call Base Hour converter
+	$pfb_sch = pfb_cron_base_hour();
+
 	$hour = date('G');
 	$dow  = date('N');
 	$pfb['update_cron'] = FALSE;
-
-	# Start hour of the 'Once a day' Schedule
-	$pfb['dailystart'] = $config['installedpackages']['pfblockerng']['config'][0]['pfb_dailystart'];
-	# Start hour of the Scheduler
-	if ($config['installedpackages']['pfblockerng']['config'][0]['pfb_hour'] != "") {
-		$pfb['hour'] = $config['installedpackages']['pfblockerng']['config'][0]['pfb_hour'];
-	} else {
-		$pfb['hour'] = "1";
-	}
-	$updates = 0;
-
-	# 2 Hour Schedule Converter
-	$shour = intval(substr($pfb['hour'], 0, 2));
-	$sch2 = strval($shour);
-	for ($i=0; $i<11; $i++) {
-		$shour += 2;
-		if ($shour >= 24)
-			$shour -= 24;
-		$sch2 .= "," . strval($shour);
-	}
-
-	# 3 Hour Schedule Converter
-	$shour = intval(substr($pfb['hour'], 0, 2));
-	$sch3 = strval($shour);
-	for ($i=0; $i<7; $i++) {
-		$shour += 3;
-		if ($shour >= 24)
-			$shour -= 24;
-		$sch3 .= "," . strval($shour);
-	}
-
-	# 4 Hour Schedule Converter
-	$shour = intval(substr($pfb['hour'], 0, 2));
-	$sch4 = strval($shour);
-	for ($i=0; $i<5; $i++) {
-		$shour += 4;
-		if ($shour >= 24)
-			$shour -= 24;
-		$sch4 .= "," . strval($shour);
-	}
-
-	# 6 Hour Schedule Converter
-	$shour = intval(substr($pfb['hour'], 0, 2));
-	$sch6 = strval($shour);
-	for ($i=0; $i<3; $i++) {
-		$shour += 6;
-		if ($shour >= 24)
-			$shour -= 24;
-		$sch6 .= "," . strval($shour);
-	}
-
-	# 8 Hour Schedule Converter
-	$shour = intval(substr($pfb['hour'], 0, 2));
-	$sch8 = strval($shour);
-	for ($i=0; $i<2; $i++) {
-		$shour += 8;
-		if ($shour >= 24)
-			$shour -= 24;
-		$sch8 .= "," . strval($shour);
-	}
-
-	# 12 Hour Schedule Converter
-	$shour = intval(substr($pfb['hour'], 0, 2));
-	$sch12 = strval($shour) . ",";
-	$shour += 12;
-	if ($shour >= 24)
-		$shour -= 24;
-	$sch12 .= strval($shour);
-
-	$e_sch2  = explode(",", $sch2);
-	$e_sch3  = explode(",", $sch3);
-	$e_sch4  = explode(",", $sch4);
-	$e_sch6  = explode(",", $sch6);
-	$e_sch8  = explode(",", $sch8);
-	$e_sch12 = explode(",", $sch12);
-
 	$log = " CRON  PROCESS  START [ NOW ]\n";
 	pfb_logger("{$log}","1");
 
@@ -348,7 +276,7 @@ if ($argv[1] == 'cron') {
 							}
 
 							# Determine Folder Location for Alias (return array $pfbarr)
-							pfb_determine_list_detail($list['action']);
+							pfb_determine_list_detail($list['action'], "", "", "");
 							$pfbfolder = $pfbarr['folder'];
 
 							$list_cron = $list['cron'];
@@ -370,46 +298,48 @@ if ($argv[1] == 'cron') {
 							}
 
 							switch ($list_cron) {
-								case "01hour":
-									pfb_update_check($header_url, $list_url, $url_format, $pfbfolder);
-									break;
-								case "02hours":
-									if (in_array($hour, $e_sch2))
-										pfb_update_check($header_url, $list_url, $url_format, $pfbfolder);
-									break;
-								case "03hours":
-									if (in_array($hour, $e_sch3))
-										pfb_update_check($header_url, $list_url, $url_format, $pfbfolder);
-									break;
-								case "04hours":
-									if (in_array($hour, $e_sch4))
-										pfb_update_check($header_url, $list_url, $url_format, $pfbfolder);
-									break;
-								case "06hours":
-									if (in_array($hour, $e_sch6))
-										pfb_update_check($header_url, $list_url, $url_format, $pfbfolder);
-									break;
-								case "08hours":
-									if (in_array($hour, $e_sch8))
-										pfb_update_check($header_url, $list_url, $url_format, $pfbfolder);
-									break;
-								case "12hours":
-									if (in_array($hour, $e_sch12))
-										pfb_update_check($header_url, $list_url, $url_format, $pfbfolder);
-									break;
 								case "EveryDay":
-									if ($hour == $pfb['dailystart'])
+									if ($hour == $pfb['24hour']) {
 										pfb_update_check($header_url, $list_url, $url_format, $pfbfolder);
+									}
 									break;
 								case "Weekly":
-									if ($hour == $pfb['dailystart'] && $dow == $header_dow)
+									if ($hour == $pfb['24hour'] && $dow == $header_dow) {
 										pfb_update_check($header_url, $list_url, $url_format, $pfbfolder);
+									}
 									break;
 								default:
+									if ($pfb['interval'] == "1" || in_array($hour, $pfb_sch)) {
+										pfb_update_check($header_url, $list_url, $url_format, $pfbfolder);
+									}
 									break;
 							}
 						}
 					}
+				}
+			}
+		}
+	}
+
+	// If Continents are Defined, continue with Update Process to determine if further changes are required.
+	$continents = array (	"Africa"		=> "pfB_Africa",
+				"Antartica"		=> "pfB_Antartica",
+				"Asia"			=> "pfB_Asia",
+				"Europe"		=> "pfB_Europe",
+				"North America"		=> "pfB_NAmerica",
+				"Oceania"		=> "pfB_Oceania",
+				"South America"		=> "pfB_SAmerica",
+				"Top Spammers"		=> "pfB_Top",
+				"Proxy and Satellite"	=> "pfB_PS"
+				);
+
+	if (!$pfb['update_cron']) {
+		foreach ($continents as $continent => $pfb_alias) {
+			if (is_array($config['installedpackages']['pfblockerng' . strtolower(preg_replace('/ /','',$continent))]['config'])) {
+				$continent_config = $config['installedpackages']['pfblockerng' . strtolower(preg_replace('/ /','',$continent))]['config'][0];
+				if ($continent_config['action'] != "Disabled" && $pfb['enable'] == "on") {
+					$pfb['update_cron'] = TRUE;
+					break;
 				}
 			}
 		}
@@ -824,44 +754,57 @@ $xml = <<<EOF
 		</field>
 		<field>
 			<fielddescr>LINKS</fielddescr>
-			<fieldname></fieldname>
-			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp; <a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
+			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp;
+				<a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
 			</description>
 			<type>info</type>
 		</field>
-		<field>	
-			<fielddescr><![CDATA[<br /><strong>IPv4</strong><br />Countries]]></fielddescr>
+		<field>
 			<fieldname>countries4</fieldname>
-			<description>
-			<![CDATA[Select IPv4 Countries you want to take an action on.<br />
-				<strong>Use CTRL + CLICK to unselect countries</strong>]]>
-			</description>
+			<fielddescr><![CDATA[<strong><center>Countries</center></strong><br />
+				<center>Use CTRL + CLICK to unselect countries</center>]]>
+			</fielddescr>
 			<type>select</type>
 			<options>
 			${'options4'}
 			</options>
 			<size>${'ftotal4'}</size>
 			<multiple/>
+
+EOF;
+
+// Adjust combinefields variable if IPv6 is empty.
+if (!empty (${'options6'})) {
+	$xml .= <<<EOF
+			<description><![CDATA[<center><br />IPv4 Countries</center>]]></description>
+			<usecolspan2/>
+			<combinefields>begin</combinefields>
 		</field>
 
 EOF;
+} else {
+	$xml .= <<<EOF
+			<description><![CDATA[<br />IPv4 Countries]]></description>
+		</field>
+
+EOF;
+}
 
 // Skip IPv6 when Null data found
 if (!empty (${'options6'})) {
 	$xml .= <<<EOF
 		<field>
-			<fielddescr><![CDATA[<br /><strong>IPv6</strong><br />Countries]]></fielddescr>
 			<fieldname>countries6</fieldname>
-			<description>
-			<![CDATA[Select IPv6 Countries you want to take an action on.<br />
-				<strong>Use CTRL + CLICK to unselect countries</strong>]]>
-			</description>
+			<description><![CDATA[<br /><center>IPv6 Countries</center>]]></description>
 			<type>select</type>
 			<options>
 			${'options6'}
 			</options>
 			<size>${'ftotal6'}</size>
 			<multiple/>
+			<usecolspan2/>
+			<dontdisplayname/>
+			<combinefields>end</combinefields>
 		</field>
 
 EOF;
@@ -870,7 +813,7 @@ EOF;
 $xml .= <<<EOF
 		<field>
 			<fielddescr>List Action</fielddescr>
-			<description><![CDATA[<br />Default : <strong>Disabled</strong><br /><br />
+			<description><![CDATA[<br />Default: <strong>Disabled</strong><br /><br />
 				Select the <strong>Action</strong> for Firewall Rules on lists you have selected.<br /><br />
 				<strong><u>'Disabled' Rules:</u></strong> Disables selection and does nothing to selected Alias.<br /><br />
 
@@ -901,7 +844,7 @@ $xml .= <<<EOF
 				<li>'Alias Permit' and 'Alias Match' will be saved in the Same folder as the other Permit/Match Auto-Rules</li><br />
 				<li>'Alias Native' lists are kept in their Native format without any modifications.</li></ul>
 				<strong>When using 'Alias' rules, change (pfB_) to ( pfb_ ) in the beginning of rule description and use the 'Exact' spelling of
-				the Alias (no trailing Whitespace)&nbsp;</strong> Custom 'Alias' rules with 'pfB_  xxx' description will be removed by package if
+				the Alias (no trailing Whitespace)</strong> Custom 'Alias' rules with 'pfB_  xxx' description will be removed by package if
 				using Auto Rule Creation.<br /><br /><strong>Tip</strong>: You can create the Auto Rules and remove "<u>auto rule</u>" from the Rule
 				Descriptions, then disable Auto Rules. This method will 'KEEP' these rules from being 'Deleted' which will allow editing for a Custom
 				Alias Configuration<br />]]>
@@ -928,9 +871,10 @@ $xml .= <<<EOF
 		<field>
 			<fielddescr>Enable Logging</fielddescr>
 			<fieldname>aliaslog</fieldname>
-			<description><![CDATA[Default:<strong>Enable</strong><br />
+			<description><![CDATA[Default: <strong>Enable</strong><br />
 				Select - Logging to Status: System Logs: FIREWALL ( Log )<br />
-				This can be overriden by the 'Global Logging' Option in the General Tab.]]></description>
+				This can be overriden by the 'Global Logging' Option in the General Tab.]]>
+			</description>
 			<type>select</type>
 			<options>
 				<option><name>Enable</name><value>enabled</value></option>
@@ -938,9 +882,87 @@ $xml .= <<<EOF
 			</options>
 		</field>
 		<field>
-			<name><![CDATA[<ul>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Changes are Applied via CRON or
-				'Force Update'</ul>]]>
-			</name>
+			<name>Advanced Inbound Firewall Rule Settings</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<type>info</type>
+			<description><![CDATA[<font color='red'>Note: </font>In general Auto-Rules are created as follows:<br />
+				<ul>Inbound &nbsp;&nbsp;- 'any' port, 'any' protocol and 'any' destination<br />
+				Outbound - 'any' port, 'any' protocol and 'any' destination address in the lists</ul>
+				Configuring the Adv. Inbound Rule settings, will allow for more customization of the Inbound Auto-Rules.<br />
+				<strong>Select the pfSense 'Port' and/or 'Destination' Alias below:</strong>]]>
+			</description>
+		</field>
+		<field>
+			<fieldname>autoports</fieldname>
+			<fielddescr>Enable Custom Port</fielddescr>
+			<type>checkbox</type>
+			<enablefields>aliasports</enablefields>
+			<usecolspan2/>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
+			<fielddescr>Define Alias</fielddescr>
+			<fieldname>aliasports</fieldname>
+			<description><![CDATA[<a href="/firewall_aliases.php?tab=port">Click Here to add/edit Aliases</a>
+				Do not manually enter port numbers. <br />Do not use 'pfB_' in the Port Alias name.]]>
+			</description>
+			<size>21</size>
+			<type>aliases</type>
+			<typealiases>port</typealiases>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields>end</combinefields>
+		</field>
+		<field>
+			<fieldname>autodest</fieldname>
+			<fielddescr>Enable Custom Destination</fielddescr>
+			<type>checkbox</type>
+			<enablefields>aliasdest,autonot</enablefields>
+			<usecolspan2/>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
+			<fieldname>aliasdest</fieldname>
+			<description><![CDATA[<a href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>
+				Do not manually enter Addresses(es). <br />Do not use 'pfB_' in the 'IP Network Type' Alias name.]]>
+			</description>
+			<size>21</size>
+			<type>aliases</type>
+			<typealiases>network</typealiases>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields/>
+		</field>
+		<field>
+			<fielddescr>Invert</fielddescr>
+			<fieldname>autonot</fieldname>
+			<description><![CDATA[<div style="padding-left: 22px;"><strong>Invert</strong> - Option to invert the sense of the match.<br />
+				ie - Not (!) Destination Address(es)</div>]]>
+			</description>
+			<type>checkbox</type>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields>end</combinefields>
+		</field>
+		<field>
+			<fielddescr>Custom Protocol</fielddescr>
+			<fieldname>autoproto</fieldname>
+			<description><![CDATA[<strong>Default: any</strong><br />Select the Protocol used for Inbound Firewall Rule(s).]]></description>
+			<type>select</type>
+			<options>
+				<option><name>any</name><value></value></option>
+				<option><name>TCP</name><value>tcp</value></option>
+				<option><name>UDP</name><value>udp</value></option>
+				<option><name>TCP/UDP</name><value>tcp/udp</value></option>
+			</options>
+			<size>4</size>
+			<default_value></default_value>
+		</field>
+		<field>
+			<name><![CDATA[<center>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
+				'Force Update'</center>]]></name>
 			<type>listtopic</type>
 		</field>
 	</fields>
@@ -1122,14 +1144,13 @@ $xmlrep = <<<EOF
 		</field>
 		<field>
 			<fielddescr>LINKS</fielddescr>
-			<fieldname></fieldname>
-			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp; <a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
+			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp;
+				<a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
 			</description>
 			<type>info</type>
 		</field>
 		<field>
 			<fielddescr><![CDATA[<strong>Why Reputation Matters:</strong>]]></fielddescr>
-			<fieldname></fieldname>
 			<type>info</type>
 			<description><![CDATA[By Enabling '<strong>Reputation</strong>', each Blocklist will be analyzed for Repeat Offenders in each IP Range.
 				<ul>Example: &nbsp;&nbsp; x.x.x.1, x.x.x.2, x.x.x.3, x.x.x.4, x.x.x.5<br />
@@ -1150,7 +1171,6 @@ $xmlrep = <<<EOF
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fieldname></fieldname>
 			<fielddescr><![CDATA[<br /><strong>Individual List Reputation</strong><br /><br />]]></fielddescr>
 			<type>info</type>
 			<description></description>
@@ -1177,13 +1197,11 @@ $xmlrep = <<<EOF
 			</options>
 		</field>
 		<field>
-			<fieldname></fieldname>
 			<fielddescr><![CDATA[<br /><strong>Collective List Reputation</strong><br /><br />]]></fielddescr>
 			<type>info</type>
 			<description></description>
 		</field>
 		<field>
-			<fieldname></fieldname>
 			<type>info</type>
 			<description><![CDATA[Once all Blocklists are Downloaded, these two 'additional' processes <strong>[ pMax ] and [ dMax ]</strong><br />
 				Can be used to Further analyze for Repeat Offenders.<br />
@@ -1244,7 +1262,6 @@ $xmlrep = <<<EOF
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fieldname>INFO</fieldname>
 			<type>info</type>
 			<description><![CDATA[When performing Queries for Repeat Offenders, you can choose to <strong>ignore</strong> Repeat Offenders in select
 				Countries. The Original Blocklisted IPs remain intact. All other Repeat Offending Country Ranges will be processed.<br /><br />
@@ -1286,7 +1303,7 @@ $xmlrep = <<<EOF
 		</field>
 		<field>
 			<fielddescr><![CDATA[<br /><strong>IPv4</strong><br />Country Exclusion<br />
-				<br />Geolite Data by:<br />MaxMind Inc.&nbsp;&nbsp;(ISO 3166)]]></fielddescr>
+				<br />Geolite Data by: <br />MaxMind Inc.&nbsp;&nbsp;(ISO 3166)]]></fielddescr>
 			<fieldname>ccexclude</fieldname>
 			<description>
 				<![CDATA[Select Countries you want to <strong>Exclude</strong> from the Reputation Process.<br />
@@ -1305,7 +1322,6 @@ $xmlrep = <<<EOF
 		</field>
 		<field>
 			<fielddescr>Subscription Pro. Blocklist</fielddescr>
-			<fieldname>ETINFO</fieldname>
 			<type>info</type>
 			<description><![CDATA[<strong>Emerging Threats IQRisk</strong> is a Subscription Professional Reputation List.<br /><br />
 					ET IQRisk Blocklist must be entered in the Lists Tab using the following example:
@@ -1429,7 +1445,7 @@ $xmlrep = <<<EOF
 		<field>
 			<fielddescr>Update ET Categories</fielddescr>
 			<fieldname>et_update</fieldname>
-			<description><![CDATA[Default:<strong>Disable</strong><br />
+			<description><![CDATA[Default: <strong>Disable</strong><br />
 				Select - Enable ET Update if Category Changes are Made.<br />
 				You can perform a 'Force Update' to enable these changes.<br />
 				Cron will also resync this list at the next Scheduled Update.]]>
@@ -1441,8 +1457,8 @@ $xmlrep = <<<EOF
 			</options>
 		</field>
 		<field>
-			<name><![CDATA[<ul>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
-				'Force Update'</ul>]]></name>
+			<name><![CDATA[<center>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
+				'Force Update'</center>]]></name>
 			<type>listtopic</type>
 		</field>
 	</fields>

--- a/config/pfblockerng/pfblockerng.priv.inc
+++ b/config/pfblockerng/pfblockerng.priv.inc
@@ -8,8 +8,6 @@ $priv_list['page-firewall-pfblockerng']['descr'] = "Allow access to pfBlockerNG 
 $priv_list['page-firewall-pfblockerng']['match'] = array();
 $priv_list['page-firewall-pfblockerng']['match'][] = "pkg_edit.php?xml=pfblockerng.xml*";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pkg_edit.php?xml=pfblockerng/pfblockerng_reputation.xml*";
-$priv_list['page-firewall-pfblockerng']['match'][] = "pkg_edit.php?xml=pfblockerng/pfblockerng_v4lists.xml*";
-$priv_list['page-firewall-pfblockerng']['match'][] = "pkg_edit.php?xml=pfblockerng/pfblockerng_v6lists.xml*";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pkg_edit.php?xml=pfblockerng/pfblockerng_top20.xml*";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pkg_edit.php?xml=pfblockerng/pfblockerng_Africa.xml*";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pkg_edit.php?xml=pfblockerng/pfblockerng_Asia.xml*";
@@ -19,6 +17,10 @@ $priv_list['page-firewall-pfblockerng']['match'][] = "pkg_edit.php?xml=pfblocker
 $priv_list['page-firewall-pfblockerng']['match'][] = "pkg_edit.php?xml=pfblockerng/pfblockerng_SouthAmerica.xml*";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pkg_edit.php?xml=pfblockerng/pfblockerng_ProxyandSatellite.xml*";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pkg_edit.php?xml=pfblockerng/pfblockerng_sync.xml*";
+
+$priv_list['page-firewall-pfblockerng']['match'][] = "pkg.php?xml=pfblockerng/pfblockerng_v4lists.xml*";
+$priv_list['page-firewall-pfblockerng']['match'][] = "pkg.php?xml=pfblockerng/pfblockerng_v6lists.xml*";
+
 $priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/pfblockerng_update.php*";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/pfblockerng_alerts.php*";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/pfblockerng_log.php*";

--- a/config/pfblockerng/pfblockerng.sh
+++ b/config/pfblockerng/pfblockerng.sh
@@ -723,7 +723,7 @@ if [ -s $pfborig$alias".gz" ]; then
 		esac
 	done <"$pfborig$alias.raw"
 	data=$(ls $etdir)
-	echo "Compiling ET IP IQRisk REP Lists based upon User Selected Categories"
+	echo; echo "Compiling ET IP IQRisk REP Lists based upon User Selected Categories"
 	printf "%-10s %-25s\n" "  Action" "Category"
 	echo "-------------------------------------------"
 

--- a/config/pfblockerng/pfblockerng.sh
+++ b/config/pfblockerng/pfblockerng.sh
@@ -24,7 +24,7 @@ fi
 
 now=$(/bin/date +%m/%d/%y' '%T)
 
-# Application Paths
+# Application Locations
 pathgrepcidr="${prefix}/bin/grepcidr"
 pathgeoip="${prefix}/bin/geoiplookup"
 
@@ -165,7 +165,7 @@ fi
 if [ -s "$matchfile" -a ! "$dedup" == "on" -a "$ccwhite" == "match" ]; then
 	mon=$(sed -e 's/^/^/' -e 's/\./\\\./g' $matchfile)
 	for ip in $mon; do
-	grep $ip $tempfile >> $tempfile2
+		grep $ip $tempfile >> $tempfile2
 	done
 	mcount=$(grep -c ^ $tempfile2)
 	if [ "$ccwhite" == "match" ]; then
@@ -372,7 +372,7 @@ if [ -e "$pfbsuppression" ] && [ -s "$pfbsuppression" ]; then
 	fi
 else
 	if [ "$cc" == "suppressheader" ]; then
-		echo "===[ Suppression Stats ]========================================"; echo
+		echo; echo "===[ Suppression Stats ]========================================"; echo
 		printf "%-20s %-10s %-10s %-10s %-10s\n" "List" "Pre" "RFC1918" "Suppress" "Masterfile"
 		echo "----------------------------------------------------------------"
 		exitnow
@@ -675,7 +675,6 @@ if [ -s $pfborig$alias".gz" ]; then
 	$pathgunzip -c $pfborig$alias".gz" > $pfborig$alias".raw"
 
 	# ET CSV Format (IP, Category, Score)
-	echo; echo "Processing [ $alias ]"
 	while IFS="," read a b c; do
 		# Some ET Categories are not in use (For Future Use)
 		case "$b" in
@@ -795,7 +794,7 @@ if [ "$alias" == "on" ]; then
 	sort -o $masterfile $masterfile
 	sort -t . -k 1,1n -k 2,2n -k 3,3n -k 4,4n $mastercat > $tempfile; mv -f $tempfile $mastercat
 
-	echo; echo; echo "===[ FINAL Processing ]====================================="; echo
+	echo; echo "===[ FINAL Processing ]====================================="; echo
 	echo "   [ Original count   ]  [ $fcount ]"
 	count=$(grep -c ^ $masterfile)
 	echo; echo "   [ Processed Count  ]  [ $count ]"; echo

--- a/config/pfblockerng/pfblockerng.widget.php
+++ b/config/pfblockerng/pfblockerng.widget.php
@@ -15,7 +15,7 @@
 	snort_alerts.widget.php
 	Copyright (C) 2009 Jim Pingle
 	mod 24-07-2012
-	mod 28-02-2014 by Bill Meeks
+	mod 28-02-2015 by Bill Meeks
 
 	Javascript and Integration modifications by J. Nieuwenhuizen
 
@@ -42,58 +42,268 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
+$nocsrf = true;
 @require_once("/usr/local/www/widgets/include/widget-pfblockerng.inc");
 @require_once("/usr/local/pkg/pfblockerng/pfblockerng.inc");
 @require_once("guiconfig.inc");
-@require_once("globals.inc");
-@require_once("pfsense-utils.inc");
-@require_once("functions.inc");
 
 pfb_global();
 
-// Ackwnowlege Failed Downloads
-if (isset($_POST['pfblockerngack'])) {
-	$clear = exec("/usr/bin/sed -i '' 's/FAIL/Fail/g' {$pfb['errlog']}");
+// Image source definition
+$pfb['down']	= "<img src ='/themes/{$g['theme']}/images/icons/icon_interface_down.gif' title='No Rules are Defined using this Alias' alt='' />";
+$pfb['up']	= "<img src ='/themes/{$g['theme']}/images/icons/icon_interface_up.gif' title='Rules are Defined using this Alias (# of fw rules defined)' alt='' />";
+$pfb['err']	= "<img src ='/themes/{$g['theme']}/images/icons/icon_wzd_nsaved.png' title='pf Errors found.' alt='' />";
+
+// Alternating line shading
+$pfb['RowOddClass']	= "style='background-color: #FFFFFF;'";
+$pfb['RowEvenClass']	= "style='background-color: #F0F0F0;'";
+$pfb['RowEvenClass2']	= "style='background-color: #D0D0D0;'";
+$pfb['ColClass']	= "listMRr";
+
+$pfb['global'] = &$config['installedpackages']['pfblockerngglobal'];
+
+// Define default widget customizations
+if (!isset($pfb['global']['widget-maxfails'])) {
+	$pfb['global']['widget-maxfails']	= '3';
+}
+if (!isset($pfb['global']['widget-maxpivot'])) {
+	$pfb['global']['widget-maxpivot']	= '200';
+}
+if (!isset($pfb['global']['widget-sortcolumn'])) {
+	$pfb['global']['widget-sortcolumn']	= 'none'; 
+}
+if (!isset($pfb['global']['widget-sortdir'])) {
+	$pfb['global']['widget-sortdir']	= 'asc';
+}
+if (!isset($pfb['global']['widget-popup'])) {
+	$pfb['global']['widget-popup']		= 'on';
+}
+
+// Collect variables
+if (is_array($pfb['global'])) {
+	$pfb['maxfails']	= $pfb['global']['widget-maxfails'];
+	$pfb['maxpivot']	= $pfb['global']['widget-maxpivot'];
+	$pfb['sortcolumn']	= $pfb['global']['widget-sortcolumn'];
+	$pfb['sortdir']		= $pfb['global']['widget-sortdir'];
+	$pfb['popup']		= $pfb['global']['widget-popup'];
+}
+
+// Save widget customizations
+if ($_POST) {
+	if (is_numeric($_POST['pfb_maxfails'])) {
+		$pfb['global']['widget-maxfails']	= $_POST['pfb_maxfails'];
+	}
+	if (is_numeric($_POST['pfb_maxpivot'])) {
+		$pfb['global']['widget-maxpivot']	= $_POST['pfb_maxpivot'];
+	}
+	if (!empty($_POST['pfb_popup'])) {
+		$pfb['global']['widget-popup']		= $_POST['pfb_popup'];
+	}
+	if (!empty($_POST['pfb_sortcolumn'])) {
+		$pfb['global']['widget-sortcolumn']	= $_POST['pfb_sortcolumn'];
+	}
+	if (!empty($_POST['pfb_sortdir'])) {
+		$pfb['global']['widget-sortdir']	= $_POST['pfb_sortdir'];
+	}
+	write_config("pfBlockerNG: Saved Widget customizations via Dashboard");
 	header("Location: ../../index.php");
 }
 
-// This function will create the counts
-function pfBlockerNG_get_counts() {
-	global $config, $g, $pfb;
+// Ackwnowlege failed downloads
+if (isset($_POST['pfblockerngack'])) {
+	exec("/usr/bin/sed -i '' 's/FAIL/Fail/g' {$pfb['errlog']}");
+	header("Location: ../../index.php");
+}
 
-	// Collect Alias Count and Update Date/Time
+// Called by Ajax to update table contents
+if (isset($_GET['getNewCounts'])) {
+	pfBlockerNG_get_table("js");
+	return;
+}
+
+// Sort widget table according to user configuration
+function pfbsort(&$array, $subkey="id", $sort_ascending=FALSE) {
+	if (empty($array)) {
+		return;
+	}
+	if (count($array)) {
+		$temp_array[key($array)] = array_shift($array);
+	}
+
+	foreach ($array as $key => $val) {
+		$offset = 0;
+		$found = FALSE;
+		foreach ($temp_array as $tmp_key => $tmp_val) {
+			if (!$found and strtolower($val[$subkey]) > strtolower($tmp_val[$subkey])) {
+				$temp_array = array_merge((array)array_slice($temp_array,0,$offset), array($key => $val), array_slice($temp_array,$offset));
+				$found = TRUE;
+			}
+			$offset++;
+		}
+		if (!$found) {
+			$temp_array = array_merge($temp_array, array($key => $val));
+		}
+	}
+
+	if ($sort_ascending) {
+		$array = array_reverse($temp_array);
+	} else {
+		$array = $temp_array;
+	}
+	return;
+}
+
+// Collect all pfBlockerNG statistics
+function pfBlockerNG_get_counts() {
+	global $config, $pfb;
 	$pfb_table = array();
-	$out = "<img src ='/themes/{$g['theme']}/images/icons/icon_interface_down.gif' title=\"No Rules are Defined using this Alias\" alt=\"\" />";
-	$in = "<img src ='/themes/{$g['theme']}/images/icons/icon_interface_up.gif' title=\"Rules are Defined using this Alias\" alt=\"\" />";
-	if (is_array($config['aliases']['alias'])) {
-		foreach ($config['aliases']['alias'] as $cbalias) {
-			if (preg_match("/pfB_/", $cbalias['name'])) {
-				if (file_exists("{$pfb['aliasdir']}/{$cbalias['name']}.txt")) {	
-					preg_match("/(\d+)/", exec("/usr/bin/grep -cv \"^1\.1\.1\.1\" {$pfb['aliasdir']}/{$cbalias['name']}.txt"), $matches);
-					$pfb_table[$cbalias['name']] = array("count" => $matches[1], "img" => $out);
-					$updates = exec("ls -ld {$pfb['aliasdir']}/{$cbalias['name']}.txt | awk '{ print $6,$7,$8 }'", $update);
-					$pfb_table[$cbalias['name']]['up'] = $updates;
+
+	/* Alias Table Definitions -	'update'	- Last Updated Timestamp
+					'rule'		- Total number of Firewall rules per alias
+					'count'		- Total Line Count per alias
+					'packets'	- Total number of pf packets per alias */
+
+	exec("/sbin/pfctl -vvsTables | grep -A4 'pfB_'", $pfb_pfctl);
+	if (!empty($pfb_pfctl)) {
+		foreach($pfb_pfctl as $line) {
+			$line = trim(str_replace(array( '[', ']' ), '', $line));
+			if (substr($line, 0, 1) == '-') {
+				$pfb_alias = trim(strstr($line, 'pfB', FALSE));
+				if (empty($pfb_alias)) {
+					unset($pfb_alias);
+					continue;
+				}
+				exec("/usr/bin/grep -cv '^1\.1\.1\.1' {$pfb['aliasdir']}/{$pfb_alias}.txt", $match);
+				$pfb_table[$pfb_alias] = array('count' => $match[1], 'img' => $pfb['down']);
+				exec("ls -ld {$pfb['aliasdir']}/{$pfb_alias}.txt | awk '{ print $6,$7,$8 }'", $update);
+				$pfb_table[$pfb_alias]['update'] = $update[0];
+				$pfb_table[$pfb_alias]['rule'] = 0;
+				unset($match, $update);
+				continue;
+			}
+
+			if (isset($pfb_alias)) {
+				if (substr($line, 0, 9) == 'Addresses') {
+					$addr = trim(substr(strrchr($line, ':'), 1));
+					$pfb_table[$pfb_alias]['count'] = $addr;
+					continue;
+				}
+				if (substr($line, 0, 11) == 'Evaluations') {
+					$packets = trim(substr(strrchr($line, ':'), 1));
+					$pfb_table[$pfb_alias]['packets'] = $packets;
+					unset($pfb_alias);
 				}
 			}
 		}
 	}
+	else {
+		// Error. No pf labels found.
+		$pfb['pfctl'] = TRUE;
+	}
 
-	// Collect if Rules are defined using pfBlockerNG Aliases.
+	// Determine if firewall rules are defined
 	if (is_array($config['filter']['rule'])) {
 		foreach ($config['filter']['rule'] as $rule) {
-			if (preg_match("/pfB_/",$rule['source']['address']) || preg_match("/pfb_/",$rule['source']['address'])) {
-				$pfb_table[$rule['source']['address']]['img'] = $in;
+			// Skip disabled rules
+			if (isset($rule['disabled'])) {
+				continue;
 			}
-			if (preg_match("/pfB_/",$rule['destination']['address']) || preg_match("/pfb_/",$rule['destination']['address'])) {
-				$pfb_table[$rule['destination']['address']]['img'] = $in;
+			if (stripos($rule['source']['address'], "pfb_") !== FALSE) {
+				$pfb_table[$rule['source']['address']]['img'] = $pfb['up'];
+				$pfb_table[$rule['source']['address']]['rule'] += 1;
+			}
+			if (stripos($rule['destination']['address'], "pfb_") !== FALSE) {
+				$pfb_table[$rule['destination']['address']]['img'] = $pfb['up'];
+				$pfb_table[$rule['destination']['address']]['rule'] += 1;
 			}
 		}
-		return $pfb_table;
+	}
+
+	// Collect packet fence rule numbers
+	exec("/sbin/pfctl -vv -sr | grep 'pfB_'", $pfrules);
+	if (!empty($pfrules)) {
+		foreach ($pfrules as $result) {
+			// Sample : @112(0) block return in log quick on em1 from any to <pfB_PRI1:160323> label "USER_RULE: pfB_PRI1"
+			if (preg_match("/@(\d+)\(\d+\).*\<(pfB_\w+):\d+\>/", $result, $rule)) {
+				$pfb_table[$rule[2]]['rules'] .= $rule[1] . '|';
+			}
+		}
+	}
+
+	// Sort tables per sort customization
+	if ($pfb['sortcolumn'] != "none") {
+		if ($pfb['sortdir'] == "asc") {
+			pfbsort($pfb_table, $pfb['sortcolumn'], TRUE);
+		} else {
+			pfbsort($pfb_table, $pfb['sortcolumn'], FALSE);
+		}
+	}
+	return $pfb_table;
+}
+
+// Called on initial load and Ajax to update table contents
+function pfBlockerNG_get_table($mode="") {
+	global $pfb;
+	$counter = 0; $dcounter = 1; $response = '';
+
+	$pfb_table = pfBlockerNG_get_counts();
+	if (!empty($pfb_table)) {
+		foreach ($pfb_table as $pfb_alias => $values) {
+			// Add firewall rules count associated with alias
+			$values['img'] = $values['img'] . "<span title='Alias Firewall Rule count' ><small>({$values['rule']})</small></span>";
+
+			// If packet fence errors found, display error.
+			if ($pfb['pfctl']) {
+				$values['img'] = $pfb['err'];
+			}
+
+			// Alias table popup
+			if ($values['count'] > 0 && $pfb['popup'] == "on") {
+				$alias_popup = rule_popup($pfb_alias, '', '', '');
+				$alias_span = $alias_popup['src'];
+				$alias_span_end = $alias_popup['src_end'];
+			}
+			else {
+				$alias_span = '';
+				$alias_span_end = '';
+			}
+
+			// Packet column pivot to Alerts Tab
+			if ($values['packets'] > 0) {
+				$rules = rtrim($values['rules'], '|');
+				if ($values['packets'] > $pfb['maxpivot']) {
+					$aentries = $pfb['maxpivot'];
+				} else {
+					$aentries = $values['packets'];
+				}
+
+				$packets  = "<a target='_new' href='/pfblockerng/pfblockerng_alerts.php?rule={$rules}&entries={$aentries}' ";
+				$packets .= "style='text-decoration: underline;' title='Click to view these packets in Alerts tab' >{$values['packets']}</a>";
+			}
+			else {
+				$packets = $values['packets'];
+			}
+
+			if ($mode == "js") {
+				echo $response = $alias_span . $pfb_alias . $alias_span_end . "||" . $values['count'] . "||" . $packets . "||" . $values['update']
+					. "||" . $values['img'] . "\n";
+			}
+			else {
+				$RowClass = $counter % 2 ? $pfb['RowEvenClass'] : $pfb['RowOddClass'];
+				$counter++;
+				echo (" <tr {$RowClass}>
+					<td class='listMRr ellipsis'>" . $alias_span . $pfb_alias . $alias_span_end . "</td>
+					<td class='listMRr' align='center'>{$values['count']}</td>
+					<td class='listMRr' sorttable_customkey='{$values['packets']}' align='center'>{$packets}</td>
+					<td class='listMRr' align='center'>{$values['update']}</td>
+					<td class='listMRr' align='center'>{$values['img']}</td>
+					</tr>");
+			}
+		}
 	}
 }
 
-// Status Indicator if pfBlockerNG is Enabled/Disabled
+// Status indicator if pfBlockerNG is enabled/disabled
 if ("{$pfb['enable']}" == "on") {
 	$pfb_status = "/themes/{$g['theme']}/images/icons/icon_pass.gif";
 	$pfb_msg = "pfBlockerNG is Active.";
@@ -102,70 +312,78 @@ if ("{$pfb['enable']}" == "on") {
 	$pfb_msg = "pfBlockerNG is Disabled.";
 }
 
-// Collect Total IP/Cidr Counts
+// Collect total IP/Cidr counts
 $dcount = exec("cat {$pfb['denydir']}/*.txt | grep -cv '^#\|^$\|^1\.1\.1\.1'");
 $pcount = exec("cat {$pfb['permitdir']}/*.txt | grep -cv '^#\|^$\|^1\.1\.1\.1'");
 $mcount = exec("cat {$pfb['matchdir']}/*.txt | grep -cv '^#\|^$\|^1\.1\.1\.1'");
 $ncount = exec("cat {$pfb['nativedir']}/*.txt | grep -cv '^#\|^$\|^1\.1\.1\.1'");
 
-// Collect Number of Suppressed Hosts
+// Collect number of suppressed hosts
 if (file_exists("{$pfb['supptxt']}")) {
 	$pfbsupp_cnt = exec ("/usr/bin/grep -c ^ {$pfb['supptxt']}");
 } else {
 	$pfbsupp_cnt = 0;
 }
 
-#check rule count
-#(label, evaluations,packets total, bytes total, packets in, bytes in,packets out, bytes out)
-$packets = exec("/sbin/pfctl -s labels", $debug);
-if (!empty($debug)) {
-	foreach ($debug as $line) {
-		// Auto-Rules start with 'pfB_', Alias Rules should start with 'pfb_' and exact spelling of Alias Name.
-		$line = str_replace("pfb_","pfB_",$line);
-		if ("{$pfb['pfsenseversion']}" >= '2.2') {
-			#USER_RULE: pfB_Top auto rule 8494 17 900 17 900 0 0 0
-			if (preg_match("/USER_RULE: (\w+).*\s+\d+\s+(\d+)\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+/", $line, $matches)) {
-				if (isset($matches)) {
-					${$matches[1]}+=$matches[2];
-				} else {
-					${$matches[1]} = 'Err';
-				}
-			}
-		} else {
-			#USER_RULE: pfB_Top auto rule 1656 0 0 0 0 0 0
-			if (preg_match("/USER_RULE: (\w+).*\s+\d+\s+(\d+)\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+/", $line, $matches)) {
-				if (isset($matches)) {
-					${$matches[1]}+=$matches[2];
-				} else {
-					${$matches[1]} = 'Err';
-				}
-			}
-		}
-	}
-}
+// Collect any failed downloads
+exec("grep $(date +%m/%d/%y) {$pfb['errlog']} | grep 'FAIL'", $results);
+$results = array_reverse($results);
 
-// Called by Ajax to update alerts table contents
-if (isset($_GET['getNewCounts'])) {
-	$response = "";
-	$pfb_table = pfBlockerNG_get_counts();
-	if (!empty($pfb_table)) {
-		foreach ($pfb_table as $alias => $values){
-			if (!isset(${$alias})) { ${$alias} = "-";}
-			$response .= $alias . "||" . $values['count'] . "||" . ${$alias} . "||" . $values['up'] . "||" . $values['img'] . "\n";
-		}
-		echo $response;
-		return;
-	}
-}
-
-// Report any Failed Downloads
-$results = array();
-$fails = exec("grep $(date +%m/%d/%y) {$pfb['errlog']} | grep 'FAIL'", $results);
-
-// Print widget Status Bar Items
 ?>
+	<!-- Widget customization settings icon -->
+	<input type="hidden" id="pfblockerng-config" name="pfblockerng-config" value="" />
+	<div id="pfblockerng-settings" class="widgetconfigdiv" style="display:none;outline: none;">
+	<form action="/widgets/widgets/pfblockerng.widget.php" method="post" name="pfb_iform">
+		<table id="widgettable" class="none" width="100%" border="0" cellpadding="0" cellspacing="0">
+		<tr>
+			<td width="22%" class="vncellt" valign="top" align="right" ><input type="checkbox" name="pfb_popup" class="formfld unknown" id="pfb_popup"
+				title="Enabling this option, will Popup a Table showing all of the Alias Table IPs"
+				value="on" <?php if ($pfb['popup'] == "on") echo 'checked'; ?> /></td>
+			<td width="78%" class="listr" ><?=gettext("Enable Alias Table Popup");?></td>
+		</tr>
+		<tr>
+			<td width="22%" class="vncellt" valign="top" ><input type="text" size="3" name="pfb_maxfails" class="formfld unknown" id="pfb_maxfails"
+				title="Tha maximum number of Failed Download Alerts to be shown. Refer to the error.log for add'l details"
+				value="<?= $pfb['maxfails'] ?>" /></td>
+			<td width="78%" class="listr" ><?=gettext("Enter number of download fails to display (default:3)");?></td>
+		</tr>
+		<tr>
+			<td width="22%" class="vncellt" valign="top" ><input type="text" size="3" name="pfb_maxpivot" class="formfld unknown" id="pfb_maxpivot"
+				title="The maximum number of Packets to pivot to the Alerts Tab"
+				value="<?= $pfb['maxpivot'] ?>" /></td>
+			<td width="78%" class="listr" ><?=gettext("Enter 'max' Packets for Alerts Tab pivot (default:200)");?></td>
+		</tr>
+		<tr>
+			<td width="22" class="vncellt" valign="top" >
+				<select name="pfb_sortcolumn" id="pfb_sortcolumn" class="formselect" title="The Column to be sorted" >
+				<?php
+				$pfbsort = array(	'none' => 'None', 'alias' => 'Alias', 'count' => 'Count',
+							'packets' => 'Packets', 'updated' => 'Updated'
+						);
+				foreach ($pfbsort as $sort => $sorttype): ?>
+					<option value="<?=$sort; ?>" <?php if ($sort == $pfb['sortcolumn']) echo 'selected'; ?> ><?=$sorttype; ?></option>
+				<?php endforeach; ?>
+				</select></td>
+			<td width="78%" class="listr" ><?=gettext("Enter Sort Column");?></td>
+		</tr>
+		</table>
+
+		<table id="widgettablesummary" width="100%" border="0" cellpadding="0" cellspacing="0">
+		<tr>
+			<td width="92%" class="vncellt" >&nbsp;<?=gettext("Sort");?>
+				<input name="pfb_sortdir" type="radio" value="asc" <?php if ($pfb['sortdir'] == "asc") echo 'checked'; ?> />
+					<?=gettext("Ascending");?>
+				<input name="pfb_sortdir" type="radio" value="des" <?php if ($pfb['sortdir'] == "des") echo 'checked'; ?> />
+					<?=gettext("Descending");?></td>
+			<td width="8%" class="vncellt" valign="top" ><input id="pfb_submit" name="pfb_submit" type="submit" class="formbtns" value="Save" /></td>
+		</tr>
+		</table>
+	</form>
+	</div>
+
+	<!-- Print widget status bar items -->
 	<div class="marinarea">
-	<table border="0" cellspacing="0" cellpadding="0">
+	<table id="pfb_table" border="0" cellspacing="0" cellpadding="0">
 		<thead>
 		<tr>
 			<td valign="middle">&nbsp;<img src="<?= $pfb_status ?>" width="13" height="13" border="0" title="<?=gettext($pfb_msg) ?>" alt="" /></td>
@@ -187,12 +405,14 @@ $fails = exec("grep $(date +%m/%d/%y) {$pfb['errlog']} | grep 'FAIL'", $results)
 										<?=gettext("&nbsp;Supp:"); echo("&nbsp;<strong>" . $pfbsupp_cnt . "</strong>"); ?>
 									<?php endif; ?></td>
 			<td valign="middle">&nbsp;&nbsp;</td>
-			<td valign="top"><a href="pfblockerng/pfblockerng_log.php"><img src="/themes/<?=$g['theme']; ?>/images/icons/icon_logs.gif" width="13" height="13" border="0" title="<?=gettext("View pfBlockerNG Logs TAB") ?>" alt="" /></a>&nbsp;
+			<td valign="top"><a href="pfblockerng/pfblockerng_log.php"><img src="/themes/<?=$g['theme']; ?>/images/icons/icon_logs.gif"
+				width="13" height="13" border="0" title="<?=gettext("View pfBlockerNG Logs TAB") ?>" alt="" /></a>&nbsp;
 			<td valign="top">
 				<?php if (!empty($results)): ?>		<!--Hide "Ack" Button when Failed Downloads are Empty-->
 					<form action="/widgets/widgets/pfblockerng.widget.php" method="post" name="widget_pfblockerng_ack">
 						<input type="hidden" value="clearack" name="pfblockerngack" />
-						<input class="vexpl" type="image" name="pfblockerng_ackbutton" src="/themes/<?=$g['theme']; ?>/images/icons/icon_x.gif" width="14" height="14" border="0" title="<?=gettext("Clear Failed Downloads") ?>"/>
+						<input class="vexpl" type="image" name="pfblockerng_ackbutton" src="/themes/<?=$g['theme']; ?>/images/icons/icon_x.gif"
+							width="14" height="14" border="0" title="<?=gettext("Clear Failed Downloads") ?>"/>
 					</form>
 				<?php endif; ?>
 			</td>
@@ -205,76 +425,53 @@ $fails = exec("grep $(date +%m/%d/%y) {$pfb['errlog']} | grep 'FAIL'", $results)
 	<tbody id="pfb-fails">
 <?php
 
-if ("{$pfb['pfsenseversion']}" > '2.0') {
-	$alertRowEvenClass = "listMReven";
-	$alertRowOddClass = "listMRodd";
-	$alertColClass = "listMRr";
-} else {
-	$alertRowEvenClass = "listr";
-	$alertRowOddClass = "listr";
-	$alertColClass = "listr";
-}
-
-# Last errors first
-$results = array_reverse($results);
-
+// Report any failed downloads
 $counter = 0;
-# Max errors to display
-$maxfailcount = 3;
 if (!empty($results)) {
 	foreach ($results as $result) {
-		$alertRowClass = $counter % 2 ? $alertRowEvenClass : $alertRowOddClass;
-		if (!isset(${$alias})) { ${$alias} = "-";}
-		echo(" <tr class='" . $alertRowClass . "'><td class='" . $alertColClass .  "'>" . $result . "</td><tr>");
+		$RowClass = $counter % 2 ? $pfb['RowEvenClass'] : $pfb['RowOddClass'];
+		echo(" <tr " . $RowClass . "><td class='" . $pfb['ColClass'] . "'>" . $result . "</td><tr>");
 		$counter++;
-		if ($counter > $maxfailcount) {
-			# To many errors stop displaying
-			echo(" <tr class='" . $alertRowClass . "'><td class='" . $alertColClass .  "'>" . (count($results) - $maxfailcount) . " more error(s)...</td><tr>");
+		if ($counter > $pfb['maxfails']) {
+			// To many errors stop displaying
+			echo(" <tr " . $RowClass . "><td class='" . $pfb['ColClass'] . "'>" . (count($results) - $pfb['maxfails']) . " more error(s)...</td><tr>");
 			break;
 		}
 	}
 }
 
-// Print Main Table Header
 ?>
+	<!-- Print main table header -->
 	</tbody>
 	</table>
-	<table id="pfb-tbl" width="100%" border="0" cellspacing="0" cellpadding="0">
+	<table id="pfb-tbl" width="100%" class="sortable" border="0" cellspacing="0" cellpadding="0">
 	<thead>
-		<tr>
-			<th class="widgetsubheader" align="center"><?=gettext("Alias");?></th>
-			<th title="The count can be a mixture of Single IPs or CIDR values" class="widgetsubheader" align="center"><?=gettext("Count");?></th>
-			<th title="Packet Counts can be cleared by the pfSense filter_configure() function. Make sure Rule Descriptions start with 'pfB_'" class="widgetsubheader" align="center"><?=gettext("Packets");?></th>
-			<th title="Last Update (Date/Time) of the Alias " class="widgetsubheader" align="center"><?=gettext("Updated");?></th>
-			<th class="widgetsubheader" align="center"><?php echo $out; ?><?php echo $in; ?></th>
+		<tr class="sortableHeaderRowIdentifier">
+			<th class="widgetsubheader" axis="string" align="center"><?=gettext("Alias");?></th>
+			<th title="The count can be a mixture of Single IPs or CIDR values" class="widgetsubheader" axis="string"
+				align="center"><?=gettext("Count");?></th>
+			<th title="Packet Counts can be cleared by the pfSense filter_configure() function. Make sure Rule Descriptions start with 'pfB_'"
+				class="widgetsubheader" axis="string" align="center"><?=gettext("Packets");?></th>
+			<th title="Last Update (Date/Time) of the Alias " class="widgetsubheader" axis="string" align="center"><?=gettext("Updated");?></th>
+			<th class="widgetsubheader" axis="string" align="center"><?php echo $pfb['down']; ?><?php echo $pfb['up']; ?></th>
 		</tr>
 	</thead>
 	<tbody id="pfbNG-entries">
-<?php
-// Print Main Table Body
-$pfb_table = pfBlockerNG_get_counts();
-$counter=0;
-if (is_array($pfb_table)) {
-	foreach ($pfb_table as $alias => $values) {
-		$evenRowClass = $counter % 2 ? " listMReven" : " listMRodd";
-		if (!isset(${$alias})) { ${$alias} = "-";}
-		echo("	<tr class='" . $evenRowClass . "'>
-				<td class='listMRr ellipsis'>{$alias}</td>
-				<td class='listMRr' align='center'>{$values['count']}</td>
-				<td class='listMRr' align='center'>{${$alias}}</td>
-				<td class='listMRr' align='center'>{$values['up']}</td>
-				<td class='listMRr' align='center'>{$values['img']}</td>
-			</tr>");
-		$counter++;
-	}
-}
 
-?>
+<!-- Print main table body, subsequent refresh by javascript function -->
+<?php pfBlockerNG_get_table(); ?>
+
 </tbody>
 </table>
 
 <script type="text/javascript">
 //<![CDATA[
-	var pfBlockerNGupdateDelay = 10000; // update every 10000 ms
+<!-- update every 10000 ms -->
+	var pfBlockerNGupdateDelay = 10000;
+
+<!-- needed to display the widget settings menu -->
+	selectIntLink = "pfblockerng-configure";
+	textlink = document.getElementById(selectIntLink);
+	textlink.style.display = "inline";
 //]]>
 </script>

--- a/config/pfblockerng/pfblockerng.xml
+++ b/config/pfblockerng/pfblockerng.xml
@@ -52,6 +52,7 @@
 	<version>1.09</version>
 	<title>pfBlockerNG: General Settings</title>
 	<include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
+	<addedit_string>pfBlockerNG: Save General Settings</addedit_string>
 	<menu>
 		<name>pfBlockerNG</name>
 		<configfile>pfblockerng.xml</configfile>

--- a/config/pfblockerng/pfblockerng.xml
+++ b/config/pfblockerng/pfblockerng.xml
@@ -49,7 +49,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>pfblockerng</name>
-	<version>1.08</version>
+	<version>1.09</version>
 	<title>pfBlockerNG: General Settings</title>
 	<include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
 	<menu>
@@ -219,45 +219,83 @@
 		<field>
 			<fielddescr>LINKS</fielddescr>
 			<fieldname></fieldname>
-			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp; <a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]></description>
+			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp;
+				<a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
+			</description>
 			<type>info</type>
 		</field>
 		<field>
-			<fielddescr><![CDATA[<strong>Enable pfBlockerNG</strong>]]></fielddescr>
+			<fielddescr>Enable pfBlockerNG</fielddescr>
 			<fieldname>enable_cb</fieldname>
 			<type>checkbox</type>
-			<description><![CDATA[Note - with "Keep settings" enabled, pfBlockerNG will maintain run state on Installation/Upgrade<br />
-					If "Keep Settings" is not "enabled" on pkg Install/De-Install, all Settings will be Wiped!]]></description>
+			<description><![CDATA[<div style="padding-right: 56px;">Enable/Disable</div>]]></description>
+			<usecolspan2/>
+			<combinefields>begin</combinefields>
 		</field>
 		<field>
-			<fielddescr><![CDATA[<strong>Keep Settings</strong>/Lists After Disable/Re-Install/De-Install]]></fielddescr>
 			<fieldname>pfb_keep</fieldname>
 			<type>checkbox</type>
-			<description>Keep Settings and Lists intact when pfBlockerNG is Disabled or After pfBlockerNG Re-Install/De-Install</description>
+			<description><![CDATA[Keep Settings: <br /><font color='red'>Note:</font> - with 'Keep settings' enabled, pfBlockerNG will maintain run state
+				on Installation/Upgrade<br />If 'Keep Settings' is not 'enabled' on pkg Install/De-Install, all Settings will be Wiped!<br /><br />
+				<font color='red'>Note: </font>To clear all downloaded lists, uncheck these two checkboxes and 'Save'.
+				re-check both boxes and run a 'Force Update']]>
+			</description>
 			<default_value>on</default_value>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields>end</combinefields>
 		</field>
 		<field>
-			<fielddescr>CRON MIN Start Time</fielddescr>
+			<fielddescr>CRON Settings</fielddescr>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
+			<fielddescr>Hour Interval</fielddescr>
+			<fieldname>pfb_interval</fieldname>
+			<description><![CDATA[Default: <strong>Every hour</strong><br />
+				Select the cron Hour Interval. The interval selected will be used with the Start min/hour below.<br />
+				<strong>Ensure that all List 'Update Settings' are within the selected Interval/Start Hour Settings.</strong>]]>
+			</description>
+			<type>select</type>
+			<options>
+				<option><name>Every hour</name><value>1</value></option>
+				<option><name>Every 2 hours</name><value>2</value></option>
+				<option><name>Every 3 hours</name><value>3</value></option>
+				<option><name>Every 4 hours</name><value>4</value></option>
+				<option><name>Every 6 hours</name><value>6</value></option>
+				<option><name>Every 8 hours</name><value>8</value></option>
+				<option><name>Every 12 hours</name><value>12</value></option>
+				<option><name>Once a day</name><value>24</value></option>
+			</options>
+			<default_value>1</default_value>
+			<combinefields/>
+		</field>
+		<field>
+			<fielddescr>Start Min</fielddescr>
 			<fieldname>pfb_min</fieldname>
-			<description><![CDATA[Default: <strong> : 00</strong><br />
-				Select Cron Update Minute ]]></description>
+			<description><![CDATA[Default: <strong>:00</strong><br />
+				Select Cron Update Minute]]>
+			</description>
 			<type>select</type>
 			<options>
-				<option><name> : 00</name><value>0</value></option>
-				<option><name> : 15</name><value>15</value></option>
-				<option><name> : 30</name><value>30</value></option>
-				<option><name> : 45</name><value>45</value></option>
+				<option><name>: 00</name><value>0</value></option>
+				<option><name>: 15</name><value>15</value></option>
+				<option><name>: 30</name><value>30</value></option>
+				<option><name>: 45</name><value>45</value></option>
 			</options>
+			<default_value>0</default_value>
+			<combinefields/>
 		</field>
 		<field>
-			<fielddescr>CRON Base Hour Start Time</fielddescr>
+			<fielddescr>Start Hour</fielddescr>
 			<fieldname>pfb_hour</fieldname>
-			<description><![CDATA[Default: <strong> 1 </strong><br />
-				Select Cron Base Start Hour ]]></description>
+			<description><![CDATA[Default: <strong>0</strong><br />
+				Select the Start Hour]]>
+			</description>
 			<type>select</type>
 			<options>
-				<option><name>1</name><value>0</value></option>
-				<option><name>0</name><value>1</value></option>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
 				<option><name>2</name><value>2</value></option>
 				<option><name>3</name><value>3</value></option>
 				<option><name>4</name><value>4</value></option>
@@ -281,17 +319,17 @@
 				<option><name>22</name><value>22</value></option>
 				<option><name>23</name><value>23</value></option>
 			</options>
+			<default_value>0</default_value>
+			<combinefields/>
 		</field>
 		<field>
-			<fielddescr>'Daily/Weekly' Start Hour</fielddescr>
+			<fielddescr><![CDATA['Daily/Weekly'<br />Start Hour]]></fielddescr>
 			<fieldname>pfb_dailystart</fieldname>
-			<description><![CDATA[Default: <strong> 1 </strong><br />
-				Select 'Daily' Schedule Start Hour <br />
-				This is used for the 'Daily/Weekly' Scheduler Only.]]></description>
+			<description><![CDATA[Default: <strong>0</strong><br />This is used for the 'Daily/Weekly' Scheduler Only.]]></description>
 			<type>select</type>
 			<options>
-				<option><name>1</name><value>0</value></option>
-				<option><name>0</name><value>1</value></option>
+				<option><name>0</name><value>0</value></option>
+				<option><name>1</name><value>1</value></option>
 				<option><name>2</name><value>2</value></option>
 				<option><name>3</name><value>3</value></option>
 				<option><name>4</name><value>4</value></option>
@@ -315,6 +353,8 @@
 				<option><name>22</name><value>22</value></option>
 				<option><name>23</name><value>23</value></option>
 			</options>
+			<default_value>0</default_value>
+			<combinefields>end</combinefields>
 		</field>
 		<field>
 			<fielddescr>Enable De-Duplication</fielddescr>
@@ -327,17 +367,20 @@
 			<fieldname>suppression</fieldname>
 			<type>checkbox</type>
 			<description><![CDATA[This will prevent Selected IPs from being Blocked. Only for IPv4 Lists (/32 and /24).<br />
-					Country Blocking Lists cannot be Suppressed.<br />
-					This will also remove any RFC1918 addresses from all Lists.<br /><br />
+					Country Blocking Lists cannot be Suppressed.<br />This will also remove any RFC1918 addresses from all Lists.<br /><br />
 					Alerts can be Suppressed using the '+' icon in the Alerts Tab and IPs added to the 'pfBlockerNGSuppress' Alias<br />
-					A Blocked IP in a CIDR other than /24 will need to be Suppressed by an 'Permit Outbound' Firewall Rule]]>
+					A Blocked IP in a CIDR other than /32 or /24 will need a 'Whitelist Alias' w/ List Action: 'Permit Outbound' Firewall Rule
+					<br />Do not use the pfBlockerNGSuppress Alias in a Firewall Rule.
+					This alias is used during the cron download process only.]]>
 			</description>
 		</field>
 		<field>
 			<fielddescr>Global Enable Logging</fielddescr>
 			<fieldname>enable_log</fieldname>
 			<type>checkbox</type>
-			<description>Enable Global Logging to Status: System Logs: FIREWALL ( Log ). This overrides any Log Settings in the Alias Tabs.</description>
+			<description><![CDATA[Firewall Rule logging - Enable Global Logging to [ Status: System Logs: FIREWALL Log ]<br />
+				This overrides any Log Settings in the Alias Tabs.]]>
+			</description>
 		</field>
 		<field>
 			<fielddescr>Disable MaxMind Country Database CRON Updates</fielddescr>
@@ -350,8 +393,9 @@
 		<field>
 			<fielddescr>Logfile Size</fielddescr>
 			<fieldname>log_maxlines</fieldname>
-			<description><![CDATA[Default:<strong>20000</strong><br />
-				Select number of Lines to Keep in Log File]]></description>
+			<description><![CDATA[Default: <strong>20000</strong><br />
+				Select number of Lines to keep in the pfblockerng.log and dnsbl.log files]]>
+			</description>
 			<type>select</type>
 			<options>
 				<option><name>20000</name><value>20000</value></option>
@@ -361,72 +405,89 @@
 				<option><name>100000</name><value>100000</value></option>
 				<option><name>No Limit</name><value>nolimit</value></option>
 			</options>
+			<default_value>20000</default_value>
 		</field>
 		<field>
-			<name><![CDATA[Interface/Rules Configuration]]> </name>
+			<name><![CDATA[Interface/Rules Configuration]]></name>
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Inbound Interface(s)</fielddescr>
+			<fielddescr>Inbound Firewall Rules</fielddescr>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
 			<fieldname>inbound_interface</fieldname>
+			<fielddescr>Interface(s)</fielddescr>
 			<description>Select the Inbound interface(s) you want to Apply Auto Rules to</description>
 			<type>interfaces_selection</type>
 			<hideinterfaceregex>loopback</hideinterfaceregex>
 			<required/>
 			<multiple/>
+			<combinefields/>
 		</field>
 		<field>
-			<fielddescr> - Rule Action</fielddescr>
+			<fielddescr>Rule Action</fielddescr>
 			<fieldname>inbound_deny_action</fieldname>
-			<description><![CDATA[Default:<strong>Block</strong><br />
-				Select 'Rule Action' for Inbound Rules]]></description>
+			<description><![CDATA[Default: <strong>Block</strong><br />Select 'Rule Action' for Inbound Rules]]></description>
 			<type>select</type>
 			<options>
 				<option><name>Block</name><value>block</value></option>
 				<option><name>Reject</name><value>reject</value></option>
 			</options>
+			<default_value>block</default_value>
+			<required/>
+			<combinefields>end</combinefields>
 		</field>
 		<field>
-			<fielddescr>Outbound Interface(s)</fielddescr>
+			<fielddescr>Outbound Firewall Rules</fielddescr>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
+			<fielddescr>Interface(s)</fielddescr>
 			<fieldname>outbound_interface</fieldname>
 			<description>Select the Outbound interface(s) you want to Apply Auto Rules to</description>
 			<type>interfaces_selection</type>
 			<hideinterfaceregex>loopback</hideinterfaceregex>
 			<required/>
 			<multiple/>
+			<combinefields/>
 		</field>
 		<field>
-			<fielddescr> - Rule Action</fielddescr>
+			<fielddescr>Rule Action</fielddescr>
 			<fieldname>outbound_deny_action</fieldname>
-			<description><![CDATA[Default:<strong>Reject</strong><br />
-				Select 'Rule Action' for Outbound rules]]></description>
+			<description><![CDATA[Default: <strong>Reject</strong><br />Select 'Rule Action' for Outbound rules]]></description>
 			<type>select</type>
 			<options>
 				<option><name>Reject</name><value>reject</value></option>
 				<option><name>Block</name><value>block</value></option>
 			</options>
+			<default_value>reject</default_value>
+			<required/>
+			<combinefields>end</combinefields>
 		</field>
 		<field>
-			<fielddescr><![CDATA[<strong>OpenVPN Interface</strong>]]></fielddescr>
+			<fielddescr>OpenVPN Interface</fielddescr>
 			<fieldname>openvpn_action</fieldname>
 			<type>checkbox</type>
 			<description>Select to add Auto-Rules for OpenVPN. These will be added to 'Floating Rules' or OpenVPN Rules Tab.</description>
 		</field>
 		<field>
-			<fielddescr><![CDATA[<strong>Floating Rules</strong>]]></fielddescr>
+			<fielddescr>Floating Rules</fielddescr>
 			<fieldname>enable_float</fieldname>
 			<type>checkbox</type>
-			<description><![CDATA[<strong>Enabled:&nbsp;</strong> Auto-Rules will be generated in the 'Floating Rules' Tab<br /><br />
+			<description><![CDATA[<strong>Enabled:</strong> Auto-Rules will be generated in the 'Floating Rules' Tab<br /><br />
 				<strong>Disabled:</strong> Auto-Rules will be generated in the Selected Inbound/Outbound Interfaces<br /><br />
-				<strong>Rules will be ordered by the selection below.</strong>]]></description>
+				<strong>Rules will be ordered by the selection below.</strong>]]>
+			</description>
 		</field>
 		<field>
-			<fielddescr><![CDATA[<strong>Rule Order</strong>]]></fielddescr>
+			<fielddescr>Rule Order</fielddescr>
 			<fieldname>pass_order</fieldname>
-			<description><![CDATA[<br />Default Order:  <strong> | pfB_Block/Reject | All other Rules | (original format)<br /></strong><br />
+			<description><![CDATA[<br />Default Order:<strong> | pfB_Block/Reject | All other Rules | (original format)<br /></strong><br />
 				Select The '<strong>Order</strong>' of the Rules<br />
 				&nbsp;&nbsp;Selecting 'original format', sets pfBlockerNG rules at the top of the Firewall TAB.<br />
-				&nbsp;&nbsp;Selecting any other 'Order' will re-order <strong>all the Rules to the format indicated!</strong>]]></description>
+				&nbsp;&nbsp;Selecting any other 'Order' will re-order <strong>all the Rules to the format indicated!</strong>]]>
+			</description>
 			<type>select</type>
 			<options>
 				<option><name>| pfB_Block/Reject | All other Rules | (original format)</name><value>order_0</value></option>
@@ -434,48 +495,48 @@
 				<option><name>| pfB_Pass/Match | pfSense Pass/Match | pfB_Block/Reject |</name><value>order_2</value></option>
 				<option><name>| pfB_Pass/Match | pfB_Block/Reject | pfSense Pass/Match |</name><value>order_3</value></option>
 			</options>
+			<default_value>order_0</default_value>
 		</field>
 		<field>
-			<fielddescr><![CDATA[<strong>Auto Rule Suffix</strong>]]></fielddescr>
+			<fielddescr>Auto Rule Suffix</fielddescr>
 			<fieldname>autorule_suffix</fieldname>
-			<description><![CDATA[Default:<strong>auto rule</strong><br />
-				Select 'Auto Rule' Description Suffix for Auto Defined rules. pfBlockerNG Must be Disabled to Modify Suffix]]></description>
+			<description><![CDATA[Default: <strong>auto rule</strong><br />
+				Select 'Auto Rule' Description Suffix for Auto Defined rules. pfBlockerNG Must be Disabled to Modify Suffix]]>
+			</description>
 			<type>select</type>
 			<options>
 				<option><name>auto rule</name><value>autorule</value></option>
 				<option><name>Null (no suffix)</name><value>standard</value></option>
 				<option><name>AR</name><value>ar</value></option>
 			</options>
+			<default_value>autorule</default_value>
 		</field>
 		<field>
-			<name><![CDATA[Acknowledgements]]> </name>
+			<name><![CDATA[Acknowledgements]]></name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Credits</fielddescr>
 			<fieldname>credits</fieldname>
 			<type>info</type>
-			<description><![CDATA[<strong>
-				pfBlockerNG</strong> Created in 2015 by <a target=_new href='https://forum.pfsense.org/index.php?action=profile;u=238481'>BBcan177.</a>
-				<br /><br />Based upon pfBlocker by Marcello Coutinho and Tom Schaefer.<br />
+			<description><![CDATA[<strong>pfBlockerNG </strong>
+				Created in 2015 by <a target=_new href='https://forum.pfsense.org/index.php?action=profile;u=238481'>BBcan177.</a><br /><br />
+				Based upon pfBlocker by Marcello Coutinho and Tom Schaefer.<br />
 				Country Database GeoLite distributed under the Creative Commons Attribution-ShareAlike 3.0 Unported License by:
 				MaxMind Inc. @ <a target=_new href='http://www.maxmind.com'>MaxMind.com</a>.
-				The Database is Automatically Updated the First Tuesday of Each Month]]></description>
+				The Database is Automatically Updated the First Tuesday of Each Month]]>
+			</description>
 		</field>
 		<field>
-			<fielddescr>pfBlocker Validation Check</fielddescr>
-			<fieldname>pfblocker_cb</fieldname>
-			<type>checkbox</type>
-			<description>Disable pfBlockerNG if the pfBlocker package is Enabled. Click to Disable this validation check.</description>
-		</field>
-		<field>
-			<fielddescr>Gold Membership</fielddescr>
+			<fielddescr>Support</fielddescr>
 			<type>info</type>
-			<description><![CDATA[If you like this package, please Support pfSense by subscribing to a <a target=_new href='https://portal.pfsense.org/gold-subscription.php'>Gold Membership</a><br /> or support the developer @ BBCan177@gmail.com]]></description>
+			<description><![CDATA[This package has been developed by BBcan177.<br />
+				 If you like this package, please support the developer @ BBCan177@gmail.com.]]>
+			</description>
 		</field>
 		<field>
-			<name><![CDATA[<ul>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
-			'Force Update'</ul>]]></name>
+			<name><![CDATA[<center>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
+			'Force Update'</center>]]></name>
 			<type>listtopic</type>
 		</field>
 	</fields>

--- a/config/pfblockerng/pfblockerng_alerts.php
+++ b/config/pfblockerng/pfblockerng_alerts.php
@@ -216,7 +216,7 @@ exec("/sbin/pfctl -vv -sr | grep 'pfB_'", $results);
 if (!empty($results)) {
 	foreach ($results as $result) {
 
-		# Find Rule Descriptions
+		// Find Rule Descriptions
 		$descr = "";
 		if (preg_match("/USER_RULE: (\w+)/",$result,$desc)) {
 			$descr = $desc[1];
@@ -225,7 +225,7 @@ if (!empty($results)) {
 		preg_match ("/@(\d+)\(/",$result, $rule);
 
 		$id = $rule[1];
-		# Create array of Rule Description and pfctl Rule Number
+		// Create array of Rule Description and pfctl Rule Number
 		$rule_list['id'][] = $id;
 		$rule_list[$id]['name'] = $descr;
 	}
@@ -905,7 +905,7 @@ if (!empty($fields_array[$type]) && !empty($rule_list)) {
 				$country = substr(exec("$pathgeoip6 -f $pathgeoipdat6 $host"),26,2);
 			}
 
-			# IP Query Grep Exclusion
+			// IP Query Grep Exclusion
 			$pfb_ex1 = "grep -v 'pfB\_\|\_v6\.txt'";
 			$pfb_ex2 = "grep -v 'pfB\_\|/32\|/24\|\_v6\.txt' | grep -m1 '/'";
 
@@ -967,7 +967,7 @@ if (!empty($fields_array[$type]) && !empty($rule_list)) {
 				$pfb_query = "No Match";
 			}
 
-			# Split List Column into Two lines.
+			// Split List Column into Two lines.
 			unset ($pfb_match);
 			if ($pfb_query == "No Match") {
 				$pfb_match[1] = "{$pfb_query}";

--- a/config/pfblockerng/pfblockerng_diag_dns.php
+++ b/config/pfblockerng/pfblockerng_diag_dns.php
@@ -56,15 +56,6 @@ foreach ($a_aliases as $a) {
 	$counter++;
 }
 
-# Collect pfSense Version
-$pfs_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
-
-if ($pfs_version > '2.2') {
-	$cmd = '/usr/bin/drill';
-} else {
-	$cmd = '/usr/bin/dig';
-}
-
 if (isset($_POST['create_alias']) && (is_hostname($host) || is_ipaddr($host))) {
 	if ($_POST['override']) {
 		$override = true;
@@ -73,7 +64,7 @@ if (isset($_POST['create_alias']) && (is_hostname($host) || is_ipaddr($host))) {
 	$type = "hostname";
 	if ($resolved) {
 		$resolved = array();
-		exec("{$cmd} {$host_esc} A | /usr/bin/grep {$host_esc} | /usr/bin/grep -v ';' | /usr/bin/awk '{ print $5 }'", $resolved);
+		exec("/usr/bin/drill {$host_esc} A | /usr/bin/grep {$host_esc} | /usr/bin/grep -v ';' | /usr/bin/awk '{ print $5 }'", $resolved);
 		$isfirst = true;
 		foreach ($resolved as $re) {
 			if ($re <> "") {
@@ -120,7 +111,7 @@ if ($_POST) {
 		$dns_servers = array();
 		exec("/usr/bin/grep nameserver /etc/resolv.conf | /usr/bin/cut -f2 -d' '", $dns_servers);
 		foreach ($dns_servers as $dns_server) {
-			$query_time = exec("{$cmd} {$host_esc} " . escapeshellarg("@" . trim($dns_server)) . " | /usr/bin/grep Query | /usr/bin/cut -d':' -f2");
+			$query_time = exec("/usr/bin/drill {$host_esc} " . escapeshellarg("@" . trim($dns_server)) . " | /usr/bin/grep Query | /usr/bin/cut -d':' -f2");
 			if ($query_time == "") {
 				$query_time = gettext("No response");
 			}
@@ -149,7 +140,7 @@ if ($_POST) {
 			$resolved = gethostbyname($host);
 			if ($resolved) {
 				$resolved = array();
-				exec("{$cmd} {$host_esc} A | /usr/bin/grep {$host_esc} | /usr/bin/grep -v ';' | /usr/bin/awk '{ print $5 }'", $resolved);
+				exec("/usr/bin/drill {$host_esc} A | /usr/bin/grep {$host_esc} | /usr/bin/grep -v ';' | /usr/bin/awk '{ print $5 }'", $resolved);
 			}
 			$hostname = $host;
 			if ($host != $resolved) {
@@ -208,7 +199,7 @@ include("head.inc"); ?>
 			<input name="host" type="text" class="formfld unknown" id="host" size="20" value="<?=htmlspecialchars($host);?>">
 			</td>
 			<?php if ($resolved && $type) { ?>
-			<td valign="middle">&nbsp;=&nbsp;</td><td>
+			<td valign="middle">&nbsp;&nbsp;</td><td>
 			<font size="+1">
 <?php
 				$found = 0;
@@ -244,8 +235,8 @@ include("head.inc"); ?>
 		</tr>
 <?php		if ($_POST): ?>
 		<tr>
-		<td width="22%" valign="top" class="vncell"><?=gettext("Resolution time per server");?></td>
-		<td width="78%" class="vtable">
+			<td width="22%" valign="top" class="vncell"><?=gettext("Resolution time per server");?></td>
+			<td width="78%" class="vtable">
 				<table width="170" border="0" cellpadding="6" cellspacing="0" summary="resolution time">
 					<tr>
 						<td class="listhdrr">
@@ -271,7 +262,7 @@ include("head.inc"); ?>
 					endforeach;
 ?>
 				</table>
-		</td>
+		  </td>
 		</tr>
 		<?php endif; ?>
 		<?php if (!$input_errors && $ipaddr) { ?>

--- a/config/pfblockerng/pfblockerng_log.php
+++ b/config/pfblockerng/pfblockerng_log.php
@@ -52,13 +52,13 @@ require_once("/usr/local/pkg/pfblockerng/pfblockerng.inc");
 
 pfb_global();
 
-# Get log files from directory
+// Get log files from directory
 function getlogs($logdir, $log_extentions = array('log')) {
 	if (!is_array($log_extentions)) {
 		$log_extentions = array($log_extentions);
 	}
 
-	# Get logfiles
+	// Get logfiles
 	$log_filenames = array();
 	foreach ($log_extentions as $extention) {
 		if ($extention <> '*') {
@@ -68,7 +68,7 @@ function getlogs($logdir, $log_extentions = array('log')) {
 		}
 	}
 
-	# Convert to filenames only
+	// Convert to filenames only
 	if (count($log_filenames) > 0) {
 		$log_totalfiles = count($log_filenames);
 		for ($cnt = 0; $cnt < $log_totalfiles; $cnt++) {
@@ -76,18 +76,19 @@ function getlogs($logdir, $log_extentions = array('log')) {
 		}
 	}
 	
-	# Sort the filename
+	// Sort the filename
 	asort($log_filenames);
 	
-	# Done
+	// Done
 	return $log_filenames;
 }
 
-# Define logtypes
-# name	=> Displayname of the type
-# ext	=> Log extentions (array for multiple extentions)
-# logdir=> Log directory
-# clear	=> Add clear button (TRUE/FALSE)
+/*	Define logtypes:
+		name	=>	Displayname of the type
+		ext	=>	Log extentions (array for multiple extentions)
+		logdir	=>	Log directory
+		clear	=>	Add clear button (TRUE/FALSE)	*/
+
 $pfb_logtypes = array(	'defaultlogs'	=> array('name'		=> 'Log Files',
 						'logdir'	=> "{$pfb['logdir']}/",
 						'logs'		=> array("pfblockerng.log", "error.log", "geoip.log", "maxmind_ver"),
@@ -153,7 +154,7 @@ $pfb_logtypes = array(	'defaultlogs'	=> array('name'		=> 'Log Files',
 						)
 		);
 
-# Check logtypes
+// Check logtypes
 $logtypeid = 'defaultlogs';
 if (isset($_POST['logtype'])) {
 	$logtypeid = $_POST['logtype'];
@@ -161,13 +162,13 @@ if (isset($_POST['logtype'])) {
 	$logtypeid = htmlspecialchars($_GET['logtype']);
 }
 
-# Check if POST has been set
+// Check if POST has been set
 if (isset($_POST['file'])) {
 	clearstatcache();
 	$pfb_logfilename = $_POST['file'];
 	$pfb_ext = pathinfo($pfb_logfilename, PATHINFO_EXTENSION);
 
-	# Load log
+	// Load log
 	if ($_POST['action'] == 'load') {
 		if (!is_file($pfb_logfilename)) {
 			echo "|3|" . gettext("Log file is empty or does not exist") . ".|";
@@ -187,12 +188,12 @@ if (isset($_POST['file'])) {
 if (isset($_POST['logFile'])) {
 	$s_logfile = $_POST['logFile'];
 
-	# Clear selected file
+	// Clear selected file
 	if (isset($_POST['clear'])) {
 		unlink_if_exists($s_logfile);
 	}
 
-	# Download log
+	// Download log
 	if (isset($_POST['download'])) {
 		if (file_exists($s_logfile)) {
 			ob_start(); //important or other posts will fail

--- a/config/pfblockerng/pfblockerng_sync.xml
+++ b/config/pfblockerng/pfblockerng_sync.xml
@@ -124,7 +124,7 @@
 			<url>/pkg_edit.php?xml=/pfblockerng/pfblockerng_sync.xml&amp;id=0</url>
 			<active/>
 		</tab>
-		</tabs>
+	</tabs>
 	<fields>
 		<field>
 			<name>pfBlockerNG XMLRPC Sync Settings</name>
@@ -132,8 +132,8 @@
 		</field>
 		<field>
 			<fielddescr>LINKS</fielddescr>
-			<fieldname>none</fieldname>
-			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp; <a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
+			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp;
+				<a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
 			</description>
 			<type>info</type>
 		</field>
@@ -173,7 +173,6 @@
 		</field>
 		<field>
 			<fielddescr>Replication Targets</fielddescr>
-			<fieldname>none</fieldname>
 			<type>rowhelper</type>
 			<rowhelper>
 				<rowhelperfield>
@@ -217,15 +216,15 @@
 				<rowhelperfield>
 					<fielddescr>Target Password</fielddescr>
 					<fieldname>varsyncpassword</fieldname>
-					<description><![CDATA[Password of the user "admin" on the destination host.]]></description>
+					<description><![CDATA[Password of the user 'admin' on the destination host.]]></description>
 					<type>password</type>
 					<size>20</size>
 				</rowhelperfield>
 			</rowhelper>
 		</field>
 		<field>
-			<name><![CDATA[<ul>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
-			'Force Update'</ul>]]></name>
+			<name><![CDATA[<center>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
+			'Force Update'</center>]]></name>
 			<type>listtopic</type>
 		</field>
 	</fields>

--- a/config/pfblockerng/pfblockerng_sync.xml
+++ b/config/pfblockerng/pfblockerng_sync.xml
@@ -52,6 +52,7 @@
 	<version>1.0</version>
 	<title>pfBlockerNG: XMLRPC Sync</title>
 	<include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
+	<addedit_string>pfBlockerNG: Save XMLRPC Sync settings</addedit_string>
 	<menu>
 		<name>pfBlockerNG</name>
 		<tooltiptext>Configure pfBlockerNG</tooltiptext>

--- a/config/pfblockerng/pfblockerng_top20.xml
+++ b/config/pfblockerng/pfblockerng_top20.xml
@@ -52,6 +52,7 @@
 	<version>1.0</version>
 	<title>pfBlockerNG: Top 20 Spammer Countries</title>
 	<include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
+	<addedit_string>pfBlockerNG: Save Top20 settings</addedit_string>
 	<menu>
 		<name>pfBlockerNG</name>
 		<tooltiptext>Configure pfblockerNG</tooltiptext>

--- a/config/pfblockerng/pfblockerng_top20.xml
+++ b/config/pfblockerng/pfblockerng_top20.xml
@@ -58,7 +58,7 @@
 		<section>Firewall</section>
 		<url>pkg_edit.php?xml=pfblockerng.xml&amp;id=0</url>
 	</menu>
-		<tabs>
+	<tabs>
 		<tab>
 			<text>General</text>
 			<url>/pkg_edit.php?xml=pfblockerng.xml&amp;id=0</url>
@@ -124,7 +124,7 @@
 			<text>Sync</text>
 			<url>/pkg_edit.php?xml=/pfblockerng/pfblockerng_sync.xml&amp;id=0</url>
 		</tab>
-		</tabs>
+	</tabs>
 	<fields>
 		<field>
 			<name><![CDATA[TOP 20 - Spammer Countries&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; (Geolite Data by Maxmind Inc. - ISO 3166)]]></name>
@@ -132,20 +132,19 @@
 		</field>
 		<field>
 			<fielddescr>LINKS</fielddescr>
-			<fieldname>none</fieldname>
-			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp; <a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
+			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp;
+				<a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
 			</description>
 			<type>info</type>
-			</field>
+		</field>
 		<field>
-			<fielddescr><![CDATA[<br /><strong>Top 20 IPv4</strong><br />Spammer Countries]]></fielddescr>
 			<fieldname>countries4</fieldname>
-			<description>
-			<![CDATA[Select Top IPv4 Spammer Countries you want to take an action on.<br />
-					<strong>Use CTRL + CLICK to unselect countries</strong>]]>
-			</description>
+			<fielddescr><![CDATA[<strong><center>Top 20<br /> Spammer Countries</center></strong><br />
+				<center>Use CTRL + CLICK to unselect countries</center>]]>
+			</fielddescr>
+			<description><![CDATA[<center><br />IPv4 Countries</center>]]></description>
 			<type>select</type>
-		<options>
+			<options>
 				<option><name>China-CN</name><value>CN</value></option>
 				<option><name>Russia-RU</name><value>RU</value></option>
 				<option><name>Japan-JP</name><value>JP</value></option>
@@ -169,14 +168,12 @@
 			</options>
 			<size>20</size>
 			<multiple/>
+			<usecolspan2/>
+			<combinefields>begin</combinefields>
 		</field>
 		<field>
-			<fielddescr><![CDATA[<br /><strong>Top 20 IPv6</strong><br />Spammer Countries]]></fielddescr>
 			<fieldname>countries6</fieldname>
-			<description>
-			<![CDATA[Select Top IPv6 Spammer Countries you want to take an action on.<br />
-				<strong>Use CTRL + CLICK to unselect countries</strong>]]>
-			</description>
+			<description><![CDATA[<br /><center>IPv6 Countries</center>]]></description>
 			<type>select</type>
 			<options>
 				<option><name>China-CN</name><value>CN</value></option>
@@ -199,13 +196,16 @@
 				<option><name>Taiwan-TW</name><value>TW</value></option>
 				<option><name>Mexico-MX</name><value>MX</value></option>
 				<option><name>Chilie-CL</name><value>CL</value></option>
-				</options>
-				<size>20</size>
-				<multiple/>
+			</options>
+			<size>20</size>
+			<multiple/>
+			<usecolspan2/>
+			<dontdisplayname/>
+			<combinefields>end</combinefields>
 		</field>
 		<field>
 			<fielddescr>List Action</fielddescr>
-			<description><![CDATA[<br />Default : <strong>Disabled</strong><br /><br />
+			<description><![CDATA[<br />Default: <strong>Disabled</strong><br /><br />
 				Select the <strong>Action</strong> for Firewall Rules on lists you have selected.<br /><br />
 				<strong><u>'Disabled' Rules:</u></strong> Disables selection and does nothing to selected Alias.<br /><br />
 
@@ -231,12 +231,12 @@
 				<strong><u>'Alias' Rules:</u></strong><br />
 				<strong>'Alias'</strong> rules create an <a href="/firewall_aliases.php">alias</a> for the list (and do nothing else).
 				This enables a pfBlockerNG list to be used by name, in any firewall rule or pfSense function, as desired.
-				<ul><li><strong>Options &nbsp;&nbsp; - Alias Deny,&nbsp; Alias Permit,&nbsp; Alias Match,&nbsp; Alias Native</strong></li><br />
+				<ul><li><strong>Options - Alias Deny,&nbsp; Alias Permit,&nbsp; Alias Match,&nbsp; Alias Native</strong></li><br />
 				<li>'Alias Deny' can use De-Duplication and Reputation Processes if configured.</li><br />
 				<li>'Alias Permit' and 'Alias Match' will be saved in the Same folder as the other Permit/Match Auto-Rules</li><br />
 				<li>'Alias Native' lists are kept in their Native format without any modifications.</li></ul>
 				<strong>When using 'Alias' rules, change (pfB_) to ( pfb_ ) in the beginning of rule description and Use the 'Exact' spelling of
-				the Alias (no trailing Whitespace)&nbsp;</strong> Custom 'Alias' rules with 'pfB_  xxx' description will be removed by package if
+				the Alias (no trailing Whitespace)</strong> Custom 'Alias' rules with 'pfB_  xxx' description will be removed by package if
 				using Auto Rule Creation.<br /><br /><strong>Tip</strong>: You can create the Auto Rules and remove "<u>auto rule</u>" from the Rule
 				Descriptions, then disable Auto Rules. This method will 'KEEP' these rules from being 'Deleted' which will allow editing for a Custom
 				Alias Configuration<br />]]>
@@ -262,7 +262,7 @@
 		<field>
 			<fielddescr>Enable Logging</fielddescr>
 			<fieldname>aliaslog</fieldname>
-			<description><![CDATA[Default:<strong>Enable</strong><br />
+			<description><![CDATA[Default: <strong>Enable</strong><br />
 				Select - Logging to Status: System Logs: FIREWALL ( Log )]]>
 			</description>
 			<type>select</type>
@@ -272,8 +272,87 @@
 			</options>
 		</field>
 		<field>
-			<name><![CDATA[<ul>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
-			'Force Update'</ul>]]> </name>
+			<name>Advanced Inbound Firewall Rule Settings</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<type>info</type>
+			<description><![CDATA[<font color='red'>Note: </font>In general Auto-Rules are created as follows:<br />
+				<ul>Inbound &nbsp;&nbsp;- 'any' port, 'any' protocol and 'any' destination<br />
+				Outbound - 'any' port, 'any' protocol and 'any' destination address in the lists</ul>
+				Configuring the Adv. Inbound Rule settings, will allow for more customization of the Inbound Auto-Rules.<br />
+				<strong>Select the pfSense 'Port' and/or 'Destination' Alias below:</strong>]]>
+			</description>
+		</field>
+		<field>
+			<fieldname>autoports</fieldname>
+			<fielddescr>Enable Custom Port</fielddescr>
+			<type>checkbox</type>
+			<enablefields>aliasports</enablefields>
+			<usecolspan2/>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
+			<fielddescr>Define Alias</fielddescr>
+			<fieldname>aliasports</fieldname>
+			<description><![CDATA[<a href="/firewall_aliases.php?tab=port">Click Here to add/edit Aliases</a>
+				Do not manually enter port numbers. <br />Do not use 'pfB_' in the Port Alias name.]]>
+			</description>
+			<size>21</size>
+			<type>aliases</type>
+			<typealiases>port</typealiases>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields>end</combinefields>
+		</field>
+		<field>
+			<fieldname>autodest</fieldname>
+			<fielddescr>Enable Custom Destination</fielddescr>
+			<type>checkbox</type>
+			<enablefields>aliasdest,autonot</enablefields>
+			<usecolspan2/>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
+			<fieldname>aliasdest</fieldname>
+			<description><![CDATA[<a href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>
+				Do not manually enter Addresses(es). <br />Do not use 'pfB_' in the 'IP Network Type' Alias name.]]>
+			</description>
+			<size>21</size>
+			<type>aliases</type>
+			<typealiases>network</typealiases>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields/>
+		</field>
+		<field>
+			<fielddescr>Invert</fielddescr>
+			<fieldname>autonot</fieldname>
+			<description><![CDATA[<div style="padding-left: 22px;"><strong>Invert</strong> - Option to invert the sense of the match.<br />
+				ie - Not (!) Destination Address(es)</div>]]>
+			</description>
+			<type>checkbox</type>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields>end</combinefields>
+		</field>
+		<field>
+			<fielddescr>Custom Protocol</fielddescr>
+			<fieldname>autoproto</fieldname>
+			<description><![CDATA[<strong>Default: any</strong><br />Select the Protocol used for Inbound Firewall Rule(s).]]></description>
+			<type>select</type>
+			<options>
+				<option><name>any</name><value></value></option>
+				<option><name>TCP</name><value>tcp</value></option>
+				<option><name>UDP</name><value>udp</value></option>
+				<option><name>TCP/UDP</name><value>tcp/udp</value></option>
+			</options>
+			<size>4</size>
+			<default_value></default_value>
+		</field>
+		<field>
+			<name><![CDATA[<center>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
+				'Force Update'</center>]]></name>
 			<type>listtopic</type>
 		</field>
 	</fields>

--- a/config/pfblockerng/pfblockerng_update.php
+++ b/config/pfblockerng/pfblockerng_update.php
@@ -76,7 +76,6 @@ function pfbupdate_status($status) {
 
 // Function to perform a Force Update, Cron or Reload
 function pfb_cron_update($type) {
-
 	global $pfb;
 
 	// Query for any Active pfBlockerNG CRON Jobs
@@ -87,8 +86,9 @@ function pfb_cron_update($type) {
 		exit;
 	}
 
-	if (!file_exists("{$pfb['log']}"))
+	if (!file_exists("{$pfb['log']}")) {
 		touch("{$pfb['log']}");
+	}
 
 	// Update Status Window with correct Task
 	if ($type == "update") {
@@ -102,7 +102,6 @@ function pfb_cron_update($type) {
 
 	// Remove any existing pfBlockerNG CRON Jobs
 	install_cron_job("pfblockerng.php cron", false);
-	write_config();
 
 	// Execute PHP Process in the Background
 	mwexec_bg("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php {$type} >> {$pfb['log']} 2>&1");
@@ -121,18 +120,19 @@ function pfb_cron_update($type) {
 			$lastpos = $len;
 		} else {
 			$f = fopen($pfb['log'], "rb");
-			if ($f === false)
+			if ($f === false) {
 				die();
+			}
 			fseek($f, $lastpos);
 
 			while (!feof($f)) {
 
 				$pfb_buffer = fread($f, 2048);
 				$pfb_output .= str_replace( array ("\r", "\")"), "", $pfb_buffer);
-
 				// Refresh on new lines only. This allows Scrolling.
-				if ($lastpos != $lastpos_old)
+				if ($lastpos != $lastpos_old) {
 					pfbupdate_output($pfb_output);
+				}
 				$lastpos_old = $lastpos;
 				ob_flush();
 				flush();
@@ -207,61 +207,112 @@ include_once("head.inc");
 			<tr>
 				<td colspan="2" class="listr">
 				<?php
-					// Collect Existing CRON settings
-					if (is_array($config['cron']['item'])) {
-						foreach ($config['cron']['item'] as $cron) {
-							if (preg_match("/usr.local.www.pfblockerng.pfblockerng.php cron/",$cron["command"])) {
-								$pfb_min = "{$cron['minute']}";
-								break;
+					if ($pfb['enable'] == "on") {
+
+						/* Legend - Time Variables
+
+							$pfb['interval']	Hour interval setting	(1,2,3,4,6,8,12,24)
+							$pfb['min']		Cron minute start time	(0-23)
+							$pfb['hour']		Cron start hour		(0-23)
+							$pfb['24hour']		Cron daily/wk start hr	(0-23)
+
+							$currenthour		Current hour
+							$currentmin		Current minute
+							$cron_hour_begin	First cron hour setting (interval 2-24)
+							$cron_hour_next		Next cron hour setting  (interval 2-24)
+
+							$max_min_remain		Max minutes to next cron (not including currentmin)
+							$min_remain		Total minutes remaining to next cron
+							$min_final		The minute component in hour:min
+
+							$nextcron		Next cron event in hour:mins
+							$cronreal		Time remaining to next cron in hours:mins	*/
+
+						$currenthour	= date('G');
+						$currentmin	= date('i');
+
+						if ($pfb['interval'] == 1) {
+							if (($currenthour + ($currentmin/60)) <= ($pfb['hour'] + ($pfb['min']/60))) {
+								$cron_hour_next = $currenthour;
+							} else {
+								$cron_hour_next = $currenthour + 1;
+							}
+							if (($currenthour + ($pfb['min']/60)) >= 24) {
+								$cron_hour_next = $pfb['hour'];
+							}
+							$max_min_remain = 60 + $pfb['min'];
+						}
+						elseif ($pfb['interval'] == 24) {
+							$cron_hour_next = $cron_hour_begin = $pfb['24hour'] != '' ? $pfb['24hour'] : '00';
+						}
+						else {
+							// Find Next Cron hour schedule
+							$crondata = pfb_cron_base_hour();
+							if (!empty($crondata)) {
+								foreach ($crondata as $key => $line) {
+									if ($key == 0) {
+										$cron_hour_begin = $line;
+									}
+									if ($line > $currenthour) {
+										$cron_hour_next = $line;
+										break;
+									}
+								}
+							}
+
+							// Roll over to First cron hour setting
+							if (!isset($cron_hour_next)) {
+								if (empty($cron_hour_begin)) {
+									// $cron_hour_begin is hour '0'
+									$cron_hour_next = (24 - $currenthour);
+								} else {
+									$cron_hour_next = $cron_hour_begin;
+								}
 							}
 						}
-					}
-					// Calculate Minutes Remaining till next CRON Event.
-					$currentmin = date('i');
-					switch ($pfb_min) {
-						case "0":
-							$min_remain = (60 - $currentmin);
-							break;
-						case "15":
-							if ($currentmin < 15) {
-								$min_remain = (15 - $currentmin);
-							} else {
-								$min_remain = (75 - $currentmin);
-							}
-							break;
-						case "30":
-							if ($currentmin < 30) {
-								$min_remain = (30 - $currentmin);
-							} else {
-								$min_remain = (90 - $currentmin);
-							}
-							break;
-						case "45":
-							if ($currentmin < 45) {
-								$min_remain = (45 - $currentmin);
-							} else {
-								$min_remain = (105 - $currentmin);
-							}
-							break;
-					}
 
-					// Default to "< 1 minute" if empty
-					if (empty($min_remain))
-						$min_remain = "< 1";
+						if ($pfb['interval'] != 1) {
+							if (($currenthour + ($currentmin/60)) <= ($cron_hour_next + ($pfb['min']/60))) {
+								$max_min_remain = (($cron_hour_next - $currenthour) * 60) + $pfb['min'];
+							} else {
+								$max_min_remain = ((24 - $currenthour + $cron_hour_begin) * 60) + $pfb['min'];
+								$cron_hour_next = $cron_hour_begin;
+							}
+						}
 
-					// Next Scheduled Cron Time
-					if ($pfb_min == "0")
-						$pfb_min = "00";
-					$nextcron = (date('H') +1) . ":{$pfb_min}";
+						$min_remain	= ($max_min_remain - $currentmin);
+						$min_final	= ($min_remain % 60);
+						$sec_final	= (60 - date('s'));
 
-					// If pfBlockerNG is Disabled or Cron Task is Missing
-					if (empty($pfb['enable']) || empty($pfb_min)) {
-						$min_remain = " -- ";
-						$nextcron = " [ Disabled ] ";
+						if (strlen($sec_final) == 1) {
+							$sec_final = '0' . $sec_final;
+						}
+						if (strlen($min_final) == 1) {
+							$min_final = '0' . $min_final;
+						}
+						if (strlen($cron_hour_next) == 1) {
+							$cron_hour_next = '0' . $cron_hour_next;
+						}
+
+						if ($min_remain > 59) {
+							$nextcron = floor($min_remain / 60) . ':' . $min_final . ':' . $sec_final;
+						} else {
+							$nextcron = '00:' . $min_final . ':' . $sec_final;
+						}
+
+						if ($pfb['min'] == 0) {
+							$pfb['min'] = '00';
+						}
+						$cronreal = "{$cron_hour_next}:{$pfb['min']}";
 					}
 
-					echo "NEXT Scheduled CRON Event will run at <font size=\"3\">&nbsp;{$nextcron}</font>&nbsp; in<font size=\"3\">
-						<span class=\"red\">&nbsp;{$min_remain}&nbsp;</span></font> Minutes.";
+					if (empty($pfb['enable']) || empty($cron_hour_next)) {
+						$cronreal = ' [ Disabled ]';
+						$nextcron = '--';
+					}
+
+					echo "NEXT Scheduled CRON Event will run at <font size=\"3\">&nbsp;{$cronreal}</font>&nbsp; with
+						<font size=\"3\"><span class=\"red\">&nbsp;{$nextcron}&nbsp;</span></font> time remaining.";
 
 					// Query for any Active pfBlockerNG CRON Jobs
 					$result_cron = array();
@@ -272,7 +323,7 @@ include_once("head.inc");
 						echo "<img src = '/themes/{$g['theme']}/images/icons/icon_pass.gif' width='15' height='15'
 							border='0' title='pfBockerNG Cron Task is Running.'/>";
 					}
-					echo "<br /><font size=\"3\"><span class=\"red\">Refresh</span></font> to update current Status and Minute(s) remaining";
+					echo "<br /><font size=\"3\"><span class=\"red\">Refresh</span></font> to update current Status and time remaining";
 				?>
 				</td>
 			</tr>
@@ -348,8 +399,9 @@ include("fend.inc");
 // Execute the Viewer output Window
 if (isset($_POST['pfbview'])) {
 
-	if (!file_exists("{$pfb['log']}"))
+	if (!file_exists("{$pfb['log']}")) {
 		touch("{$pfb['log']}");
+	}
 
 	// Reference: http://stackoverflow.com/questions/3218895/php-how-to-read-a-file-live-that-is-constantly-being-written-to
 	pfbupdate_status(gettext("Log Viewing in progress.    ** Press 'END VIEW' to Exit ** "));
@@ -372,8 +424,9 @@ if (isset($_POST['pfbview'])) {
 			$lastpos = $len;
 		} else {
 			$f = fopen($pfb['log'], "rb");
-			if ($f === false)
+			if ($f === false) {
 				die();
+			}
 			fseek($f, $lastpos);
 
 			while (!feof($f)) {
@@ -415,8 +468,9 @@ if (isset($_POST['pfbcron']) && $pfb['enable'] == "on") {
 
 // Execute a Reload of all Aliases and Lists
 if (isset($_POST['pfbreload']) && $pfb['enable'] == "on") {
+	// Set 'Reuse' Flag for Reload process
 	$config['installedpackages']['pfblockerng']['config'][0]['pfb_reuse'] = "on";
-	write_config();
+	write_config("pfBlockerNG: Executing Force Reload");
 	pfb_cron_update(reload);
 }
 

--- a/config/pfblockerng/pfblockerng_update.php
+++ b/config/pfblockerng/pfblockerng_update.php
@@ -151,7 +151,7 @@ function pfb_cron_update($type) {
 			ob_flush();
 			flush();
 			fclose($f);
-			# Call Log Mgmt Function
+			// Call Log Mgmt Function
 			pfb_log_mgmt();
 			die();
 		}

--- a/config/pfblockerng/pfblockerng_v4lists.xml
+++ b/config/pfblockerng/pfblockerng_v4lists.xml
@@ -54,6 +54,7 @@
 	<version>1.0</version>
 	<title>pfBlockerNG: IPv4 Alias/List Configuration</title>
 	<include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
+	<addedit_string>pfBlockerNG: Save IPv4 settings</addedit_string>
 	<menu>
 		<name>pfBlockerNG</name>
 		<tooltiptext></tooltiptext>

--- a/config/pfblockerng/pfblockerng_v4lists.xml
+++ b/config/pfblockerng/pfblockerng_v4lists.xml
@@ -149,6 +149,8 @@
 				<fielddescr>Logging</fielddescr>
 				<fieldname>aliaslog</fieldname>
 			</columnitem>
+			<addtext>Add a new Alias</addtext>
+			<movable>on</movable>
 		</adddeleteeditpagefields>
 	<fields>
 		<field>
@@ -158,15 +160,15 @@
 		</field>
 		<field>
 			<fielddescr>LINKS</fielddescr>
-			<fieldname>none</fieldname>
-			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp; <a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
+			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp;
+				<a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
 			</description>
 			<type>info</type>
 		</field>
 		<field>
 			<fielddescr>Alias Name</fielddescr>
 			<fieldname>aliasname</fieldname>
-			<description><![CDATA[Enter lists Alias Names.<br />
+			<description><![CDATA[Enter Alias Name.<br />
 				Example: Badguys<br />
 				Do not include <strong>'pfBlocker' or 'pfB_'</strong> in the Alias Name, it's done by package.<br />
 				<strong>International, special or space characters will be ignored in firewall alias names.
@@ -182,40 +184,37 @@
 			<size>90</size>
 		</field>
 		<field>
-			<fieldname>InfoLists</fieldname>
 			<type>info</type>
-			<description><![CDATA[<strong><u>'Format'</u></strong> : Select the Format Type<br /><br />
-				<strong><u>'URL'</u></strong> : Add direct link to list:
+			<description><![CDATA[<strong><u>'Format'</u></strong>: Select the Format Type<br /><br />
+				<strong><u>'URL'</u></strong>: Add direct link to list:
 				Example: <a target=_new href='http://list.iblocklist.com/?list=bt_ads&fileformat=p2p&archiveformat=gz'>Ads</a>,
 				<a target=_new href='http://list.iblocklist.com/?list=bt_spyware&fileformat=p2p&archiveformat=gz'>Spyware</a>,
-				<a target=_new href='http://list.iblocklist.com/?list=bt_proxy&fileformat=p2p&archiveformat=gz'>Proxies</a> )<br /><br />
-				<strong><u>'pfSense Local File'</u></strong> Format :<br /><br />
-				&nbsp;&nbsp;http(s)://127.0.0.1/NAME_OF_FILE &nbsp;&nbsp;<strong>or</strong>&nbsp;&nbsp; 
+				<a target=_new href='http://list.iblocklist.com/?list=bt_proxy&fileformat=p2p&archiveformat=gz'>Proxies</a><br /><br />
+				<strong><u>'pfSense Local File'</u></strong> Format:<br /><br />
+				&nbsp;&nbsp;http(s)://127.0.0.1/NAME_OF_FILE &nbsp;&nbsp;<strong>or</strong>&nbsp;&nbsp;
 				/usr/local/www/NAME_OF_FILE &nbsp;&nbsp; (Files can also be placed in the /var/db/pfblockerng folders)<br /><br />
 
-				<strong><u>'Header'</u></strong> : The <u>'Header' Field</u> must be <u>Unique</u>, it will
+				<strong><u>'Header'</u></strong>: The <u>'Header' Field</u> must be <u>Unique</u>, it will
 				name the List File and it will be referenced in the pfBlockerNG Widget.
 				Use a Unique Prefix per 'Alias Category' followed by a unique descriptor for each List.<br /><br />]]>
 			</description>
 		</field>
 		<field>
 			<fielddescr><![CDATA[<strong>IPv4</strong> Lists]]></fielddescr>
-			<fieldname>none</fieldname>
 			<description><![CDATA[<br /><strong>'Format'</strong> - Select the file format that URL will retrieve.<br />
-
-				<ul><li><strong>'txt'</strong> Plain txt Lists</li><br />
-				<li><strong>'gz'</strong> - IBlock GZ Lists in Range Format only.</li><br />
-				<li><strong>'gz_2'</strong> - Other GZ Lists in IP or CIDR only.</li><br />
-				<li><strong>'gz_lg'</strong> - Large IBlock GZ Lists in Range Format only.</li><br />
-				<li><strong>'zip'</strong> - ZIP'd Lists</li><br />
-				<li><strong>'block'</strong>- IP x.x.x.0 Block type</li><br />
-				<li><strong>'html'</strong> - Web Links</li><br />
-				<li><strong>'xlsx'</strong> - Excel Lists</li><br />
-				<li><strong>'rsync'</strong> - RSync Lists</li><br />
+				<ul><li><strong>'txt'</strong> Plain txt Lists</li>
+				<li><strong>'gz'</strong> - IBlock GZ Lists in Range Format only</li>
+				<li><strong>'gz_2'</strong> - Other GZ Lists in IP or CIDR only</li>
+				<li><strong>'gz_lg'</strong> - Large IBlock GZ Lists in Range Format only</li>
+				<li><strong>'zip'</strong> - ZIP'd Lists</li>
+				<li><strong>'block'</strong>- IP x.x.x.0 Block type</li>
+				<li><strong>'html'</strong> - Web Links</li>
+				<li><strong>'xlsx'</strong> - Excel Lists</li>
+				<li><strong>'rsync'</strong> - RSync Lists</li>
 				<li><strong>'ET' IQRisk</strong> - Only</li></ul>
-				<strong>'State'</strong> - Select the Run State for each list.<br />
-				<ul><li><strong>'ON/OFF'</strong> - Enabled / Disabled</li><br />
-				<li><strong>'HOLD'</strong> - Once a List has been Downloaded, list will remain Static.</li></ul>
+				<strong>'State'</strong> - Select the Run State for each list<br />
+				<ul><li><strong>'ON/OFF'</strong> - Enabled / Disabled</li>
+				<li><strong>'HOLD'</strong> - Once a List has been Downloaded, list will remain Static</li></ul>
 				<strong>'Note' -</strong> Downloaded or pfsense local file must have only one network per line and follows the syntax below:
 				<ul>Network ranges: <strong>172.16.1.0-172.16.1.255</strong><br />
 				IP Address: <strong>172.16.1.10</strong><br />
@@ -223,50 +222,50 @@
 			</description>
 			<type>rowhelper</type>
 			<rowhelper>
-			<rowhelperfield>
-			<fielddescr>Format</fielddescr>
-			<fieldname>format</fieldname>
-			<type>select</type>
-			<options>
-				<option><name>txt</name><value>txt</value></option>
-				<option><name>gz</name><value>gz</value></option>
-				<option><name>gz_2</name><value>gz_2</value></option>
-				<option><name>gz_lg</name><value>gz_lg</value></option>
-				<option><name>zip</name><value>zip</value></option>
-				<option><name>block</name><value>block</value></option>
-				<option><name>html</name><value>html</value></option>
-				<option><name>xlsx</name><value>xlsx</value></option>
-				<option><name>RSync</name><value>rsync</value></option>
-				<option><name>ET</name><value>et</value></option>
-			</options>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>State</fielddescr>
-				<fieldname>state</fieldname>
-				<type>select</type>
-				<options>
-					<option><name>ON</name><value>Enabled</value></option>
-					<option><name>OFF</name><value>Disabled</value></option>
-					<option><name>HOLD</name><value>Hold</value></option>
-				</options>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>URL or pfSense local file</fielddescr>
-				<fieldname>url</fieldname>
-				<type>input</type>
-				<size>50</size>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>Header</fielddescr>
-				<fieldname>header</fieldname>
-				<type>input</type>
-				<size>15</size>
-			</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Format</fielddescr>
+					<fieldname>format</fieldname>
+					<type>select</type>
+					<options>
+						<option><name>txt</name><value>txt</value></option>
+						<option><name>gz</name><value>gz</value></option>
+						<option><name>gz_2</name><value>gz_2</value></option>
+						<option><name>gz_lg</name><value>gz_lg</value></option>
+						<option><name>zip</name><value>zip</value></option>
+						<option><name>block</name><value>block</value></option>
+						<option><name>html</name><value>html</value></option>
+						<option><name>xlsx</name><value>xlsx</value></option>
+						<option><name>RSync</name><value>rsync</value></option>
+						<option><name>ET</name><value>et</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>State</fielddescr>
+					<fieldname>state</fieldname>
+					<type>select</type>
+					<options>
+						<option><name>ON</name><value>Enabled</value></option>
+						<option><name>OFF</name><value>Disabled</value></option>
+						<option><name>HOLD</name><value>Hold</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>URL or pfSense local file</fielddescr>
+					<fieldname>url</fieldname>
+					<type>input</type>
+					<size>50</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Header</fielddescr>
+					<fieldname>header</fieldname>
+					<type>input</type>
+					<size>15</size>
+				</rowhelperfield>
 			</rowhelper>
 		</field>
 		<field>
 			<fielddescr>List Action</fielddescr>
-			<description><![CDATA[<br />Default : <strong>Disabled</strong><br /><br />
+			<description><![CDATA[<br />Default: <strong>Disabled</strong><br /><br />
 				Select the <strong>Action</strong> for Firewall Rules on lists you have selected.<br /><br />
 				<strong><u>'Disabled' Rules:</u></strong> Disables selection and does nothing to selected Alias.<br /><br />
 
@@ -292,12 +291,12 @@
 				<strong><u>'Alias' Rules:</u></strong><br />
 				<strong>'Alias'</strong> rules create an <a href="/firewall_aliases.php">alias</a> for the list (and do nothing else).
 				This enables a pfBlockerNG list to be used by name, in any firewall rule or pfSense function, as desired.
-				<ul><li><strong>Options &nbsp;&nbsp; - Alias Deny,&nbsp; Alias Permit,&nbsp; Alias Match,&nbsp; Alias Native</strong></li><br />
+				<ul><li><strong>Options - Alias Deny,&nbsp; Alias Permit,&nbsp; Alias Match,&nbsp; Alias Native</strong></li><br />
 				<li>'Alias Deny' can use De-Duplication and Reputation Processes if configured.</li><br />
 				<li>'Alias Permit' and 'Alias Match' will be saved in the Same folder as the other Permit/Match Auto-Rules</li><br />
 				<li>'Alias Native' lists are kept in their Native format without any modifications.</li></ul>
 				<strong>When using 'Alias' rules, change (pfB_) to ( pfb_ ) in the beginning of rule description and Use the 'Exact' spelling of
-				the Alias (no trailing Whitespace)&nbsp;</strong> Custom 'Alias' rules with 'pfB_  xxx' description will be removed by package if
+				the Alias (no trailing Whitespace)</strong> Custom 'Alias' rules with 'pfB_  xxx' description will be removed by package if
 				using Auto Rule Creation.<br /><br /><strong>Tip</strong>: You can create the Auto Rules and remove "<u>auto rule</u>" from the Rule
 				Descriptions, then disable Auto Rules. This method will 'KEEP' these rules from being 'Deleted' which will allow editing for a Custom
 				Alias Configuration<br />]]>
@@ -324,8 +323,8 @@
 		<field>
 			<fielddescr>Update Frequency</fielddescr>
 			<fieldname>cron</fieldname>
-			<description><![CDATA[Default:<strong>Never</strong><br />
-				Select how often List files will be downloaded]]>
+			<description><![CDATA[Default: <strong>Never</strong><br />
+				Select how often List files will be downloaded. <strong>This must be within the Cron Interval/Start Hour settings.</strong>]]>
 			</description>
 			<type>select</type>
 			<options>
@@ -344,7 +343,7 @@
 		<field>
 			<fielddescr>Weekly (Day of Week)</fielddescr>
 			<fieldname>dow</fieldname>
-			<description><![CDATA[Default:<strong>1</strong><br />
+			<description><![CDATA[Default: <strong>Monday</strong><br />
 				Select the 'Weekly' ( Day of the Week ) to Update <br />
 				This is only required for the 'Weekly' Frequency Selection. The 24 Hour Download 'Time' will be used.]]>
 			</description>
@@ -362,7 +361,7 @@
 		<field>
 			<fielddescr>Enable Logging</fielddescr>
 			<fieldname>aliaslog</fieldname>
-			<description><![CDATA[Default:<strong>Enable</strong><br />
+			<description><![CDATA[Default: <strong>Enable</strong><br />
 				Select - Logging to Status: System Logs: FIREWALL ( Log )<br />
 				This can be overriden by the 'Global Logging' Option in the General Tab.]]>
 			</description>
@@ -371,6 +370,85 @@
 				<option><name>Enable</name><value>enabled</value></option>
 				<option><name>Disable</name><value>disabled</value></option>
 			</options>
+		</field>
+		<field>
+			<name>Advanced Inbound Firewall Rule Settings</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<type>info</type>
+			<description><![CDATA[<font color='red'>Note: </font>In general Auto-Rules are created as follows:<br />
+				<ul>Inbound &nbsp;&nbsp;- 'any' port, 'any' protocol and 'any' destination<br />
+				Outbound - 'any' port, 'any' protocol and 'any' destination address in the lists</ul>
+				Configuring the Adv. Inbound Rule settings, will allow for more customization of the Inbound Auto-Rules.<br />
+				<strong>Select the pfSense 'Port' and/or 'Destination' Alias below:</strong>]]>
+			</description>
+		</field>
+		<field>
+			<fieldname>autoports</fieldname>
+			<fielddescr>Enable Custom Port</fielddescr>
+			<type>checkbox</type>
+			<enablefields>aliasports</enablefields>
+			<usecolspan2/>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
+			<fielddescr>Define Alias</fielddescr>
+			<fieldname>aliasports</fieldname>
+			<description><![CDATA[<a href="/firewall_aliases.php?tab=port">Click Here to add/edit Aliases</a>
+				Do not manually enter port numbers. <br />Do not use 'pfB_' in the Port Alias name.]]>
+			</description>
+			<size>21</size>
+			<type>aliases</type>
+			<typealiases>port</typealiases>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields>end</combinefields>
+		</field>
+		<field>
+			<fieldname>autodest</fieldname>
+			<fielddescr>Enable Custom Destination</fielddescr>
+			<type>checkbox</type>
+			<enablefields>aliasdest,autonot</enablefields>
+			<usecolspan2/>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
+			<fieldname>aliasdest</fieldname>
+			<description><![CDATA[<a href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>
+				Do not manually enter Addresses(es). <br />Do not use 'pfB_' in the 'IP Network Type' Alias name.]]>
+			</description>
+			<size>21</size>
+			<type>aliases</type>
+			<typealiases>network</typealiases>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields/>
+		</field>
+		<field>
+			<fielddescr>Invert</fielddescr>
+			<fieldname>autonot</fieldname>
+			<description><![CDATA[<div style="padding-left: 22px;"><strong>Invert</strong> - Option to invert the sense of the match.<br />
+				ie - Not (!) Destination Address(es)</div>]]>
+			</description>
+			<type>checkbox</type>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields>end</combinefields>
+		</field>
+		<field>
+			<fielddescr>Custom Protocol</fielddescr>
+			<fieldname>autoproto</fieldname>
+			<description><![CDATA[<strong>Default: any</strong><br />Select the Protocol used for Inbound Firewall Rule(s).]]></description>
+			<type>select</type>
+			<options>
+				<option><name>any</name><value></value></option>
+				<option><name>TCP</name><value>tcp</value></option>
+				<option><name>UDP</name><value>udp</value></option>
+				<option><name>TCP/UDP</name><value>tcp/udp</value></option>
+			</options>
+			<size>4</size>
+			<default_value></default_value>
 		</field>
 		<field>
 			<name>IPv4 Custom list</name>
@@ -394,18 +472,19 @@
 		<field>
 			<fielddescr>Update Custom List</fielddescr>
 			<fieldname>custom_update</fieldname>
-			<description><![CDATA[Default:<strong>Disable</strong><br />
-				select - Enable Update if changes are made to this List. Cron will also resync this list at the next Scheduled Update.]]>
+			<description><![CDATA[Select - '<strong>Default</strong>' to update Custom List as per Update Frequency setting.<br />
+				Select - '<strong>Update Custom List</strong>' followed by a 'Force Update' to apply Custom List Changes.<br />
+				Cron will also resync this Custom List at the next Update Frequency.]]>
 			</description>
 			<type>select</type>
 			<options>
-				<option><name>Disable</name><value>disabled</value></option>
-				<option><name>Enable</name><value>enabled</value></option>
+				<option><name>Default</name><value>disabled</value></option>
+				<option><name>Update Custom List</name><value>enabled</value></option>
 			</options>
 		</field>
 		<field>
-			<name><![CDATA[<ul>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
-				'Force Update'</ul>]]></name>
+			<name><![CDATA[<center>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
+				'Force Update'</center>]]></name>
 			<type>listtopic</type>
 		</field>
 	</fields>

--- a/config/pfblockerng/pfblockerng_v6lists.xml
+++ b/config/pfblockerng/pfblockerng_v6lists.xml
@@ -54,6 +54,7 @@
 	<version>1.0</version>
 	<title>pfBlockerNG: IPv6 Alias/List Configuration</title>
 	<include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
+	<addedit_string>pfBlockerNG: Save IPv6 settings</addedit_string>
 	<menu>
 		<name>pfBlockerNG</name>
 		<tooltiptext></tooltiptext>

--- a/config/pfblockerng/pfblockerng_v6lists.xml
+++ b/config/pfblockerng/pfblockerng_v6lists.xml
@@ -118,7 +118,7 @@
 		<tab>
 			<text>P.S.</text>
 			<url>/pkg_edit.php?xml=/pfblockerng/pfblockerng_ProxyandSatellite.xml&amp;id=0</url>
-			</tab>
+		</tab>
 		<tab>
 			<text>Logs</text>
 			<url>/pfblockerng/pfblockerng_log.php</url>
@@ -149,6 +149,8 @@
 				<fielddescr>Logging</fielddescr>
 				<fieldname>aliaslog</fieldname>
 			</columnitem>
+			<addtext>Add a new Alias</addtext>
+			<movable>on</movable>
 		</adddeleteeditpagefields>
 	<fields>
 		<field>
@@ -157,15 +159,15 @@
 		</field>
 		<field>
 			<fielddescr>LINKS</fielddescr>
-			<fieldname>none</fieldname>
-			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp; <a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
+			<description><![CDATA[<a href="/firewall_aliases.php">Firewall Alias</a> &nbsp;&nbsp;&nbsp;
+				<a href="/firewall_rules.php">Firewall Rules</a> &nbsp;&nbsp;&nbsp; <a href="diag_logs_filter.php">Firewall Logs</a>]]>
 			</description>
 			<type>info</type>
 		</field>
 		<field>
 			<fielddescr>Alias Name</fielddescr>
 			<fieldname>aliasname</fieldname>
-			<description><![CDATA[Enter lists Alias Names.<br />
+			<description><![CDATA[Enter Alias Name.<br />
 				Example: Badguys<br />
 				Do not include <strong>'pfBlocker' or 'pfB_'</strong> in the Alias Name, it's done by package.<br />
 				<strong>International, special or space characters will be ignored in firewall alias names.
@@ -181,38 +183,35 @@
 			<size>90</size>
 		</field>
 		<field>
-			<fieldname>InfoLists</fieldname>
 			<type>info</type>
-			<description><![CDATA[<strong><u>'Format'</u></strong> : Select the Format Type<br /><br />
-				<strong><u>'URL'</u></strong> : Add direct link to list:
+			<description><![CDATA[<strong><u>'Format'</u></strong>: Select the Format Type<br /><br />
+				<strong><u>'URL'</u></strong>: Add direct link to list:
 				Example: <a target=_new href='http://list.iblocklist.com/?list=bt_ads&fileformat=p2p&archiveformat=gz'>Ads</a>,
 				<a target=_new href='http://list.iblocklist.com/?list=bt_spyware&fileformat=p2p&archiveformat=gz'>Spyware</a>,
 				<a target=_new href='http://list.iblocklist.com/?list=bt_proxy&fileformat=p2p&archiveformat=gz'>Proxies</a><br /><br />
-				<strong><u>'pfSense Local File'</u></strong> Format :<br /><br />
-				&nbsp;&nbsp;http(s)://127.0.0.1/NAME_OF_FILE &nbsp;&nbsp;<strong>or</strong>&nbsp;&nbsp; 
+				<strong><u>'pfSense Local File'</u></strong> Format:<br /><br />
+				&nbsp;&nbsp;http(s)://127.0.0.1/NAME_OF_FILE &nbsp;&nbsp;<strong>or</strong>&nbsp;&nbsp;
 				/usr/local/www/NAME_OF_FILE &nbsp;&nbsp; (Files can also be placed in the /var/db/pfblockerng folders)<br /><br />
 
-				<strong><u>'Header'</u></strong> : The <u>'Header' Field</u> must be <u>Unique</u>, it will
+				<strong><u>'Header'</u></strong>: The <u>'Header' Field</u> must be <u>Unique</u>, it will
 				name the List File and it will be referenced in the pfBlockerNG Widget.
 				Use a Unique Prefix per 'Alias Category' followed by a unique descriptor for each List.<br /><br />]]>
 			</description>
 		</field>
 		<field>
 			<fielddescr><![CDATA[<strong>IPv6</strong> Lists]]></fielddescr>
-			<fieldname>none</fieldname>
-			<description><![CDATA[<br /><strong>'Format'</strong> - Choose the file format that URL will retrieve.<br />
-
-				<ul><li><strong>'txt'</strong> Plain txt Lists</li><br />
-				<li><strong>'gz'</strong> - IBlock GZ Lists in Range Format only.</li><br />
-				<li><strong>'gz_2'</strong> - Other GZ Lists in IP or CIDR only.</li><br />
-				<li><strong>'zip'</strong> - ZIP'd Lists</li><br />
-				<li><strong>'block'</strong>- IP x.x.x.0 Block type</li><br />
-				<li><strong>'html'</strong> - Web Links</li><br />
-				<li><strong>'xlsx'</strong> - Excel Lists</li><br />
-				<li><strong>'rsync'</strong> - RSync Lists</li><br />
-				<strong>'State'</strong> - Select the Run State for each list.<br />
-				<ul><li><strong>'ON/OFF'</strong> - Enabled / Disabled</li><br />
-				<li><strong>'HOLD'</strong> - Once a List has been Downloaded, list will remain Static.</li></ul>
+			<description><![CDATA[<br /><strong>'Format'</strong> - Select the file format that URL will retrieve.<br />
+				<ul><li><strong>'txt'</strong> Plain txt Lists</li>
+				<li><strong>'gz'</strong> - IBlock GZ Lists in Range Format only</li>
+				<li><strong>'gz_2'</strong> - Other GZ Lists in IP or CIDR only</li>
+				<li><strong>'zip'</strong> - ZIP'd Lists</li>
+				<li><strong>'block'</strong>- IP x.x.x.0 Block type</li>
+				<li><strong>'html'</strong> - Web Links</li>
+				<li><strong>'xlsx'</strong> - Excel Lists</li>
+				<li><strong>'rsync'</strong> - RSync Lists</li>
+				<strong>'State'</strong> - Select the Run State for each list<br />
+				<ul><li><strong>'ON/OFF'</strong> - Enabled / Disabled</li>
+				<li><strong>'HOLD'</strong> - Once a List has been Downloaded, list will remain Static</li></ul>
 				<strong>'Note' -</strong> Downloaded or pfsense local file must have only one network per line and follows the syntax below:
 				<ul>Network ranges: <strong> TBC </strong><br />
 				IP Address: <strong> TBC </strong><br />
@@ -220,48 +219,48 @@
 			</description>
 			<type>rowhelper</type>
 			<rowhelper>
-			<rowhelperfield>
-			<fielddescr>Format</fielddescr>
-			<fieldname>format</fieldname>
-			<type>select</type>
-			<options>
-				<option><name>txt</name><value>txt</value></option>
-				<option><name>gz</name><value>gz</value></option>
-				<option><name>gz_2</name><value>gz_2</value></option>
-				<option><name>zip</name><value>zip</value></option>
-				<option><name>block</name><value>block</value></option>
-				<option><name>html</name><value>html</value></option>
-				<option><name>xlsx</name><value>xlsx</value></option>
-				<option><name>RSync</name><value>rsync</value></option>
-			</options>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>State</fielddescr>
-				<fieldname>state</fieldname>
-				<type>select</type>
-				<options>
-					<option><name>ON</name><value>Enabled</value></option>
-					<option><name>OFF</name><value>Disabled</value></option>
-					<option><name>HOLD</name><value>Hold</value></option>
-				</options>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>URL or pfSense local file</fielddescr>
-				<fieldname>url</fieldname>
-				<type>input</type>
-				<size>50</size>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>Header</fielddescr>
-				<fieldname>header</fieldname>
-				<type>input</type>
-				<size>15</size>
-			</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Format</fielddescr>
+					<fieldname>format</fieldname>
+					<type>select</type>
+					<options>
+						<option><name>txt</name><value>txt</value></option>
+						<option><name>gz</name><value>gz</value></option>
+						<option><name>gz_2</name><value>gz_2</value></option>
+						<option><name>zip</name><value>zip</value></option>
+						<option><name>block</name><value>block</value></option>
+						<option><name>html</name><value>html</value></option>
+						<option><name>xlsx</name><value>xlsx</value></option>
+						<option><name>RSync</name><value>rsync</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>State</fielddescr>
+					<fieldname>state</fieldname>
+					<type>select</type>
+					<options>
+						<option><name>ON</name><value>Enabled</value></option>
+						<option><name>OFF</name><value>Disabled</value></option>
+						<option><name>HOLD</name><value>Hold</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>URL or pfSense local file</fielddescr>
+					<fieldname>url</fieldname>
+					<type>input</type>
+					<size>50</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Header</fielddescr>
+					<fieldname>header</fieldname>
+					<type>input</type>
+					<size>15</size>
+				</rowhelperfield>
 			</rowhelper>
 		</field>
 		<field>
 			<fielddescr>List Action</fielddescr>
-			<description><![CDATA[<br />Default : <strong>Disabled</strong><br /><br />
+			<description><![CDATA[<br />Default: <strong>Disabled</strong><br /><br />
 				Select the <strong>Action</strong> for Firewall Rules on lists you have selected.<br /><br />
 				<strong><u>'Disabled' Rules:</u></strong> Disables selection and does nothing to selected Alias.<br /><br />
 
@@ -287,7 +286,7 @@
 				<strong><u>'Alias' Rules:</u></strong><br />
 				<strong>'Alias'</strong> rules create an <a href="/firewall_aliases.php">alias</a> for the list (and do nothing else).
 				This enables a pfBlockerNG list to be used by name, in any firewall rule or pfSense function, as desired.
-				<ul><li><strong>Options &nbsp;&nbsp; - Alias Deny,&nbsp; Alias Permit,&nbsp; Alias Match,&nbsp; Alias Native</strong></li><br />
+				<ul><li><strong>Options - Alias Deny,&nbsp; Alias Permit,&nbsp; Alias Match,&nbsp; Alias Native</strong></li><br />
 				<li>'Alias Deny' can use De-Duplication and Reputation Processes if configured.</li><br />
 				<li>'Alias Permit' and 'Alias Match' will be saved in the Same folder as the other Permit/Match Auto-Rules</li><br />
 				<li>'Alias Native' lists are kept in their Native format without any modifications.</li></ul>
@@ -319,8 +318,8 @@
 		<field>
 			<fielddescr>Update Frequency</fielddescr>
 			<fieldname>cron</fieldname>
-			<description><![CDATA[Default:<strong>Never</strong><br />
-				Select how often List files will be downloaded]]>
+			<description><![CDATA[Default: <strong>Never</strong><br />
+				Select how often List files will be downloaded. <strong>This must be within the Cron Interval/Start Hour settings.</strong>]]>
 			</description>
 			<type>select</type>
 			<options>
@@ -339,7 +338,7 @@
 		<field>
 			<fielddescr>Weekly (Day of Week)</fielddescr>
 			<fieldname>dow</fieldname>
-			<description><![CDATA[Default:<strong>1</strong><br />
+			<description><![CDATA[Default: <strong>Monday</strong><br />
 				Select the 'Weekly' ( Day of the Week ) to Update <br />
 				This is only required for the 'Weekly' Frequency Selection. The 24 Hour Download 'Time' will be used.]]>
 			</description>
@@ -357,7 +356,7 @@
 		<field>
 			<fielddescr>Enable Logging</fielddescr>
 			<fieldname>aliaslog</fieldname>
-			<description><![CDATA[Default:<strong>Enable</strong><br />
+			<description><![CDATA[Default: <strong>Enable</strong><br />
 				Select - Logging to Status: System Logs: FIREWALL ( Log )<br />
 				This can be overriden by the 'Global Logging' Option in the General Tab.]]>
 			</description>
@@ -366,6 +365,85 @@
 				<option><name>Enable</name><value>enabled</value></option>
 				<option><name>Disable</name><value>disabled</value></option>
 			</options>
+		</field>
+		<field>
+			<name>Advanced Inbound Firewall Rule Settings</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<type>info</type>
+			<description><![CDATA[<font color='red'>Note: </font>In general Auto-Rules are created as follows:<br />
+				<ul>Inbound &nbsp;&nbsp;- 'any' port, 'any' protocol and 'any' destination<br />
+				Outbound - 'any' port, 'any' protocol and 'any' destination address in the lists</ul>
+				Configuring the Adv. Inbound Rule settings, will allow for more customization of the Inbound Auto-Rules.<br />
+				<strong>Select the pfSense 'Port' and/or 'Destination' Alias below:</strong>]]>
+			</description>
+		</field>
+		<field>
+			<fieldname>autoports</fieldname>
+			<fielddescr>Enable Custom Port</fielddescr>
+			<type>checkbox</type>
+			<enablefields>aliasports</enablefields>
+			<usecolspan2/>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
+			<fielddescr>Define Alias</fielddescr>
+			<fieldname>aliasports</fieldname>
+			<description><![CDATA[<a href="/firewall_aliases.php?tab=port">Click Here to add/edit Aliases</a>
+				Do not manually enter port numbers. <br />Do not use 'pfB_' in the Port Alias name.]]>
+			</description>
+			<size>21</size>
+			<type>aliases</type>
+			<typealiases>port</typealiases>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields>end</combinefields>
+		</field>
+		<field>
+			<fieldname>autodest</fieldname>
+			<fielddescr>Enable Custom Destination</fielddescr>
+			<type>checkbox</type>
+			<enablefields>aliasdest,autonot</enablefields>
+			<usecolspan2/>
+			<combinefields>begin</combinefields>
+		</field>
+		<field>
+			<fieldname>aliasdest</fieldname>
+			<description><![CDATA[<a href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>
+				Do not manually enter Addresses(es). <br />Do not use 'pfB_' in the 'IP Network Type' Alias name.]]>
+			</description>
+			<size>21</size>
+			<type>aliases</type>
+			<typealiases>network</typealiases>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields/>
+		</field>
+		<field>
+			<fielddescr>Invert</fielddescr>
+			<fieldname>autonot</fieldname>
+			<description><![CDATA[<div style="padding-left: 22px;"><strong>Invert</strong> - Option to invert the sense of the match.<br />
+				ie - Not (!) Destination Address(es)</div>]]>
+			</description>
+			<type>checkbox</type>
+			<dontdisplayname/>
+			<usecolspan2/>
+			<combinefields>end</combinefields>
+		</field>
+		<field>
+			<fielddescr>Custom Protocol</fielddescr>
+			<fieldname>autoproto</fieldname>
+			<description><![CDATA[<strong>Default: any</strong><br />Select the Protocol used for Inbound Firewall Rule(s).]]></description>
+			<type>select</type>
+			<options>
+				<option><name>any</name><value></value></option>
+				<option><name>TCP</name><value>tcp</value></option>
+				<option><name>UDP</name><value>udp</value></option>
+				<option><name>TCP/UDP</name><value>tcp/udp</value></option>
+			</options>
+			<size>4</size>
+			<default_value></default_value>
 		</field>
 		<field>
 			<name>IPv6 Custom list</name>
@@ -389,18 +467,19 @@
 		<field>
 			<fielddescr>Update Custom List</fielddescr>
 			<fieldname>custom_update</fieldname>
-			<description><![CDATA[Default:<strong>Disable</strong><br />
-				Select - Enable Update if changes are made to this List. Cron will also resync this list at the next Scheduled Update.]]>
+			<description><![CDATA[Select - '<strong>Default</strong>' to update Custom List as per Update Frequency setting.<br />
+				Select - '<strong>Update Custom List</strong>' followed by a 'Force Update' to apply Custom List Changes.<br />
+				Cron will also resync this Custom List at the next Update Frequency.]]>
 			</description>
 			<type>select</type>
 			<options>
-				<option><name>Disable</name><value>disabled</value></option>
-				<option><name>Enable</name><value>enabled</value></option>
+				<option><name>Default</name><value>disabled</value></option>
+				<option><name>Update Custom List</name><value>enabled</value></option>
 			</options>
 		</field>
 		<field>
-			<name><![CDATA[<ul>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
-				'Force Update'</ul>]]></name>
+			<name><![CDATA[<center>Click to SAVE Settings and/or Rule Edits. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Changes are Applied via CRON or
+				'Force Update'</center>]]></name>
 			<type>listtopic</type>
 		</field>
 	</fields>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -125,7 +125,7 @@
 		<category>Firewall</category>
 		<pkginfolink>https://forum.pfsense.org/index.php?topic=86212.0</pkginfolink>
 		<config_file>https://packages.pfsense.org/packages/config/pfblockerng/pfblockerng.xml</config_file>
-		<version>1.08</version>
+		<version>1.09</version>
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<maintainer>BBCan177@gmail.com</maintainer>


### PR DESCRIPTION
## Changelog:

- Code Style improvements
- Add option to customize the Inbound Ports and Destination Addresses using pfSense Aliases.
- Add function to check if Cron task needs updating. Minimize Config backups.
- Cron time function moved from .php to .inc file
- Cron settings now allow for hour 'interval' customizations.
- Added preliminary code "$pfb['cron_mod']" which will only save the config when changes are found. This will avoid creating config backups when not required. Not fully implemented.
- Remove code to determine pfSense version below 2.2
- Remove code to check for presence of pfBlocker original version.
- Reduce blank lines in pfblockerng.log
- Adjust IP regex for CIDR matching
- Remove '/32' from Lists as pf strips this out anyways
- When parsing IP lists, use regex to find Ranges first before CIDR or single addresses.
- Add Input validation for IPv4/6 Tab inputs
- Improve log text in XMLRPC sync function and add missing quotes around key ['row']
- If continent blocking is used solely, Cron will check for Continent setting changes each time cron is called.
- Improve XML code style. Remove some unneeded Tags.
- Use pkg_edit.php "combinefields" tags to group settings for ease of use.
- IPv4/6 Continent Tables are now side-by-side to make it easier to configure.
- IPv4/6 Aliases can be now be re-ordered.
- Remove reference to "Gold Membership" as everyone thinks I work and collect a commission from pfSense:)
- priv.inc file, Incorrect reference for IPv4/6 tabs to pkg_edit.php when they should be pkg.php
- Complete overhaul of widget. Added "Wrench icon" to configure additional settings.
  Maxfails, Pivot to alerts tab, Sort column, and Widget Rule table Popup.
- Clicking on widget packet count will pivot to the Alerts Tab and open the filter search to show the selected packet alerts.
- Improve the collection of Local IP addresses in the Alerts Tab (function ip_in_pfb_localsub)
- Alerts Tab, remove check for previous pfSense versions
- pfblockerng_diag_dns.php, remove check for previous pfSense versions
- Update Tab, use the new Cron Interval settings to report the next cron run in hr:min:sec remaining.