### PR TITLE
Bug #4612 - fix syslog-ng logrotate cron job

### DIFF
--- a/config/syslog-ng/syslog-ng.inc
+++ b/config/syslog-ng/syslog-ng.inc
@@ -69,6 +69,7 @@ function syslogng_deinstall_command() {
 	if (is_link("/usr/local/lib/syslog-ng"))
 		unlink_if_exists("/usr/local/lib/syslog-ng");
 	syslogng_install_cron(false);
+	unlink_if_exists("/usr/local/etc/logrotate.conf");
 	conf_mount_ro();
 	filter_configure();
 }

--- a/config/syslog-ng/syslog-ng.inc
+++ b/config/syslog-ng/syslog-ng.inc
@@ -70,6 +70,7 @@ function syslogng_deinstall_command() {
 		unlink_if_exists("/usr/local/lib/syslog-ng");
 	syslogng_install_cron(false);
 	unlink_if_exists("/usr/local/etc/logrotate.conf");
+	unlink_if_exists("/usr/local/etc/syslog-ng.conf");
 	conf_mount_ro();
 	filter_configure();
 }

--- a/config/syslog-ng/syslog-ng.inc
+++ b/config/syslog-ng/syslog-ng.inc
@@ -165,7 +165,7 @@ function syslogng_install_cron($should_install) {
 				$cron_item['month'] = "*";
 				$cron_item['wday'] = "*";
 				$cron_item['who'] = "root";
-				$cron_item['command'] = "/usr/bin/nice -n20 /usr/local/sbin/logrotate /usr/local/etc/logrotate.conf";
+				$cron_item['command'] = "/usr/bin/nice -n20 " . SYSLOGNG_BASEDIR .  "local/sbin/logrotate /usr/local/etc/logrotate.conf";
 				$config['cron']['item'][] = $cron_item;
 				$need_write = true;
 			}

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1463,7 +1463,7 @@
 		<website>http://www.balabit.com/network-security/syslog-ng/</website>
 		<descr>Syslog-ng syslog server. This service is not intended to replace the default pfSense syslog server but rather acts as an independent syslog server.</descr>
 		<category>Services</category>
-		<version>1.0.6</version>
+		<version>1.0.7</version>
 		<status>ALPHA</status>
 		<required_version>2.2</required_version>
 		<depends_on_package_pbi>syslog-ng-3.6.2_3-##ARCH##.pbi</depends_on_package_pbi>


### PR DESCRIPTION
Fix the path to logrotate binary + clean up after itself on uninstall.