### PR TITLE
General freeradius2 cleanup and fix for #4346

### DIFF
--- a/config/freeradius2/freeradius.inc
+++ b/config/freeradius2/freeradius.inc
@@ -76,6 +76,7 @@ if ($pfs_version == "2.2") {
 	}
 	
 function freeradius_deinstall_command() {
+	exec("killall -9 radiusd");
 	return;
 }
 

--- a/config/freeradius2/freeradius.inc
+++ b/config/freeradius2/freeradius.inc
@@ -76,7 +76,15 @@ if ($pfs_version == "2.2") {
 	}
 	
 function freeradius_deinstall_command() {
-	exec("killall -9 radiusd");
+	$pidFile = "/var/run/radiusd.pid";
+	$i = 0;
+
+	while (isvalidpid($pidFile) && $i < 3) {
+		$sig = ($i == 2 ? SIGKILL : SIGTERM);
+		sigkillbypid($pidFile, $sig);
+		sleep(1);
+		$i++;
+	}
 	return;
 }
 

--- a/config/freeradius2/freeradius_view_config.php
+++ b/config/freeradius2/freeradius_view_config.php
@@ -100,8 +100,8 @@ else{
 		display_top_tabs($tab_array);
 	?>
 			</td></tr>
-	 		<tr>
-	    		<td>
+			<tr>
+				<td>
 					<div id="mainarea">
 						<table class="tabcont" width="100%" border="0" cellpadding="8" cellspacing="0">
 						<tr><td></td></tr>
@@ -126,8 +126,8 @@ else{
 							</td>
 								</tr>
 								<tr>
-	     						<td class="tabcont" >
-	     						<div id="file_div"></div>
+								<td class="tabcont" >
+								<div id="file_div"></div>
 									
 								</td>
 							</tr>

--- a/config/freeradius2/freeradiusauthorizedmacs.xml
+++ b/config/freeradius2/freeradiusauthorizedmacs.xml
@@ -101,61 +101,6 @@
 			<url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
 		</tab>
 	</tabs>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradius.inc</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/www/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradius_view_config.php</item>
-	</additional_files_needed>	
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiusclients.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiussettings.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiuseapconf.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiussqlconf.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiusinterfaces.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiuscerts.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiussync.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiusmodulesldap.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/freeradius2/freeradiusauthorizedmacs.xml</item>
-	</additional_files_needed>
 	<adddeleteeditpagefields>
 		<columnitem>
 			<fielddescr>MAC Address</fielddescr>

--- a/config/freeradius2/freeradiusauthorizedmacs.xml
+++ b/config/freeradius2/freeradiusauthorizedmacs.xml
@@ -54,13 +54,6 @@
 		<section>Services</section>
 		<url>/pkg.php?xml=freeradiusauthorizedmacs.xml</url>
 	</menu>
-	<service>
-		<name>radiusd</name>
-		<rcfile>radiusd.sh</rcfile>
-		<executable>radiusd</executable>
-		<description><![CDATA[FreeRADIUS Server]]></description>
-	</service>
-
 	<tabs>
 		<tab>
 			<text>Users</text>

--- a/config/freeradius2/freeradiusauthorizedmacs.xml
+++ b/config/freeradius2/freeradiusauthorizedmacs.xml
@@ -45,7 +45,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiusauthorizedmacs</name>
-	<version>2.1.12</version>
+	<version>2.2.0</version>
 	<title>FreeRADIUS: MACs</title>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>
 	<menu>

--- a/config/freeradius2/freeradiuscerts.xml
+++ b/config/freeradius2/freeradiuscerts.xml
@@ -45,7 +45,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiuscerts</name>
-	<version>none</version>
+	<version>2.2.0</version>
 	<title>FreeRADIUS: Certificates</title>
 	<aftersaveredirect>pkg_edit.php?xml=freeradiuscerts.xml&amp;id=0</aftersaveredirect>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>

--- a/config/freeradius2/freeradiusclients.xml
+++ b/config/freeradius2/freeradiusclients.xml
@@ -45,7 +45,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiusclients</name>
-	<version>none</version>
+	<version>2.2.0</version>
 	<title>FreeRADIUS: Clients</title>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>
 	<tabs>

--- a/config/freeradius2/freeradiuseapconf.xml
+++ b/config/freeradius2/freeradiuseapconf.xml
@@ -46,7 +46,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiuseapconf</name>
-	<version>none</version>
+	<version>2.2.0</version>
 	<title>FreeRADIUS: EAP</title>
 	<aftersaveredirect>pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</aftersaveredirect>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>

--- a/config/freeradius2/freeradiusinterfaces.xml
+++ b/config/freeradius2/freeradiusinterfaces.xml
@@ -45,7 +45,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>freeradiusinterfaces</name>
-	<version>none</version>
+	<version>2.2.0</version>
 	<title>FreeRADIUS: Interfaces</title>
 	<include_file>/usr/local/pkg/freeradius.inc</include_file>
 	<tabs>

--- a/config/freeradius2/freeradiussync.xml
+++ b/config/freeradius2/freeradiussync.xml
@@ -56,12 +56,6 @@ POSSIBILITY OF SUCH DAMAGE.
 		<section>Services</section>
 		<url>/pkg.php?xml=freeradiussync.xml</url>
 	</menu>
-	<service>
-		<name>FreeRADIUS</name>
-		<rcfile>radiusd.sh</rcfile>
-		<executable>radiusd</executable>
-		<description><![CDATA[The FreeRADIUS daemon.]]></description>
-	</service>
 	<tabs>
 		<tab>
 			<text>Users</text>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -886,7 +886,7 @@
 					On pfSense docs there is a how-to which could help you on porting users.]]></descr>
 		<pkginfolink>https://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
 		<category>System</category>
-		<version>1.6.13</version>
+		<version>1.6.14</version>
 		<status>RC1</status>
 		<required_version>2.2</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1041,7 +1041,7 @@
 					On pfSense docs there is a how-to which could help you on porting users.]]></descr>
 		<pkginfolink>https://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
 		<category>System</category>
-		<version>1.6.13</version>
+		<version>1.6.14</version>
 		<status>RC1</status>
 		<required_version>2.1</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1028,7 +1028,7 @@
 					On pfSense docs there is a how-to which could help you on porting users.]]></descr>
 		<pkginfolink>https://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
 		<category>System</category>
-		<version>1.6.13</version>
+		<version>1.6.14</version>
 		<status>RC1</status>
 		<required_version>2.1</required_version>
 		<maintainer>nachtfalkeaw@web.de</maintainer>


### PR DESCRIPTION
Replaces pull  #831

Removed and from files other than freeradius.xml, since that is the main package config file where these things need to be defined.

Kill radiusd processes during deinstall. RC script fails to stop radiusd process because it calls script from freeradius package and that package is uninstalled before RC script is called. #4346