### PR TITLE
ntopng - Some more fixes for this package

### DIFF
--- a/config/ntopng/ntopng.xml
+++ b/config/ntopng/ntopng.xml
@@ -287,7 +287,8 @@
 		foreach(glob("{$source_dir}/Geo*.dat*") as $geofile) {
 			/* Decompress if needed. */
 			if (substr($geofile, -3, 3) == ".gz") {
-				mwexec("/usr/bin/gzip -d " . escapeshellarg($geofile));
+				// keep -f here, otherwise the files will not get updated
+				mwexec("/usr/bin/gzip -d -f " . escapeshellarg($geofile));
 			}
 		}
 


### PR DESCRIPTION
Need to run gzip -d with --force switch, otherwise the files don't get decompressed on update:
```
php-fpm[90509]: /pkg_mgr_install.php: The command '/usr/bin/gzip -d '/usr/pbi/ntopng-amd64/share/ntopng/GeoLiteCityv6.dat.gz'' returned exit code '1', the output was 'gzip: /usr/pbi/ntopng-amd64/share/ntopng/GeoLiteCityv6.dat already exists -- skipping'
```