### PR TITLE
apache_mod_security-dev - fix Bug #3360, Bug #4421

### DIFF
--- a/config/apache_mod_security-dev/apache_mod_security.inc
+++ b/config/apache_mod_security-dev/apache_mod_security.inc
@@ -603,8 +603,8 @@ EOF;
 						}
 	
 						$vh_config.=" <Location ".($backend['sitepath'] ? $backend['sitepath'] : "/").">\n";
-						$vh_config.="  ProxyPass        balancer://{$backend['balancer']}{$backend['backendpath']}\n";
-						$vh_config.="  ProxyPassReverse balancer://{$backend['balancer']}{$backend['backendpath']}\n";
+						$vh_config.="  ProxyPass        balancer://{$backend['balancer']}".($backend['backendpath'] ? $backend['backendpath'] : "/")."\n";
+						$vh_config.="  ProxyPassReverse balancer://{$backend['balancer']}".($backend['backendpath'] ? $backend['backendpath'] : "/")."\n";
 						if ($backend['compress']== "no")
 							$vh_config.="  SetInputFilter   INFLATE\n  SetOutputFilter  INFLATE\n";
 						if ($backend['modsecgroup']!="" && $backend['modsecgroup']!="none" && $mods_settings['enablemodsecurity']=="on"){

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -201,7 +201,7 @@
 			In addition this package allows URL forwarding which can be convenient for hosting multiple websites behind pfSense using 1 IP address.<br>
 			<b>Backup your location config before updating from 0.2.x to 0.3 package version.</b>]]></descr>
 		<category>Network Management</category>
-		<version>0.43</version>
+		<version>0.44</version>
 		<status>ALPHA</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/apache_mod_security-dev/apache_virtualhost.xml</config_file>


### PR DESCRIPTION
Leaving the Backend Path blank does not add / to backendpath in configuration, contrary to what's suggested in the GUI, resulting in HTTP 503 Error.