### PR TITLE
tinydns - fix Bug #2720

### DIFF
--- a/config/tinydns/tinydns.inc
+++ b/config/tinydns/tinydns.inc
@@ -1163,7 +1163,7 @@ function tinydns_dnscache_forwarding_servers($index) {
 		exec("rm -R {$g['varetc_path']}/dnscache/root/servers/");
 	exec("/bin/mkdir -p {$g['varetc_path']}/dnscache{$index}/root/servers/");
 	if (intval($config['version']) >= 6)
-		if (file_exists("{$g['varetc_path']}/nameserver_*")) {
+		if (!empty(glob("{$g['varetc_path']}/nameserver_*"))) {
 			exec("/bin/cat {$g['varetc_path']}/nameserver_* > {$g['varetc_path']}/dnscache{$index}/root/servers/@");
 		} else {
 			$fw = fopen("{$g['varetc_path']}/dnscache{$index}/root/servers/@", "w");

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -686,7 +686,7 @@
 		<descr>pfSense version of TinyDNS which features failover host support</descr>
 		<website>http://cr.yp.to/djbdns.html</website>
 		<category>Services</category>
-		<version>1.0.6.21</version>
+		<version>1.0.6.22</version>
 		<status>Beta</status>
 		<pkginfolink>https://doc.pfsense.org/index.php/Tinydns_package</pkginfolink>
 		<required_version>2.2</required_version>


### PR DESCRIPTION
Add patch by Yonas Yanfa; cannot use file_exists with wildcard.