### PR TITLE
softflowd - do not restart on boot plus style fixes

### DIFF
--- a/config/softflowd/softflowd.xml
+++ b/config/softflowd/softflowd.xml
@@ -1,6 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
+	<copyright>
+	<![CDATA[
+/* $Id$ */
+/* ========================================================================== */
+/*
+	softflowd.xml
+	part of pfSense (http://www.pfSense.com)
+	Copyright (C) 2013-2015 ESF, LLC
+	All rights reserved.
+*/
+/* ========================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	 1. Redistributions of source code must retain the above copyright notice,
+		this list of conditions and the following disclaimer.
+
+	 2. Redistributions in binary form must reproduce the above copyright
+		notice, this list of conditions and the following disclaimer in the
+		documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ========================================================================== */
+	]]>
+	</copyright>
 	<name>softflowd</name>
-	<version>0.9.8_2 pkg v1.1</version>
+	<version>1.2</version>
 	<title>softflowd: Settings</title>
 	<aftersaveredirect>pkg_edit.php?xml=softflowd.xml&amp;id=0</aftersaveredirect>
 	<menu>
@@ -50,7 +89,7 @@
 		<field>
 			<fielddescr>Hop Limit</fielddescr>
 			<fieldname>hoplimit</fieldname>
-			<description>Set the IPv4 TTL or the IPv6 hop limit to hoplimit.  softflowd will use the default system TTL when exporting flows to a unicast host.  When exporting to a multicast group, the default TTL will be 1 (i.e. link-local).</description>
+			<description>Set the IPv4 TTL or the IPv6 hop limit to hoplimit. softflowd will use the default system TTL when exporting flows to a unicast host. When exporting to a multicast group, the default TTL will be 1 (i.e. link-local).</description>
 			<type>input</type>
 		</field>
 		<field>
@@ -76,7 +115,7 @@
 		<field>
 			<fielddescr>Flow Tracking Level</fielddescr>
 			<fieldname>flowtracking</fieldname>
-			<description>Specify which flow elements softflowd should be used to define a flow.  track_level may be one of: &quot;full&quot; (track everything in the flow, the default), &quot;proto&quot; (track source and destination addresses and protocol), or &quot;ip&quot; (only track source and destination addresses).  Selecting either of the latter options will produce flows with less information in them (e.g. TCP/UDP ports will not be recorded).  This will cause flows to be consolidated, reducing the quantity of output and CPU load that softflowd will place on the system at the cost of some detail being lost.</description>
+			<description>Specify which flow elements softflowd should be used to define a flow. track_level may be one of: &quot;full&quot; (track everything in the flow, the default), &quot;proto&quot; (track source and destination addresses and protocol), or &quot;ip&quot; (only track source and destination addresses). Selecting either of the latter options will produce flows with less information in them (e.g. TCP/UDP ports will not be recorded). This will cause flows to be consolidated, reducing the quantity of output and CPU load that softflowd will place on the system at the cost of some detail being lost.</description>
 			<type>select</type>
 			<options>
 				<option>
@@ -106,13 +145,13 @@
 		<field>
 			<fielddescr>Maximum Lifetime</fielddescr>
 			<fieldname>timeout-maxlife</fieldname>
-			<description>(Seconds) This is the maximum lifetime that a flow may exist for.  All flows are forcibly expired when they pass maxlife seconds.  To disable this feature, specify a maxlife of 0.</description>
+			<description>(Seconds) This is the maximum lifetime that a flow may exist for. All flows are forcibly expired when they pass maxlife seconds. To disable this feature, specify a maxlife of 0.</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Expire Interval</fielddescr>
 			<fieldname>timeout-expint</fieldname>
-			<description>(Seconds) Specify the interval between expiry checks.  Increase this to group more flows into a NetFlow packet.  To disable this feature, specify a expint of 0.</description>
+			<description>(Seconds) Specify the interval between expiry checks. Increase this to group more flows into a NetFlow packet. To disable this feature, specify a expint of 0.</description>
 			<type>input</type>
 		</field>
 		<field>
@@ -145,7 +184,7 @@
 		function sync_package_softflowd() {
 			conf_mount_rw();
 			config_lock();
-			global $config;
+			global $config, $g;
 			$cf = $config['installedpackages']['softflowd']['config'][0];
 			$interface_list = explode(",", $cf['interface']);
 			if (!empty($cf['host']) && !empty($interface_list)) {
@@ -191,39 +230,52 @@
 						"stop" => "/usr/bin/killall -9 softflowd"
 					)
 				);
-				restart_service("softflowd");
+				/* Only try to restart if not booting */
+				if (!($g['booting'])) {
+					restart_service("softflowd");
+				}
 			}
 			conf_mount_ro();
 			config_unlock();
 		}
 
 		function validate_form_softflowd($post, &$input_errors) {
-			if (($post['host'] == "") || !is_ipaddr($post['host']))
+			if (($post['host'] == "") || !is_ipaddr($post['host'])) {
 				$input_errors[] = 'You must specify a valid ip address in the \'Host\' field';
-			if (($post['port'] == "") || !is_port($post['port']))
+			}
+			if (($post['port'] == "") || !is_port($post['port'])) {
 				$input_errors[] = 'You must specify a valid port number in the \'Port\' field';
-
-			if (($post['version'] == "" || !in_array($post['version'], array(1, 5, 9))))
+			}
+			if (($post['version'] == "" || !in_array($post['version'], array(1, 5, 9)))) {
 				$input_errors[] = 'You must specify a netflow version';
-			if (($post['flowtracking'] == "" || !in_array($post['flowtracking'], array("full", "proto", "ip"))))
+			}
+			if (($post['flowtracking'] == "" || !in_array($post['flowtracking'], array("full", "proto", "ip")))) {
 				$input_errors[] = 'You must specify a valid flow tracking selection';
-
-			if (!empty($post['hoplimit'])        && (!is_numeric($post['hoplimit']) || ($post['hoplimit'] < 1) || ($post['hoplimit'] > 255)))
+			}
+			if (!empty($post['hoplimit']) && (!is_numeric($post['hoplimit']) || ($post['hoplimit'] < 1) || ($post['hoplimit'] > 255))) {
 				$input_errors[] = 'You must specify a valid hop limit';
-			if (!empty($post['timeout-general']) && (!is_numeric($post['timeout-general']) || ($post['timeout-general'] < 0)))
+			}
+			if (!empty($post['timeout-general']) && (!is_numeric($post['timeout-general']) || ($post['timeout-general'] < 0))) {
 				$input_errors[] = 'You must specify a valid General Timeout';
-			if (!empty($post['timeout-maxlife']) && (!is_numeric($post['timeout-maxlife']) || ($post['timeout-maxlife'] < 0)))
+			}
+			if (!empty($post['timeout-maxlife']) && (!is_numeric($post['timeout-maxlife']) || ($post['timeout-maxlife'] < 0))) {
 				$input_errors[] = 'You must specify a valid Maximum Lifetime Timeout';
-			if (!empty($post['timeout-expint'])  && (!is_numeric($post['timeout-expint']) || ($post['timeout-expint'] < 0)))
+			}
+			if (!empty($post['timeout-expint']) && (!is_numeric($post['timeout-expint']) || ($post['timeout-expint'] < 0))) {
 				$input_errors[] = 'You must specify a valid Expire Interval';
-			if (!empty($post['timeout-tcp'])     && (!is_numeric($post['timeout-tcp']) || ($post['timeout-tcp'] < 0)))
+			}
+			if (!empty($post['timeout-tcp']) && (!is_numeric($post['timeout-tcp']) || ($post['timeout-tcp'] < 0))) {
 				$input_errors[] = 'You must specify a valid TCP Timeout';
-			if (!empty($post['timeout-tcp-rst']) && (!is_numeric($post['timeout-tcp-rst']) || ($post['timeout-tcp-rst'] < 0)))
+			}
+			if (!empty($post['timeout-tcp-rst']) && (!is_numeric($post['timeout-tcp-rst']) || ($post['timeout-tcp-rst'] < 0))) {
 				$input_errors[] = 'You must specify a valid TCP RST Timeout';
-			if (!empty($post['timeout-tcp-fin']) && (!is_numeric($post['timeout-tcp-fin']) || ($post['timeout-tcp-fin'] < 0)))
+			}
+			if (!empty($post['timeout-tcp-fin']) && (!is_numeric($post['timeout-tcp-fin']) || ($post['timeout-tcp-fin'] < 0))) {
 				$input_errors[] = 'You must specify a valid TCP FIN Timeout';
-			if (!empty($post['timeout-udp'])     && (!is_numeric($post['timeout-udp']) || ($post['timeout-udp'] < 0)))
+			}
+			if (!empty($post['timeout-udp']) && (!is_numeric($post['timeout-udp']) || ($post['timeout-udp'] < 0))) {
 				$input_errors[] = 'You must specify a valid UDP Timeout';
+			}
 		}
 		
 		function cleanup_config_softflowd() {

--- a/config/softflowd/softflowd.xml
+++ b/config/softflowd/softflowd.xml
@@ -184,7 +184,7 @@
 		function sync_package_softflowd() {
 			conf_mount_rw();
 			config_lock();
-			global $config, $g;
+			global $config;
 			$cf = $config['installedpackages']['softflowd']['config'][0];
 			$interface_list = explode(",", $cf['interface']);
 			if (!empty($cf['host']) && !empty($interface_list)) {

--- a/config/softflowd/softflowd.xml
+++ b/config/softflowd/softflowd.xml
@@ -244,7 +244,7 @@
 					)
 				);
 				/* Only try to restart if not booting */
-				if (platform_booting()) {
+				if (!platform_booting()) {
 					restart_service("softflowd");
 				}
 			}

--- a/config/softflowd/softflowd.xml
+++ b/config/softflowd/softflowd.xml
@@ -8,7 +8,7 @@
 /* ========================================================================== */
 /*
 	softflowd.xml
-	part of pfSense (http://www.pfSense.com)
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2013-2015 ESF, LLC
 	All rights reserved.
 */

--- a/config/softflowd/softflowd.xml
+++ b/config/softflowd/softflowd.xml
@@ -244,7 +244,7 @@
 					)
 				);
 				/* Only try to restart if not booting */
-				if (!($g['booting'])) {
+				if (platform_booting()) {
 					restart_service("softflowd");
 				}
 			}

--- a/config/softflowd/softflowd.xml
+++ b/config/softflowd/softflowd.xml
@@ -191,36 +191,49 @@
 				$cf['host'] = is_ipaddrv6($cf['host']) ? "[{$cf['host']}]" : $cf['host'];
 				$start = "/usr/bin/killall -9 softflowd";
 				foreach ($interface_list as $interface_friendly) {
-					if (empty($interface_friendly))
+					if (empty($interface_friendly)) {
 						continue;
+					}
 					$interface = get_real_interface($interface_friendly);
-					if (empty($interface))
+					if (empty($interface)) {
 						continue;
+					}
 					$start .= "\n\t/usr/local/sbin/softflowd ";
 					$start .= " -i " . escapeshellarg($interface);
 					$start .= " -n " . escapeshellarg("{$cf['host']}:{$cf['port']}");
-					if (is_numeric($cf['maxflows']))
+					if (is_numeric($cf['maxflows'])) {
 						$start .= " -m " . escapeshellarg($cf['maxflows']);
-					if (is_numeric($cf['hoplimit']))
+					}
+					if (is_numeric($cf['hoplimit'])) {
 						$start .= " -L " . escapeshellarg($cf['hoplimit']);
-					if ($cf['version'] != "") 
+					}
+					if ($cf['version'] != "") {
 						$start .= " -v " . escapeshellarg($cf['version']);
-					if ($cf['flowtracking'] != "")
+					}
+					if ($cf['flowtracking'] != "") {
 						$start .= " -T " . escapeshellarg($cf['flowtracking']);
-					if (is_numeric($cf['timeout-general']))
+					}
+					if (is_numeric($cf['timeout-general'])) {
 						$start .= " -t " . escapeshellarg("general={$cf['timeout-general']}");
-					if (is_numeric($cf['timeout-maxlife']))
+					}
+					if (is_numeric($cf['timeout-maxlife'])) {
 						$start .= " -t " . escapeshellarg("maxlife={$cf['timeout-maxlife']}");
-					if (is_numeric($cf['timeout-expint']))
+					}
+					if (is_numeric($cf['timeout-expint'])) {
 						$start .= " -t " . escapeshellarg("expint={$cf['timeout-expint']}");
-					if (is_numeric($cf['timeout-tcp']))
+					}
+					if (is_numeric($cf['timeout-tcp'])) {
 						$start .= " -t " . escapeshellarg("tcp={$cf['timeout-tcp']}");
-					if (is_numeric($cf['timeout-tcp-rst']))
+					}
+					if (is_numeric($cf['timeout-tcp-rst'])) {
 						$start .= " -t " . escapeshellarg("tcp.rst={$cf['timeout-tcp-rst']}");
-					if (is_numeric($cf['timeout-tcp-fin']))
+					}
+					if (is_numeric($cf['timeout-tcp-fin'])) {
 						$start .= " -t " . escapeshellarg("tcp.fin={$cf['timeout-tcp-fin']}");
-					if (is_numeric($cf['timeout-udp']))
+					}
+					if (is_numeric($cf['timeout-udp'])) {
 						$start .= " -t " . escapeshellarg("udp={$cf['timeout-udp']}");
+					}
 					$start .= " -p " . escapeshellarg("/var/run/softflowd.{$interface}.pid");
 					$start .= " -c " . escapeshellarg("/var/run/softflowd.{$interface}.ctl");
 				}

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1603,7 +1603,7 @@
 		<category>Network Management</category>
 		<config_file>https://packages.pfsense.org/packages/config/softflowd/softflowd.xml</config_file>
 		<depends_on_package_pbi>softflowd-0.9.8_2-##ARCH##.pbi</depends_on_package_pbi>
-		<version>1.1</version>
+		<version>1.2</version>
 		<status>Beta</status>
 		<required_version>2.2</required_version>
 		<configurationfile>softflowd.xml</configurationfile>


### PR DESCRIPTION
- Do not try to restart service on boot, otherwise it may get started twice via /etc/rc.start_packages (Fixes bug #4731).
- Add standard XML and copyright headers.
- Remove doubled spaces between sentences in descriptions.
- Developer style guidelines (spacing, braces).