### PR TITLE
haproxy-devel, dont send the root CA cert to clients when using ssl-offloading, its not needed.

### DIFF
--- a/config/haproxy-devel/pkg/haproxy.inc
+++ b/config/haproxy-devel/pkg/haproxy.inc
@@ -957,18 +957,23 @@ function haproxy_write_certificate_crl($filename, $crlid, $append = false) {
 	unset($crl);
 }
 
-function haproxy_write_certificate_fullchain($filename, $certid, $append = false) {
+function haproxy_write_certificate_fullchain($filename, $certid, $append = false, $skiproot = true) {
 	$cert = haproxy_lookup_cert($certid);
 
 	$certcontent = base64_decode($cert['crt']);
 	if (isset($cert['prv']))
 		$certcontent .= "\r\n".base64_decode($cert['prv']);
 	
-	$certchaincontent = ca_chain($cert);
-	if ($certchaincontent != "") {
-		$certcontent .= "\r\n" . $certchaincontent;
+	$ca = $cert;
+	while(!empty($ca['caref'])) {
+		$ca = lookup_ca($ca['caref']);
+		if ($ca) {
+			if ($skiproot && (cert_get_subject($ca['crt']) == cert_get_issuer($ca['crt'])))
+				break;
+			$certcontent .= "\r\n" . base64_decode($ca['crt']);
+		} else
+			break;
 	}
-	unset($certchaincontent);
 	$flags = $append ? FILE_APPEND : 0;
 	file_put_contents($filename, $certcontent, $flags);
 	unset($certcontent);
@@ -1155,7 +1160,7 @@ function haproxy_writeconf($configpath) {
 				if ($frontend['sslocsp'] == 'yes') {
 					if (!empty(haproxy_getocspurl($filename))) {
 						haproxy_write_certificate_issuer($filename . ".issuer", $frontend['ssloffloadcert']);
-						touch($filename . ".ocsp");
+						touch($filename . ".ocsp");//create initial empty file. this will trigger updates, and inform haproxy it 'should' be using ocsp
 					}
 				}
 				

--- a/config/haproxy-devel/www/haproxy_listeners_edit.php
+++ b/config/haproxy-devel/www/haproxy_listeners_edit.php
@@ -811,7 +811,8 @@ $primaryfrontends = get_haproxy_frontends($excludefrontend);
 				<input type='text' name='dcertadv' size="64" id='dcertadv' <?if(isset($pconfig['dcertadv'])) echo 'value="'.htmlspecialchars($pconfig['dcertadv']).'"';?> />
 				<br/>
 				NOTE: Paste additional ssl options(without commas) to include on ssl listening options.<br/>
-				some options: force-sslv3, force-tlsv10 force-tlsv11 force-tlsv12 no-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets
+				some options: force-sslv3, force-tlsv10 force-tlsv11 force-tlsv12 no-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets<br/>
+				Example: no-sslv3 ciphers EECDH+aRSA+AES:TLSv1+kRSA+AES:TLSv1+kRSA+3DES
 			</td>
 		</tr>
 		<tr class="haproxy_ssloffloading_enabled haproxy_primary">

--- a/config/haproxy-devel/www/haproxy_pool_edit.php
+++ b/config/haproxy-devel/www/haproxy_pool_edit.php
@@ -961,7 +961,7 @@ set by the 'retries' parameter.</div>
 			<td colspan="2" valign="top" class="listtopic">Advanced</td>
 		</tr>
 		<tr class="" align="left" id='Strict-Transport-Security'>
-			<td width="22%" valign="top" class="vncell">Strict-Transport-Security</td>
+			<td width="22%" valign="top" class="vncell">HSTS Strict-Transport-Security</td>
 			<td width="78%" class="vtable" colspan="2">
 				When configured enables "HTTP Strict Transport Security" leave empty to disable. (only used on 'http' frontends)<br/>
 				<b>WARNING! the domain will only work over https with a valid certificate!</b><br/>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -172,7 +172,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>0.24</version>
+		<version>0.25</version>
 		<status>Release</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>
@@ -186,7 +186,7 @@
 			<custom_name>haproxy-devel</custom_name>
 			<port>net/haproxy-devel</port>
 		</build_pbi>
-		<build_options>WITH_OPENSSL_PORT=yes;haproxy_UNSET_FORCE=DPCRE;haproxy_SET_FORCE=OPENSSL SPCRE</build_options>
+		<build_options>WITH_OPENSSL_PORT=yes;haproxy_UNSET_FORCE=DPCRE;haproxy_SET_FORCE=OPENSSL SPCRE LUA</build_options>
 	</package>
 	<package>
 		<name>Apache with mod_security-dev</name>


### PR DESCRIPTION
haproxy-devel, dont send the root CA cert to clients when using ssl-offloading, its not needed.
-cipher example and HSTS textual addition
-another try to include lua for haproxy1.6dev package binary