### PR TITLE
nut - major code cleanup, code style fixes

### DIFF
--- a/config/nut/nut.inc
+++ b/config/nut/nut.inc
@@ -2,8 +2,8 @@
 /*
 	nut.inc
 	part of pfSense (https://www.pfsense.org/)
-
-	Copyright (C) 2007 Ryan Wagoner <rswagoner@gmail.com>.
+	Copyright (C) 2007 Ryan Wagoner <rswagoner@gmail.com>
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -30,8 +30,7 @@
 
 	require_once("config.inc");
 	require_once("functions.inc");
-
-	/* Nut */
+	require_once("util.inc");
 
 	define('NUT_RCFILE', '/usr/local/etc/rc.d/nut.sh');
 
@@ -43,80 +42,58 @@
 		define('NUT_DIR','/usr/local/etc/nut');
 	}
 
-	function nut_notice ($msg) { syslog(LOG_NOTICE, "nut: {$msg}"); return; }
-	function nut_warn ($msg) { syslog(LOG_WARNING, "nut: {$msg}"); return; }
-
-	function nut_action ($action) {
-		if (file_exists(NUT_RCFILE))
-			mwexec(NUT_RCFILE.' '.$action);
+	function nut_config($name) {
+		global $config;
+		if ($config['installedpackages']['nut']['config'][0]["{$name}"]) {
+			return $config['installedpackages']['nut']['config'][0]["{$name}"];
+		} else {
+			return null;
+		}
 	}
 
-	function nut_config ($name) {
+	function nut_config_sub($name,$len) {
 		global $config;
-		if($config['installedpackages']['nut']['config'][0]["{$name}"])
-			return $config['installedpackages']['nut']['config'][0]["{$name}"];
-		return null;
-	}	
-
-	function nut_config_sub ($name,$len) {
-		global $config;
-		if(nut_config($name))
+		if (nut_config($name)) {
 			return substr(nut_config($name),0,strlen(nut_config($name))-$len);
-		return null;
-	}	
-	
+		} else {
+			return null;
+		}
+	}
+
 	function nut_write_config($file, $text, $mask = null, $uid = null) {
 		$conf = fopen($file, "w");
-		if(!$conf) {
-			nut_warn("Could not open {$file} for writing.");
+		if (!$conf) {
+			log_error("[nut] ERROR: Could not open {$file} for writing.");
 			exit;
 		}
 		fwrite($conf, $text);
 		fclose($conf);
-		if($mask) chmod($file, $mask);
-		if($uid) chown($file, $uid);
+		if ($mask) {
+			chmod($file, $mask);
+		}
+		if ($uid) {
+			chown($file, $uid);
+		}
 	}
 
-	function nut_validate_ip($ip,$check_cdir) {
-		/* validate cdir */	
-		if($check_cdir)	{
-			$ip_array = explode("/",$ip);
-			if(count($ip_array) == 2) {
-				if($ip_array[1] < 1 || $ip_array[1] > 32)
-					return false;
-			} else
-				if(count($ip_array) != 1)
-					return false;
-		} else
-			$ip_array[] = $ip;
-
-		/* validate ip */
-		if(!eregi("^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$", $ip_array[0]))
-			return false;
-		foreach(explode(".", $ip_array[0]) as $sub)
-			if($sub < 0 || $sub > 256)
-				return false;
-		return true;
-	}
-	
 	function before_form_nut(&$pkg) {
 		/* return available serial ports */
-		
+
 		$serial_types = array("sio", "cua", "tty");
 		$ignore_files = array(".lock", ".init");
 
-		foreach($serial_types as $st) {
+		foreach ($serial_types as $st) {
 			$devices = glob("/dev/{$st}*");
-			foreach($devices as $line) {
-				if($line != '') {
+			foreach ($devices as $line) {
+				if ($line != '') {
 					$ignore = false;
-					foreach($ignore_files as $if) {
-						if(strstr($line, $if)) {
+					foreach ($ignore_files as $if) {
+						if (strstr($line, $if)) {
 							$ignore = true;
 							continue;
 						}
 					}
-					if($ignore == false) {
+					if ($ignore == false) {
 						$names[] = str_replace("/dev/", "", $line);
 						$values[] = $line;
 					}
@@ -127,69 +104,80 @@
 		/* find correct field */
 		$i = 0;
 		foreach ($pkg['fields']['field'] as $field) {
-			if ($field['fieldname'] == 'port')
+			if ($field['fieldname'] == 'port') {
 				break;
-			$i++;
-		}	
-		$field = &$pkg['fields']['field'][$i];	
+			} else {
+				$i++;
+			}
+		}
+		$field = &$pkg['fields']['field'][$i];
 
 		/* add available serial ports */
-		for ($i = 0; $i < count($values) ; $i++)
+		for ($i = 0; $i < count($values); $i++) {
 			$field['options']['option'][] = array('name' => $names[$i], 'value' => $values[$i]);
+		}
 	}
 
 	function validate_form_nut($post, &$input_errors) {
 		global $config;
 
 		/* monitor remote validation */
-		if($post['monitor'] == 'remote') {
-			if(!$post['remotename'])
+		if ($post['monitor'] == 'remote') {
+			if (!$post['remotename']) {
 				$input_errors[] = 'You must specify a name in the \'Remote UPS Name\' field';
-			if($post['remotename'] && !eregi('^[a-z0-9_.-]+$', $post['remotename']))
-				$input_errors[] = 'Only [Aa-Zz], [0-9], and [-_] accepted in the \'Remote UPS Name\' field';		
-			if(!$post['remoteaddr'] || !nut_validate_ip($post['remoteaddr'],false))
+			}
+			if ($post['remotename'] && !preg_match("/^[a-zA-Z0-9-_]+$/", $post['name'])) {
+				$input_errors[] = 'Only [Aa-Zz], [0-9], and [-_] accepted in the \'Remote UPS Name\' field';
+			}
+			if (!$post['remoteaddr'] || !is_ipaddr($post['remoteaddr'])) {
 				$input_errors[] = 'You must specify a valid address \'Remote UPS Address\' field';
-			if(!$post['remoteuser'])
+			}
+			if (!$post['remoteuser']) {
 				$input_errors[] = 'You must specify a name in the \'Remote UPS User\' field';
-			if(!$post['remotepass'])
+			}
+			if (!$post['remotepass']) {
 				$input_errors[] = 'You must specify a name in the \'Remote UPS Password\' field';
-		}
-
-		/* monitor local validation */
-		elseif($post['monitor'] == 'local') {
-			if(!$post['name'])
+			}
+		} elseif ($post['monitor'] == 'local') {
+			/* monitor local validation */
+			if (!$post['name']) {
 				$input_errors[] = 'You must specify a name in the \'Local UPS Name\' field';
-			if($post['name'] && !eregi('^[a-z0-9_.-]+$', $post['name']))
-				$input_errors[] = 'Only [Aa-Zz], [0-9], and [-_] accepted in the \'Local UPS Name\' field';			
-			if(!$post['driver'])
+			}
+			if ($post['name'] && !preg_match("/^[a-zA-Z0-9-_]+$/", $post['name'])) {
+				$input_errors[] = 'Only [Aa-Zz], [0-9], and [-_] accepted in the \'Local UPS Name\' field';
+			}
+			if (!$post['driver']) {
 				$input_errors[] = 'You must select a driver in the \'Local UPS Driver\' field';
-			if(!$post['port'])
+			}
+			if (!$post['port']) {
 				$input_errors[] = 'You must select a port in the \'Local UPS Port\' field';
+			}
 		}
 	}
 
 	function deinstall_package_nut() {
-		nut_action('stop');
+		stop_service("nut");
 
-		@unlink(NUT_RCFILE);
-		@unlink(NUT_DIR.'/upsmon.conf');
-		@unlink(NUT_DIR.'/ups.conf');
-		@unlink(NUT_DIR.'/upsd.conf');
-		@unlink(NUT_DIR.'/upsd.users');
+		unlink_if_exists(NUT_RCFILE);
+		unlink_if_exists(NUT_DIR.'/upsmon.conf');
+		unlink_if_exists(NUT_DIR.'/ups.conf');
+		unlink_if_exists(NUT_DIR.'/upsd.conf');
+		unlink_if_exists(NUT_DIR.'/upsd.users');
 
-		exec('rm -rf /var/db/nut');
-	}	
+		exec('/bin/rm -rf /var/db/nut');
+	}
 
 	function sync_package_nut_remote() {
 		$remotename = nut_config('remotename');
 		$remoteaddr = nut_config('remoteaddr');
 		$remoteuser = nut_config('remoteuser');
 		$remotepass = nut_config('remotepass');
-		$shutdownflag  = (nut_config('powerdown') == 'on') ? '-p' : '-h';
+		$shutdownflag = (nut_config('powerdown') == 'on') ? '-p' : '-h';
 		$custom_upsmonconf = str_replace(";", "\n", nut_config('custom_upsmonconf'));
 
-		if(!($remotename && $remoteaddr && $remoteuser && $remotepass))
+		if (!($remotename && $remoteaddr && $remoteuser && $remotepass)) {
 			return false;
+		}
 
 		/* upsmon.conf */
 		$upsmon_conf = <<<EOD
@@ -199,16 +187,16 @@ SHUTDOWNCMD "/sbin/shutdown {$shutdownflag} +0"
 POWERDOWNFLAG /etc/killpower
 {$custom_upsmonconf}
 EOD;
-	
+
 		$stop = <<<EOD
-if [ `pgrep upsmon | wc -l` != 0 ]; then
+if [ `/bin/pgrep upsmon | /usr/bin/wc -l` != 0 ]; then
 		/usr/bin/killall upsmon
-		while [ `pgrep upsmon | wc -l` != 0 ]; do 
+		while [ `/bin/pgrep upsmon | /usr/bin/wc -l` != 0 ]; do
 			sleep 1
 		done
 	fi
 EOD;
-	
+
 		$start = $stop."\n\t/usr/local/sbin/upsmon {$remotename}@{$remoteaddr}\n";
 
 		/* write out configuration */
@@ -216,10 +204,10 @@ EOD;
 		nut_write_config(NUT_DIR.'/upsmon.conf', $upsmon_conf, 0640, 'uucp');
 		write_rcfile(array(
 			'file' => 'nut.sh',
-	    	'start' => $start,
-	    	'stop' => $stop
-	   		)
-		);	
+			'start' => $start,
+			'stop' => $stop
+			)
+		);
 		conf_mount_ro();
 
 		return true;
@@ -227,6 +215,7 @@ EOD;
 
 	function sync_package_nut_local() {
 		global $pfs_version;
+		$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
 
 		$name = nut_config('name');
 		$driver = nut_config_sub('driver', 2);
@@ -235,43 +224,46 @@ EOD;
 		$cable = nut_config_sub('cable', 3);
 		$allowuser = nut_config('allowuser');
 		$allowpass = nut_config('allowpass');
-		$shutdownflag  = (nut_config('powerdown') == 'on') ? '-p' : '-h';
+		$shutdownflag = (nut_config('powerdown') == 'on') ? '-p' : '-h';
 		$custom_upsconf = str_replace(";", "\n", nut_config('custom_upsconf'));
 		$custom_upsdconf = str_replace(";", "\n", nut_config('custom_upsdconf'));
 		$custom_upsdusers = str_replace(";", "\n", nut_config('custom_upsdusers'));
 		$custom_upsmonconf = str_replace(";", "\n", nut_config('custom_upsmonconf'));
 
 
-		if(!($name && $driver && $port))
+		if (!($name && $driver && $port)) {
 			return false;
+		}
 
 		/* some installs are missing the lock dir */
-		if(!is_dir('/var/spool/lock')) {
-			@mkdir('/var/spool');
-			mkdir('/var/spool/lock');
+		if (!is_dir('/var/spool/lock')) {
+			safe_mkdir('/var/spool');
+			safe_mkdir('/var/spool/lock');
 			chown('/var/spool/lock', 'uucp');
 			chgrp('/var/spool/lock', 'dialer');
 		}
 
 		/* determine permissions for port */
-		if($port != 'auto') {
+		if ($port != 'auto') {
 			$port_rel = "chown root {$port}";
 			$port_set = "chown uucp {$port}";
 		}
 
 		/* ups.conf */
-		/* for usb ups run as root */
-		if($port == 'auto') {
+		/* for USB ups run as root */
+		if ($port == 'auto') {
 			$ups_conf = "user=root\n";
 			$ovr_user = '-u root';
 		}
 		$ups_conf .= "[{$name}]\n";
 		$ups_conf .= "driver={$driver}\n";
 		$ups_conf .= "port={$port}\n";
-		if($cable)
+		if ($cable) {
 			$ups_conf .= "cable={$cable}\n";
-		if($upstype)
+		}
+		if ($upstype) {
 			$ups_conf .= "upstype={$upstype}\n";
+		}
 		$ups_conf .= "{$custom_upsconf}";
 
 		/* upsd.conf */
@@ -284,17 +276,18 @@ EOD;
 		$upsd_users = "[monuser]\n";
 		$upsd_users .= "password = {$password}\n";
 		$upsd_users .= "upsmon master\n";
-		if($allowuser && $allowpass) {
+		if ($allowuser && $allowpass) {
 			$upsd_users .= "\n[$allowuser]\n";
 			$upsd_users .= "password = $allowpass\n";
 			$upsd_users .= "upsmon master\n";
 		}
 		$upsd_users .= "{$custom_upsdusers}";
 
-		if ($pfs_version == "2.1")
+		if ($pfs_version == "2.1") {
 			$upsdrvctl = "/usr/local/libexec/nut/upsdrvctl";
-		else
+		} else {
 			$upsdrvctl = "/usr/local/sbin/upsdrvctl";
+		}
 
 		/* upsmon.conf */
 		$upsmon_conf = <<<EOD
@@ -306,26 +299,26 @@ POWERDOWNFLAG /etc/killpower
 EOD;
 
 		$stop = <<<EOD
-	if [ `pgrep upsmon | wc -l` != 0 ]; then
+	if [ `/bin/pgrep upsmon | /usr/bin/wc -l` != 0 ]; then
 		echo stopping upsmon
 		/usr/bin/killall upsmon
-		while [ `pgrep upsmon | wc -l` != 0 ]; do
+		while [ `/bin/pgrep upsmon | /usr/bin/wc -l` != 0 ]; do
 			sleep 1
 		done
 	fi
-	if [ `pgrep upsd | wc -l` != 0 ]; then
+	if [ `/bin/pgrep upsd | /usr/bin/wc -l` != 0 ]; then
 		echo stopping upsd
 		/usr/bin/killall upsd
 	fi
-	if [ `pgrep {$driver} | wc -l` != 0 ]; then
+	if [ `/bin/pgrep {$driver} | /usr/bin/wc -l` != 0 ]; then
 		echo stopping {$driver}
 		{$upsdrvctl} stop
 	fi
 	sleep 1
-	if [ `pgrep {$driver} | wc -l` != 0 ]; then
+	if [ `/bin/pgrep {$driver} | /usr/bin/wc -l` != 0 ]; then
 		echo forcing {$driver} termination
 		/usr/bin/killall {$driver}
-		while [ `pgrep {$driver} | wc -l` != 0 ]; do
+		while [ `/bin/pgrep {$driver} | /usr/bin/wc -l` != 0 ]; do
 			sleep 1
 		done
 	fi
@@ -333,7 +326,7 @@ EOD;
 EOD;
 
 		$start = <<<EOD
-if [ `pgrep {$driver} | wc -l` != 0 ]; then
+if [ `/bin/pgrep {$driver} | /usr/bin/wc -l` != 0 ]; then
 	{$stop}
 	fi
 	{$port_set}
@@ -356,9 +349,9 @@ EOD;
 		nut_write_config(NUT_DIR.'/upsmon.conf', $upsmon_conf, 0640, 'uucp');
 		write_rcfile(array(
 			'file' => 'nut.sh',
-    		'start' => $start,
-	    	'stop' => $stop
-	   		)
+			'start' => $start,
+			'stop' => $stop
+			)
 		);
 		conf_mount_ro();
 
@@ -369,7 +362,7 @@ EOD;
 		$name = nut_config('snmpname');
 		$driver = "snmp-ups";
 		$port = nut_config('snmpaddr');
-		$shutdownflag  = (nut_config('powerdown') == 'on') ? '-p' : '-h';
+		$shutdownflag = (nut_config('powerdown') == 'on') ? '-p' : '-h';
 		$snmpmib = nut_config('snmpmib');
 		$snmpversion = nut_config('snmpversion');
 		$snmpcommunity = nut_config('snmpcommunity');
@@ -382,8 +375,9 @@ EOD;
 		$custom_upsdusers = str_replace(";", "\n", nut_config('custom_upsdusers'));
 		$custom_upsmonconf = str_replace(";", "\n", nut_config('custom_upsmonconf'));
 
-		if(!($name && $driver && $port))
+		if (!($name && $driver && $port)) {
 			return false;
+		}
 
 		/* ups.conf */
 		$ups_conf = "user=root\n";
@@ -391,16 +385,21 @@ EOD;
 		$ups_conf .= "[{$name}]\n";
 		$ups_conf .= "driver={$driver}\n";
 		$ups_conf .= "port={$port}\n";
-		if($snmpmib)
+		if ($snmpmib) {
 			$ups_conf .= "mibs={$snmpmib}\n";
-		if($snmpversion)
+		}
+		if ($snmpversion) {
 			$ups_conf .= "snmp_version={$snmpversion}\n";
-		if($snmpcommunity)
+		}
+		if ($snmpcommunity) {
 			$ups_conf .= "community={$snmpcommunity}\n";
-		if($snmpfreq)
+		}
+		if ($snmpfreq) {
 			$ups_conf .= "pollfreq={$snmpfreq}\n";
-		if($snmpdisabletransfer)
+		}
+		if ($snmpdisabletransfer) {
 			$ups_conf .= "notransferoids=true\n";
+		}
 		$ups_conf .= "{$custom_upsconf}";
 
 		/* upsd.conf */
@@ -413,13 +412,14 @@ EOD;
 		$upsd_users = "[monuser]\n";
 		$upsd_users .= "password = {$password}\n";
 		$upsd_users .= "upsmon master\n";
-		if($allowuser && $allowpass) {
+		if ($allowuser && $allowpass) {
 			$upsd_users .= "\n[$allowuser]\n";
 			$upsd_users .= "password = $allowpass\n";
 			$upsd_users .= "upsmon master\n";
 		}
 		$upsd_users .= "{$custom_upsdusers}";
 
+		$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
 		if ($pfs_version == "2.1")
 			$upsdrvctl = "/usr/local/libexec/nut/upsdrvctl";
 		else
@@ -435,26 +435,26 @@ POWERDOWNFLAG /etc/killpower
 EOD;
 
 		$stop = <<<EOD
-	if [ `pgrep upsmon | wc -l` != 0 ]; then
+	if [ `/bin/pgrep upsmon | /usr/bin/wc -l` != 0 ]; then
 		echo stopping upsmon
 		/usr/bin/killall upsmon
-		while [ `pgrep upsmon | wc -l` != 0 ]; do
+		while [ `/bin/pgrep upsmon | /usr/bin/wc -l` != 0 ]; do
 			sleep 1
 		done
 	fi
-	if [ `pgrep upsd | wc -l` != 0 ]; then
+	if [ `/bin/pgrep upsd | /usr/bin/wc -l` != 0 ]; then
 		echo stopping upsd
 		/usr/bin/killall upsd
 	fi
-	if [ `pgrep {$driver} | wc -l` != 0 ]; then
+	if [ `/bin/pgrep {$driver} | /usr/bin/wc -l` != 0 ]; then
 		echo stopping {$driver}
 		{$upsdrvctl} stop
 	fi
 	sleep 1
-	if [ `pgrep {$driver} | wc -l` != 0 ]; then
+	if [ `/bin/pgrep {$driver} | /usr/bin/wc -l` != 0 ]; then
 		echo forcing {$driver} termination
 		/usr/bin/killall {$driver}
-		while [ `pgrep {$driver} | wc -l` != 0 ]; do
+		while [ `/bin/pgrep {$driver} | /usr/bin/wc -l` != 0 ]; do
 			sleep 1
 		done
 	fi
@@ -462,7 +462,7 @@ EOD;
 EOD;
 
 		$start = <<<EOD
-if [ `pgrep {$driver} | wc -l` != 0 ]; then
+if [ `/bin/pgrep {$driver} | /usr/bin/wc -l` != 0 ]; then
 	{$stop}
 	fi
 	{$port_set}
@@ -485,8 +485,8 @@ EOD;
 		nut_write_config(NUT_DIR.'/upsmon.conf', $upsmon_conf, 0640, 'uucp');
 		write_rcfile(array(
 			'file' => 'nut.sh',
-		'start' => $start,
-		'stop' => $stop
+			'start' => $start,
+			'stop' => $stop
 			)
 		);
 		conf_mount_ro();
@@ -500,51 +500,49 @@ EOD;
 
 		config_lock();
 
-		nut_action('stop');
+		stop_service("nut");
 
 		/* create state path */
-		if(!is_dir('/var/db/nut')) {
-			mkdir('/var/db/nut');
-			chmod('/var/db/nut', 0700);
-			chown('/var/db/nut', 'uucp');
+		safe_mkdir("/var/db/nut", 0700);
+		chown('/var/db/nut', 'uucp');
+
+		if (nut_config('monitor') == 'remote') {
+			$return = sync_package_nut_remote();
+		} elseif (nut_config('monitor') == 'local') {
+			$return = sync_package_nut_local();
+		} elseif (nut_config('monitor') == 'snmp') {
+			$return = sync_package_nut_snmp();
 		}
 
-		if(nut_config('monitor') == 'remote')
-			$return = sync_package_nut_remote();
-		elseif(nut_config('monitor') == 'local')
-			$return = sync_package_nut_local();
-		elseif(nut_config('monitor') == 'snmp')
-			$return = sync_package_nut_snmp();
-
-		if($return && $_POST['monitor']) {
+		if ($return && $_POST['monitor']) {
 			/* only start if changing settings as we have a startup script for system boot */
 			/* this prevents service from starting / stopping / starting on boot */
-				
-			nut_notice('Starting service');
-			nut_action('start');
-			if((int)exec('pgrep upsmon | wc -l') == 0)
-				nut_notice('Service failed to start: check configuration');
 
-		} elseif(!$return && file_exists(NUT_RCFILE)) {
+			log_error("[nut] INFO: Starting service");
+			start_service("nut");
+			if ((int)exec('/bin/pgrep upsmon | /usr/bin/wc -l') == 0) {
+				log_error("[nut] ERROR: Service failed to start: check configuration.");
+			}
+		} elseif (!$return && file_exists(NUT_RCFILE)) {
 			/* no parameters user does not want nut running */
 			/* lets stop the service and remove the rc file */
 
-			if(!nut_config('monitor'))
-				nut_notice('Service stopped: nut disabled');
-			else
-				nut_notice('Service stopped: check configuration');
+			if (!nut_config('monitor')) {
+				log_error("[nut] INFO: Service stopped: nut disabled");
+			} else {
+				log_error("[nut] WARNING: Service stopped: check configuration.");
+			}
 
 			conf_mount_rw();
-			unlink(NUT_RCFILE);
-			unlink(NUT_DIR.'/upsmon.conf');
-			/* might not always exist */
-			@unlink(NUT_DIR.'/ups.conf');
-			@unlink(NUT_DIR.'/upsd.conf');
-			@unlink(NUT_DIR.'/upsd.users');
-			exec('rm -rf /var/db/nut');
+			unlink_if_exists(NUT_RCFILE);
+			unlink_if_exists(NUT_DIR.'/upsmon.conf');
+			unlink_if_exists(NUT_DIR.'/ups.conf');
+			unlink_if_exists(NUT_DIR.'/upsd.conf');
+			unlink_if_exists(NUT_DIR.'/upsd.users');
+			exec('/bin/rm -rf /var/db/nut');
 			conf_mount_ro();
 		}
-		
+
 		config_unlock();
 	}
 ?>

--- a/config/nut/nut.xml
+++ b/config/nut/nut.xml
@@ -2,51 +2,46 @@
 <!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
 <?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-        <copyright>
-        <![CDATA[
+	<copyright>
+	<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    nut.xml
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2007 to whom it may belong
-    All rights reserved.
-
-    Based on m0n0wall (http://m0n0.ch/wall)
-    Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
+	nut.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2009-2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
-        </copyright>
-    <description>Describe your package here</description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>nut</name>
-	<version>2.6.5_1 pkg 2.0.1</version>
+	<version>2.0.5</version>
 	<title>Services: NUT</title>
 	<savetext>Change</savetext>
 	<aftersaveredirect>/status_nut.php</aftersaveredirect>
@@ -75,13 +70,11 @@
 		</tab>
 	</tabs>
 	<additional_files_needed>
-	    <prefix>/usr/local/pkg/</prefix>
-	    <chmod>0755</chmod>
+		<prefix>/usr/local/pkg/</prefix>
 		<item>https://packages.pfsense.org/packages/config/nut/nut.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
-	    <prefix>/usr/local/www/</prefix>
-	    <chmod>0755</chmod>
+		<prefix>/usr/local/www/</prefix>
 		<item>https://packages.pfsense.org/packages/config/nut/status_nut.php</item>
 	</additional_files_needed>
 	<advanced_options>enabled</advanced_options>
@@ -187,8 +180,7 @@
 		<field>
 			<fielddescr>&lt;strong&gt;Local UPS Model&lt;/strong&gt;</fielddescr>
 			<fieldname>driver</fieldname>
-			<description>If generic or cable specified in parenthesis you need 
-				to select the appropriate option below.</description>
+			<description>If generic or cable specified in parenthesis you need to select the appropriate option below.</description>
 			<type>select</type>
 			<options>
 				<option>

--- a/config/nut/status_nut.php
+++ b/config/nut/status_nut.php
@@ -2,8 +2,8 @@
 /*
 	status_nut.php
 	part of pfSense (https://www.pfsense.org/)
-
 	Copyright (C) 2007 Ryan Wagoner <rswagoner@gmail.com>.
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -29,13 +29,15 @@
 */
 
 require("guiconfig.inc");
-
+global $nut_config;
 $nut_config = $config['installedpackages']['nut']['config'][0];
 
 /* functions */
 
 function secs2hms($secs) {
-	if ($secs<0) return false;
+	if ($secs < 0 ) {
+		return false;
+	}
 	$m = (int)($secs / 60); $s = $secs % 60;
 	$h = (int)($m / 60); $m = $m % 60;
 	return "{$h}h {$m}m {$s}s";
@@ -50,25 +52,29 @@ function tblclose () {
 }
 
 function tblrow ($name, $value, $symbol = null) {
-	if(!$value) return;
-
-	if($symbol == '&deg;')
+	if (!$value) {
+		return;
+	}
+	if ($symbol == '&deg;') {
 		$value = sprintf("%.1f", $value);
-
-	if($symbol == 'Hz')
+	}
+	if ($symbol == 'Hz') {
 		$value = sprintf("%d", $value);
+	}
 
 	print(<<<EOD
 <tr>
-  <td class="vncellreq" width="100px">{$name}</td>
-  <td class="vtable">{$value}{$symbol}</td>
+	<td class="vncellreq" width="100px">{$name}</td>
+	<td class="vtable">{$value}{$symbol}</td>
 <tr>
 EOD
 	."\n");
 }
 
 function tblrowbar ($name, $value, $symbol, $red, $yellow, $green) {
-	if(!$value) return;
+	if (!$value) {
+		return;
+	}
 
 	$value = sprintf("%.1f", $value);
 
@@ -80,57 +86,54 @@ function tblrowbar ($name, $value, $symbol, $red, $yellow, $green) {
 	sort($yellow);
 	sort($green);
 
-	if($value >= $red[0] && $value <= ($red[0]+9)) {
+	if ($value >= $red[0] && $value <= ($red[0]+9)) {
 		$color = 'black';
 		$bgcolor = 'red';
 	}
-	if($value >= ($red[0]+10) && $value <= $red[1]) {
+	if ($value >= ($red[0]+10) && $value <= $red[1]) {
 		$color = 'white';
 		$bgcolor = 'red';
 	}
-	if($value >= $yellow[0] && $value <= $yellow[1]) {
+	if ($value >= $yellow[0] && $value <= $yellow[1]) {
 		$color = 'black';
 		$bgcolor = 'yellow';
 	}
-	if($value >= $green[0] && $value <= ($green[0]+9)) {
+	if ($value >= $green[0] && $value <= ($green[0]+9)) {
 		$color = 'black';
 		$bgcolor = 'green';
 	}	
-	if($value >= ($green[0]+10) && $value <= $green[1]) {
+	if ($value >= ($green[0]+10) && $value <= $green[1]) {
 		$color = 'white';
 		$bgcolor = 'green';
 	}
 
 	print(<<<EOD
 <tr>
-  <td class="vncellreq" width="100px">{$name}</td>
-  <td class="vtable">
-    <div style="width: 125px; height: 12px; border-top: thin solid gray; border-bottom: thin solid gray;">
-      <div style="width: {$value}{$symbol}; height: 12px; background-color: {$bgcolor};">
-        <div style="text-align: center; color: {$color}">{$value}{$symbol}</div>
-      </div>
-    </div>
-  </td>
+	<td class="vncellreq" width="100px">{$name}</td>
+	<td class="vtable">
+	<div style="width: 125px; height: 12px; border-top: thin solid gray; border-bottom: thin solid gray;">
+		<div style="width: {$value}{$symbol}; height: 12px; background-color: {$bgcolor};">
+			<div style="text-align: center; color: {$color}">{$value}{$symbol}</div>
+		</div>
+	</div>
+	</td>
 <tr>
 EOD
 	."\n");
 }
 
 /* defaults to this page but if no settings are present, redirect to setup page */
-if(!$nut_config['monitor'])
+if (!$nut_config['monitor']) {
 	Header("Location: /pkg_edit.php?xml=nut.xml&id=0");
+}
 
 $pgtitle = "Status: NUT Status";
 include("head.inc");
-/* put your custom HTML head content here        */
-/* using some of the $pfSenseHead function calls */
-//$pfSenseHead->addMeta("<meta http-equiv=\"refresh\" content=\"120;url={$_SERVER['SCRIPT_NAME']}\" />");
-//echo $pfSenseHead->getHTML();
 
 ?>
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 <?php include("fbegin.inc"); ?>
-<p class="pgtitle"><?=$pgtitle?></font></p>
+<p class="pgtitle"><?=$pgtitle?></p>
 <?php if ($savemsg) print_info_box($savemsg); ?>
 
 <div id="mainlevel">
@@ -143,32 +146,33 @@ include("head.inc");
 ?>
 </table>
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tr>
+<tr>
 	<td>
 <?php
 	tblopen();
 
-	$running = ((int)exec('pgrep upsmon | wc -l') > 0) ? true : false;
+	$running = ((int)exec('/bin/pgrep upsmon | /usr/bin/wc -l') > 0) ? true : false;
 
-	if($nut_config['monitor'] == 'local') {
+	if ($nut_config['monitor'] == 'local') {
 		tblrow('Monitoring:','Local UPS'); 
-		$cmd = "upsc {$nut_config['name']}@localhost";
-	} elseif($nut_config['monitor'] == 'remote') {
+		$cmd = "/usr/local/bin/upsc {$nut_config['name']}@localhost";
+	} elseif ($nut_config['monitor'] == 'remote') {
 		tblrow('Monitoring:','Remote UPS');
-		$cmd = "upsc {$nut_config['remotename']}@{$nut_config['remoteaddr']}";
-	} elseif($nut_config['monitor'] == 'snmp') {
+		$cmd = "/usr/local/bin/upsc {$nut_config['remotename']}@{$nut_config['remoteaddr']}";
+	} elseif ($nut_config['monitor'] == 'snmp') {
 		tblrow('Monitoring:','SNMP UPS');
-		$cmd = "upsc {$nut_config['snmpname']}@localhost";
+		$cmd = "/usr/local/bin/upsc {$nut_config['snmpname']}@localhost";
 	}
 
-	if($running)
+	if ($running) {
 		$handle = popen($cmd, 'r');
-	elseif($nut_config['monitor'] == 'snmp')
+	} elseif ($nut_config['monitor'] == 'snmp') {
 		tblrow('ERROR:','NUT is enabled, however the service is not running! The SNMP UPS may be unreachable.');
-	else
+	} else {
 		tblrow('ERROR:','NUT is enabled, however the service is not running!');
+	}
 	
-	if($handle) {
+	if ($handle) {
 		$read = fread($handle, 4096);
 		pclose($handle);
 
@@ -179,14 +183,17 @@ include("head.inc");
 			$ups[$line[0]] = trim($line[1]);
 		}
 
-		if(count($lines) == 1)
+		if (count($lines) == 1) {
 			tblrow('ERROR:', 'Data stale!');
+		}
 
 		tblrow('Model:', $ups['ups.model']);
 
 		$status = explode(' ', $ups['ups.status']);
 		foreach($status as $condition) {
-			if($disp_status) $disp_status .= ', ';
+			if ($disp_status) {
+				$disp_status .= ', ';
+			}
 			switch ($condition) {
 				case 'WAIT':
 					$disp_status .= 'Waiting';
@@ -241,14 +248,11 @@ include("head.inc");
 
 	tblclose();
 ?>
-    </td>
-  </tr>
+	</td>
+</tr>
 </table>
-<?php 
-	/* display upsc array */
-	/*print('<pre>'); print_r($ups); print('</pre>');*/
-?>
 </div>
+
 <?php include("fend.inc"); ?>
 </body>
 </html>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -796,7 +796,7 @@
 		<descr>Network UPS Tools</descr>
 		<website>http://www.networkupstools.org/</website>
 		<category>Network Management</category>
-		<version>2.0.4</version>
+		<version>2.0.5</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<maintainer>rswagoner@gmail.com</maintainer>


### PR DESCRIPTION
nut.xml and status_nut.php contain just code style fixes per developer style guide.
nut.inc was a **lot** of work

1. nut_notice() and nut_warn() functions removed; use log_error() instead
2. nut_action() function removed; use service_start() and service_stop() instead
3. nut_validate_ip() function removed (WTF); use is_ipaddr() instead
4. replace deprecated eregi() with preg_match()
5. *major* coding style cleanup
6. use full paths to commands in the heredocs

