### PR TITLE
ntopng - need to create $target_dir before symlinking

### DIFF
--- a/config/ntopng/ntopng.xml
+++ b/config/ntopng/ntopng.xml
@@ -284,6 +284,8 @@
 			$source_dir = "/usr/local/share/ntopng";
 		}
 
+		safe_mkdir($target_dir, 0755);
+
 		foreach(glob("{$source_dir}/Geo*.dat*") as $geofile) {
 			/* Decompress if needed. */
 			if (substr($geofile, -3, 3) == ".gz") {

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -300,7 +300,7 @@
 			<ports_before>databases/redis databases/gdbm net/GeoIP x11-fonts/font-util x11-fonts/webfonts graphics/graphviz</ports_before>
 			<port>net/ntopng</port>
 		</build_pbi>
-		<version>0.7</version>
+		<version>0.7.1</version>
 		<status>ALPHA</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/ntopng/ntopng.xml</config_file>


### PR DESCRIPTION
The target directory does not exist on reinstall. Need to create it to avoid these errors:

```
Starting package ntopng...
Warning: symlink(): No such file or directory in /etc/inc/pkg-utils.inc(423) : eval()'d code on line 159
Warning: symlink(): No such file or directory in /etc/inc/pkg-utils.inc(423) : eval()'d code on line 159
Warning: symlink(): No such file or directory in /etc/inc/pkg-utils.inc(423) : eval()'d code on line 159
Warning: symlink(): No such file or directory in /etc/inc/pkg-utils.inc(423) : eval()'d code on line 159
```