### PR TITLE
FTP Client Proxy - add standard XML and copyright headers

### DIFF
--- a/config/ftpproxy/ftpproxy.inc
+++ b/config/ftpproxy/ftpproxy.inc
@@ -1,7 +1,7 @@
 <?php
 /*
 	ftpproxy.inc
-	part of pfSense (http://www.pfSense.com)
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 

--- a/config/ftpproxy/ftpproxy.inc
+++ b/config/ftpproxy/ftpproxy.inc
@@ -1,4 +1,34 @@
 <?php
+/*
+	ftpproxy.inc
+	part of pfSense (http://www.pfSense.com)
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+
+*/
 function sync_package_ftpproxy() {
 	conf_mount_rw();
 	config_lock();

--- a/config/ftpproxy/ftpproxy.xml
+++ b/config/ftpproxy/ftpproxy.xml
@@ -1,12 +1,52 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
+	<copyright>
+	<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
+/*
+	ftpproxy.xml
+	part of pfSense (http://www.pfSense.com)
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>FTP Client Proxy</name>
-	<version>0.2</version>
+	<version>0.2.1</version>
 	<title>FTP Client Proxy</title>
 	<aftersaveredirect>pkg_edit.php?xml=ftpproxy.xml</aftersaveredirect>
 	<include_file>/usr/local/pkg/ftpproxy.inc</include_file>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/ftpproxy/ftpproxy.inc</item>
 	</additional_files_needed>
 	<menu>
@@ -95,7 +135,7 @@
 		<field>
 			<fielddescr>Idle Timeout (Default: 86400)</fielddescr>
 			<fieldname>idletimeout</fieldname>
-			<description>(Seconds) Number of seconds that the control connection can be idle, before the proxy will disconnect. The maximum is 86400 seconds.  Do not set this too low, because the control connection is usually idle when large data transfers are taking place.</description>
+			<description>(Seconds) Number of seconds that the control connection can be idle, before the proxy will disconnect. The maximum is 86400 seconds. Do not set this too low, because the control connection is usually idle when large data transfers are taking place.</description>
 			<type>input</type>
 		</field>
 		<field>

--- a/config/ftpproxy/ftpproxy.xml
+++ b/config/ftpproxy/ftpproxy.xml
@@ -8,7 +8,7 @@
 /* ====================================================================================== */
 /*
 	ftpproxy.xml
-	part of pfSense (http://www.pfSense.com)
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 */

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1674,7 +1674,7 @@
 		<internal_name>FTP_Client_Proxy</internal_name>
 		<descr><![CDATA[Basic FTP Client Proxy using ftp-proxy from FreeBSD]]></descr>
 		<maintainer>jimp@pfsense.org</maintainer>
-		<version>0.2</version>
+		<version>0.2.1</version>
 		<category>Services</category>
 		<status>Beta</status>
 		<port_category>ftp</port_category>


### PR DESCRIPTION
- Also removed chmod 077 for the inc file, really don't get the point here?! (Seems like it's being pasted from the test_package into quite a few other packages.)
- Removed accidental double space in one of the descriptions.