### PR TITLE
Minor Stunnel Improvements

### DIFF
--- a/config/stunnel/stunnel.inc
+++ b/config/stunnel/stunnel.inc
@@ -123,6 +123,7 @@ function stunnel_save($config) {
 	if(!is_array($config['installedpackages']['stunnel']['config'])) { $config['installedpackages']['stunnel']['config']=Array(); }
 	foreach($config['installedpackages']['stunnel']['config'] as $pkgconfig) {
 		fwrite($fout, "\n[" . $pkgconfig['description'] . "]\n");
+		if($pkgconfig['client']) fwrite($fout, "client = yes" . "\n");
 		if($pkgconfig['certificate']) {
 			if(file_exists('/usr/local/etc/stunnel/'.$pkgconfig['certificate'].'.key') and
 			   file_exists('/usr/local/etc/stunnel/'.$pkgconfig['certificate'].'.chain')) {

--- a/config/stunnel/stunnel.xml
+++ b/config/stunnel/stunnel.xml
@@ -158,7 +158,7 @@
 	</fields>
 	<service>
 	  <name>stunnel</name>
-	  <rcfile>/usr/local/etc/rc.d/stunnel.sh</rcfile>
+	  <rcfile>stunnel.sh</rcfile>
 	  <executable>stunnel</executable>
 	</service>
 	<include_file>/usr/local/pkg/stunnel.inc</include_file>

--- a/config/stunnel/stunnel.xml
+++ b/config/stunnel/stunnel.xml
@@ -116,6 +116,12 @@
 			<type>input</type>
 		</field>
 		<field>
+			<fielddescr>Client Mode?</fielddescr>
+			<fieldname>client</fieldname>
+			<description>Use client mode for this tunnel (i.e. connect to an SSL server, do not act as an SSL server)</description>
+			<type>checkbox</type>
+		</field>
+		<field>
 			<fielddescr>Listen on IP</fielddescr>
 			<fieldname>localip</fieldname>
 			<description>Enter the local IP address to bind this redirection to.</description>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -930,7 +930,7 @@
 		<descr>An SSL encryption wrapper between remote client and local or remote servers. </descr>
 		<category>Network Management</category>
 		<depends_on_package_pbi>stunnel-5.07-##ARCH##.pbi</depends_on_package_pbi>
-		<version>5.07</version>
+		<version>5.07.1</version>
 		<status>Stable</status>
 		<pkginfolink>https://doc.pfsense.org/index.php/Stunnel_package</pkginfolink>
 		<required_version>2.2</required_version>


### PR DESCRIPTION
This fixes stunnel start/stop from the GUI by correcting the rcfile in stunnel.xml and adds the ability to create client mode tunnels from the GUI.

Tested with a local package repository and it appears to work properly.

The package still fails to start if the "cert = ..." line is present, which I think is due to an outdated package.  Installing stunnel 5.19 with "pkg install stunnel" fixes that issue, so I think the pbi needs to be updated as well, but I don't have access to the pfsense-tools repo to hack on that.