### PR TITLE
mtr-nox11 - multiple improvements plus code style fixes

### DIFF
--- a/config/mtr-nox11/mtr-nox11.xml
+++ b/config/mtr-nox11/mtr-nox11.xml
@@ -2,54 +2,53 @@
 <!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
-        <copyright>
-        <![CDATA[
+	<copyright>
+	<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    authng.xml
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2007 to whom it may belong
-    All rights reserved.
-
-    Based on m0n0wall (http://m0n0.ch/wall)
-    Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
+	mtr-nox11.xml
+	part of pfSense (http://www.pfSense.com)
+	Copyright (C) 2014-2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
-        </copyright>
-    <description>Describe your package here</description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
+	<description>Describe your package here</description>
+	<requirements>Describe your package requirements here</requirements>
+	<faq>Currently there are no FAQ items provided.</faq>
 	<name>mtr</name>
-	<version>0.65_2</version>
+	<version>0.85_3</version>
 	<title>Diagnostics: mtr</title>
-	<savetext>mtr</savetext>
+	<savetext>Run mtr</savetext>
 	<preoutput>yes</preoutput>
+	<!-- Invokes a simple input menu and will not update the configuration database. -->
 	<donotsave>true</donotsave>
 	<!-- Menu is where this packages menu will appear -->
 	<menu>
@@ -58,36 +57,86 @@
 		<section>Diagnostics</section>
 		<configfile>mtr-nox11.xml</configfile>
 	</menu>
-        <!-- Do not save invokes a simple input menu and will not update
-             the configuration database. -->
 	<fields>
 		<field>
-                    <fielddescr>IP or Hostname</fielddescr>
-                    <fieldname>hostname</fieldname>
-                    <description>Enter the IP address or hostname that you would like to traceroute to.</description>
-                    <type>input</type>
+			<fielddescr>IP or Hostname</fielddescr>
+			<fieldname>hostname</fieldname>
+			<description>Enter the IP address or hostname that you would like to traceroute to.</description>
+			<type>input</type>
+			<required>true</required>
 		</field>
-                <field>
-                    <fielddescr>Count</fielddescr>
-                    <fieldname>count</fieldname>
-                    <description>This is the number of pings to send, each one takes 1 second</description>
-                    <type>input</type>
-                    <typehint>Defaults to 10</typehint>
-                </field>
-                <field>
-                    <fielddescr>No DNS Lookup</fielddescr>
-                    <fieldname>nodns</fieldname>
-                    <description>Use this option to force mtr to display numeric IP numbers and not try to resolve the host names</description>
-		    <type>checkbox</type>
-                </field>
-        </fields>
-        <custom_add_php_command>
-            $mtr_options = " -r";
-            if($_POST['count']) $mtr_options .= " -c " . $_POST['count'];
-	    if($_POST['nodns']) $mtr_options .= " -n";
-            $mtr_options .= " " . $_POST['hostname'];
-            system("/usr/local/sbin/mtr" . $mtr_options);
-        </custom_add_php_command>
-		<custom_php_deinstall_command>
-		</custom_php_deinstall_command>
+		<field>
+			<fielddescr>Count</fielddescr>
+			<fieldname>count</fieldname>
+			<description>This is the number of pings to send, each one takes 1 second.</description>
+			<type>input</type>
+			<typehint>(Defaults to 10)</typehint>
+		</field>
+		<field>
+			<fielddescr>No DNS Lookup</fielddescr>
+			<fieldname>nodns</fieldname>
+			<description>Use this option to force mtr to display numeric IP numbers and not try to resolve the host names.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Show IPs</fielddescr>
+			<fieldname>showips</fieldname>
+			<description>Use this option to tell mtr to display both the host names and numeric IP numbers.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Raw Output Format</fielddescr>
+			<fieldname>raw</fieldname>
+			<description>Use this option to tell mtr to use the raw output format.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Interval</fielddescr>
+			<fieldname>interval</fieldname>
+			<description>Use this option to specify the positive number of seconds between ICMP ECHO requests.</description>
+			<type>input</type>
+			<typehint>(Default is 1 second.)</typehint>
+		</field>
+		<field>
+			<fielddescr>Use IPv4 only</fielddescr>
+			<fieldname>ipv4only</fieldname>
+			<description>Use this option to use IPv4 only.</description>
+			<type>checkbox</type>
+		</field>
+	</fields>
+	<custom_add_php_command>
+	<![CDATA[
+	/* Do some basic input validation/sanitation here */
+	$int_count = (is_numeric($_POST['count']) ? (int)$_POST['count'] : 10);
+	$int_interval = (is_numeric($_POST['interval']) ? (int)$_POST['interval'] : 1);
+
+	if (!is_hostname($_POST['hostname']) && !is_ipaddr($_POST['hostname'])) {
+		echo "<div class=\"errmsg\">ERROR: No valid IP or Hostname given. Fix this and try again!</div>";
+		echo "\n<input class=\"formbtn\" type=\"button\" value=\"Back to mtr\" onclick=\"history.back()\">";
+		die();
+	}
+
+	/* Set up the configured options */
+	/* Use wide report mode to not cut hostnames in the report */
+	$mtr_options = " -w";
+	$mtr_options .= " -c " . $int_count;
+	if ($_POST['nodns']) {
+		$mtr_options .= " -n";
+	}
+	if ($_POST['showips']) {
+		$mtr_options .= " -b";
+	}
+	if ($_POST['raw']) {
+		$mtr_options .= " -l";
+	}
+	$mtr_options .= " -i " . $int_interval;
+	if ($_POST['ipv4only']) {
+		$mtr_options .= " -4";
+	}
+	$mtr_options .= " " . $_POST['hostname'];
+	echo "Running mtr $mtr_options:\n\n";
+	system("/usr/local/sbin/mtr" . $mtr_options);
+	echo "\n<input class=\"formbtn\" type=\"button\" value=\"Back to mtr\" onclick=\"history.back()\">";
+	]]>
+	</custom_add_php_command>
 </packagegui>

--- a/config/mtr-nox11/mtr-nox11.xml
+++ b/config/mtr-nox11/mtr-nox11.xml
@@ -107,8 +107,8 @@
 	<custom_add_php_command>
 	<![CDATA[
 	/* Do some basic input validation/sanitation here */
-	$int_count = (is_numeric($_POST['count']) ? (int)$_POST['count'] : 10);
-	$int_interval = (is_numeric($_POST['interval']) ? (int)$_POST['interval'] : 1);
+	$int_count = (is_numeric($_POST['count']) ? (abs(intval($_POST['count']))) : 10);
+	$int_interval = (is_numeric($_POST['interval']) ? (abs(intval($_POST['interval']))) : 1);
 
 	if (!is_hostname($_POST['hostname']) && !is_ipaddr($_POST['hostname'])) {
 		echo "<div class=\"errmsg\">ERROR: No valid IP or Hostname given. Fix this and try again!</div>";

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -988,7 +988,7 @@
 		<website>http://www.bitwizard.nl/mtr/</website>
 		<category>Network Management</category>
 		<depends_on_package_pbi>mtr-0.85_1-##ARCH##.pbi</depends_on_package_pbi>
-		<version>0.85_2</version>
+		<version>0.85_3</version>
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/mtr-nox11/mtr-nox11.xml</config_file>


### PR DESCRIPTION
## New features
1. Change the report format to wide to avoid cut off hostnames.
2. Added multiple options:
   * --no-dns (skip DNS lookups)
   * --show-ips (display both the host names and numeric IP numbers)
   * --raw (raw output format)
   * --interval (specify interval between ICMP reqs)
   * -4 (use IPv4 only)
3. Command options are shown before the output
4. Added a Back button after command output, to go back to mtr menu

## Code fixes
1. Add basic input validation
   * check valid hostname/IP, also mark the field as required
   * on invalid count input, default to 10, otherwise, convert the input to integer
   * Added a Back button after failed input validation

## Style fixes
Fix indentation, fix package name in header, fix copyright, etc.