### PR TITLE
Fix bug in status_mail_report_add_cmd.php

### DIFF
--- a/config/mailreport/status_mail_report_add_cmd.php
+++ b/config/mailreport/status_mail_report_add_cmd.php
@@ -130,7 +130,7 @@ include("head.inc");
 			<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>">
 			<a href="status_mail_report_edit.php?id=<?php echo $reportid;?>"><input name="cancel" type="button" class="formbtn" value="<?=gettext("Cancel");?>"></a>
 			<input name="reportid" type="hidden" value="<?=htmlspecialchars($reportid);?>">
-			<?php if (isset($id) && $a_graphs[$id]): ?>
+			<?php if (isset($id) && $a_cmds[$id]): ?>
 			<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>">
 			<?php endif; ?>
 			</td>


### PR DESCRIPTION
Existing code was referencing the wrong variable (`$a_graphs` instead of `$a_cmds`), which caused the `if` test to fail, which then caused duplicate entries to be created each time the Edit function of the "Report Commands" form was submitted.  This patch fixes the issue. Tested on pfSense 2.1.5 nanobsd.