### PR TITLE
haproxy-devel, include lua53 for compilation of haproxy 1.6-dev1

### DIFF
--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -158,7 +158,7 @@
 		<conflicts>haproxy-devel</conflicts>
 		<depends_on_package_pbi>haproxy-devel-1.5.11-##ARCH##.pbi</depends_on_package_pbi>
 		<build_pbi>
-			<ports_before>security/openssl</ports_before>
+			<ports_before>security/openssl lang/lua53</ports_before>
 			<custom_name>haproxy-devel</custom_name>
 			<port>net/haproxy</port>
 		</build_pbi>


### PR DESCRIPTION
haproxy-devel, include lua53 for compilation of haproxy 1.6-dev1

@rbgarga , please also check openssl version that gets compiled into the pbi today seems to be confused what version it uses when running "haproxy -vv" after installing the pbi it outputs:
Built with OpenSSL version : OpenSSL 1.0.2a 19 Mar 2015
Running on OpenSSL version : OpenSSL 1.0.1m 19 Mar 2015 (VERSIONS DIFFER!)
Should any additional build options be set? Or is it a problem with the buildserver/scripts perhaps?