### PR TITLE
Backup pkg check if byte_convert function exists

### DIFF
--- a/config/backup/backup.inc
+++ b/config/backup/backup.inc
@@ -32,16 +32,17 @@
 */
 
 
-function byte_convert( $bytes ) {
-	if ($bytes<=0)
-		return '0 Byte';
+if (!function_exists("byte_convert")) {
+	function byte_convert( $bytes ) {
+		if ($bytes<=0)
+			return '0 Byte';
 
-	$convention=1000; //[1000->10^x|1024->2^x]
-	$s=array('B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB');
-	$e=floor(log($bytes,$convention));
-	return round($bytes/pow($convention,$e),2).' '.$s[$e];
+		$convention=1000; //[1000->10^x|1024->2^x]
+		$s=array('B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB');
+		$e=floor(log($bytes,$convention));
+		return round($bytes/pow($convention,$e),2).' '.$s[$e];
+	}
 }
-
  
 function backup_sync_package_php()
 {

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -355,7 +355,7 @@
 		<category>System</category>
 		<pkginfolink></pkginfolink>
 		<config_file>https://packages.pfsense.org/packages/config/backup/backup.xml</config_file>
-		<version>0.1.6</version>
+		<version>0.1.7</version>
 		<status>Beta</status>
 		<required_version>2.2</required_version>
 		<maintainer>markjcrane@gmail.com</maintainer>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -445,7 +445,7 @@
 		<pkginfolink></pkginfolink>
 		<config_file>https://packages.pfsense.org/packages/config/backup/backup.xml</config_file>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
-		<version>0.1.6</version>
+		<version>0.1.7</version>
 		<status>Beta</status>
 		<required_version>1.2</required_version>
 		<maintainer>markjcrane@gmail.com</maintainer>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -432,7 +432,7 @@
 		<pkginfolink></pkginfolink>
 		<config_file>https://packages.pfsense.org/packages/config/backup/backup.xml</config_file>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
-		<version>0.1.6</version>
+		<version>0.1.7</version>
 		<status>Beta</status>
 		<required_version>1.2</required_version>
 		<maintainer>markjcrane@gmail.com</maintainer>


### PR DESCRIPTION
As reported in forum https://forum.pfsense.org/index.php?topic=95790.0
When Backup and Vhosts package are both installed there can be errors
logged about Cannot redeclare byte_convert().