### PR TITLE
ntopng - attempt to reduce log spam

### DIFF
--- a/config/ntopng/ntopng.xml
+++ b/config/ntopng/ntopng.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
 	<copyright>
 	<![CDATA[
@@ -8,7 +8,7 @@
 /* ========================================================================== */
 /*
 	ntopng.xml
-	part of pfSense (https://www.pfsense.org/)
+	part of pfSense (http://www.pfSense.com)
 	Copyright (C) 2014 ESF, LLC
 	All rights reserved.
 */
@@ -146,7 +146,7 @@
 		config_lock();
 		global $config;
 		global $input_errors;
-		global $pf_version;
+		global $pf_version, $scripts_path, $fonts_path;
 		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 		if ($_POST) {
 			$config['installedpackages']['ntopng']['config'] = array();
@@ -271,7 +271,7 @@
 		$geolite_city_v6 = "https://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz";
 		$geoip_asnum = "https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz";
 		$geoip_asnum_v6 = "https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz";
-		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
+
 		if ($pf_version == "2.1" || $pf_version == "2.2") {
 			$output_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/share/ntopng";
 		} else {
@@ -287,7 +287,6 @@
 		restart_service("ntopng");
 	}
 	function ntopng_fixup_geoip() {
-		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 		if ($pf_version == "2.1" || $pf_version == "2.2") {
 			$target_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/local/share/ntopng/httpdocs/geoip";
 			$source_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/share/ntopng";
@@ -330,7 +329,6 @@
 	</custom_php_install_command>
 	<custom_php_deinstall_command>
 		exec("rm /usr/local/etc/rc.d/ntopng*");
-		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 		if ($pf_version == "2.1" || $pf_version == "2.2") {
 			if (is_dir("/usr/local/share/ntopng/")) {
 				exec("rm -rf /usr/local/share/ntopng/");

--- a/config/ntopng/ntopng.xml
+++ b/config/ntopng/ntopng.xml
@@ -8,7 +8,7 @@
 /* ========================================================================== */
 /*
 	ntopng.xml
-	part of pfSense (http://www.pfSense.com)
+	part of pfSense (https://www.pfsense.org/)
 	Copyright (C) 2014 ESF, LLC
 	All rights reserved.
 */

--- a/config/ntopng/ntopng.xml
+++ b/config/ntopng/ntopng.xml
@@ -39,7 +39,7 @@
 	]]>
 	</copyright>
 	<name>ntopng</name>
-	<version>1.2 v0.5</version>
+	<version>0.7.2</version>
 	<title>Diagnostics: ntopng Settings</title>
 	<savetext>Change</savetext>
 	<aftersaveredirect>pkg_edit.php?xml=ntopng.xml</aftersaveredirect>
@@ -146,6 +146,8 @@
 		config_lock();
 		global $config;
 		global $input_errors;
+		global $pf_version;
+		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 		if ($_POST) {
 			$config['installedpackages']['ntopng']['config'] = array();
 			$config['installedpackages']['ntopng']['config'][0] = $_POST;
@@ -156,15 +158,26 @@
 		safe_mkdir("/var/db/ntopng/rrd/graphics", 0755, true);
 		system("/bin/chmod -R 755 /var/db/ntopng");
 		system("/usr/sbin/chown -R nobody:nobody /var/db/ntopng");
-		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
+		
 		if ($pf_version == "2.2") {
 			$fonts_path = "/usr/pbi/ntopng-" . php_uname("m") . "/local/lib/X11/fonts";
+			$scripts_path = "/usr/pbi/ntopng-" . php_uname("m") . "/local/share/ntopng/scripts";
 		} else if ($pf_version == "2.1") {
 			$fonts_path = "/usr/pbi/ntopng-" . php_uname("m") . "/lib/X11/fonts";
+			$scripts_path = "/usr/pbi/ntopng-" . php_uname("m") . "/share/ntopng/scripts";
 		} else {
 			$fonts_path = "/usr/local/lib/X11/fonts";
 		}
+		if ($pf_version == "2.1" || $pf_version == "2.2") {
+			$ntopng_share_path = "/usr/local/share/ntopng";
+			$scripts_link_path = $ntopng_share_path . "/scripts";
+			safe_mkdir("$ntopng_share_path", 0755, true);
+			if (!file_exists($scripts_link_path)) {
+				symlink($scripts_path, $scripts_link_path);
+			}
+		}
 		system("/bin/cp -Rp {$fonts_path}/webfonts/ {$fonts_path}/TTF/");
+
 		$first = 0;
 		foreach($ntopng_config['interface_array'] as $iface) {
 			$if = convert_friendly_interface_to_real_interface_name($iface);
@@ -211,7 +224,6 @@
 			$disable_alerts = "-H";
 		}
 
-		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 		if ($pf_version == "2.2") {
 			$redis_path = "/usr/pbi/ntopng-" . php_uname("m") . "/local/bin";
 		} else if ($pf_version == "2.1") {
@@ -259,7 +271,7 @@
 		$geolite_city_v6 = "https://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz";
 		$geoip_asnum = "https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz";
 		$geoip_asnum_v6 = "https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz";
-		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
+
 		if ($pf_version == "2.1" || $pf_version == "2.2") {
 			$output_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/share/ntopng";
 		} else {
@@ -275,7 +287,6 @@
 		restart_service("ntopng");
 	}
 	function ntopng_fixup_geoip() {
-		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 		if ($pf_version == "2.1" || $pf_version == "2.2") {
 			$target_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/local/share/ntopng/httpdocs/geoip";
 			$source_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/share/ntopng";
@@ -318,6 +329,11 @@
 	</custom_php_install_command>
 	<custom_php_deinstall_command>
 		exec("rm /usr/local/etc/rc.d/ntopng*");
+		if ($pf_version == "2.1" || $pf_version == "2.2") {
+			if (is_dir("/usr/local/share/ntopng/")) {
+				exec("rm -rf /usr/local/share/ntopng/");
+			}
+		}
 	</custom_php_deinstall_command>
 	<custom_php_validation_command>
 	<![CDATA[

--- a/config/ntopng/ntopng.xml
+++ b/config/ntopng/ntopng.xml
@@ -271,7 +271,7 @@
 		$geolite_city_v6 = "https://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz";
 		$geoip_asnum = "https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz";
 		$geoip_asnum_v6 = "https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz";
-
+		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 		if ($pf_version == "2.1" || $pf_version == "2.2") {
 			$output_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/share/ntopng";
 		} else {
@@ -287,6 +287,7 @@
 		restart_service("ntopng");
 	}
 	function ntopng_fixup_geoip() {
+		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 		if ($pf_version == "2.1" || $pf_version == "2.2") {
 			$target_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/local/share/ntopng/httpdocs/geoip";
 			$source_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/share/ntopng";
@@ -329,6 +330,7 @@
 	</custom_php_install_command>
 	<custom_php_deinstall_command>
 		exec("rm /usr/local/etc/rc.d/ntopng*");
+		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 		if ($pf_version == "2.1" || $pf_version == "2.2") {
 			if (is_dir("/usr/local/share/ntopng/")) {
 				exec("rm -rf /usr/local/share/ntopng/");

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -301,7 +301,7 @@
 			<ports_before>databases/redis databases/gdbm net/GeoIP x11-fonts/font-util x11-fonts/webfonts graphics/graphviz</ports_before>
 			<port>net/ntopng</port>
 		</build_pbi>
-		<version>0.7.1</version>
+		<version>0.7.2</version>
 		<status>ALPHA</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/ntopng/ntopng.xml</config_file>


### PR DESCRIPTION
Symlink the scripts directory to /usr/local/share/ntopng to reduce logspam caused by PBI stupidity. (Declare $pf_version global on first use while at it, and clean up after itself on uninstall.)