### PR TITLE
blinkled - code style fixes, add copyright headers

### DIFF
--- a/config/blinkled/blinkled.inc
+++ b/config/blinkled/blinkled.inc
@@ -1,20 +1,45 @@
 <?php
+/*
+	blinkled.inc
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2009 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+
 require_once("config.inc");
 require_once("functions.inc");
-
-function blinkled_running () {
-	return ((int)exec('pgrep blinkled | wc -l') > 0);
-}
 
 function sync_package_blinkled() {
 	global $config;
 	$blinkled_config = $config['installedpackages']['blinkled']['config'][0];
-	/* kill all instances of blinkled */
-	if(blinkled_running()) {
-		blinkled_stop();
+	/* Kill all instances of blinkled */
+	if (is_process_running("blinkled")) {
+		mwexec("/usr/bin/killall -9 blinkled");
 	}
-	/* if blinkled not running start it */
-	if(!blinkled_running()) {
+	/* If blinkled is not running, start it */
+	if (!is_process_running("blinkled")) {
 		blinkled_start();
 	}
 }
@@ -26,25 +51,25 @@ function blinkled_launch($int, $led) {
 function blinkled_start() {
 	global $config;
 	$blinkled_config = $config['installedpackages']['blinkled']['config'][0];
-	if (!($blinkled_config['enable']))
+	if (!($blinkled_config['enable'])) {
 		return;
+	}
 
-	if (($blinkled_config['enable_led2']) && ($blinkled_config['iface_led2']))
+	if (($blinkled_config['enable_led2']) && ($blinkled_config['iface_led2'])) {
 		blinkled_launch(convert_friendly_interface_to_real_interface_name($blinkled_config['iface_led2']), 2);
-	if (($blinkled_config['enable_led3']) && ($blinkled_config['iface_led3']))
+	}
+	if (($blinkled_config['enable_led3']) && ($blinkled_config['iface_led3'])) {
 		blinkled_launch(convert_friendly_interface_to_real_interface_name($blinkled_config['iface_led3']), 3);
-}
-
-function blinkled_stop() {
-	mwexec("/usr/bin/killall -9 blinkled");
+	}
 }
 
 function validate_form_blinkled($post, &$input_errors) {
 	/* Make sure both aren't using the same interface */
-	if (($post['iface_led2']) && ($post['iface_led3']) && 
+	if (($post['iface_led2']) && ($post['iface_led3']) &&
 	    (($post['enable_led2']) && ($post['enable_led3'])) &&
-	    ($post['iface_led2'] == $post['iface_led3']))
+	    ($post['iface_led2'] == $post['iface_led3'])) {
 		$input_errors[] = 'You cannot set two LEDs for a single interface. Please choose seperate interfaces.';
+	}
 }
 
 ?>

--- a/config/blinkled/blinkled.xml
+++ b/config/blinkled/blinkled.xml
@@ -1,8 +1,49 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
+	<copyright>
+	<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
+/*
+	blinkled.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2009-2012 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<title>Interfaces: Assign LEDs</title>
 	<name>blinkled</name>
-	<version>20090710</version>
+	<version>0.4.4</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/blinkled.inc</include_file>
 	<menu>
@@ -14,13 +55,13 @@
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/blinkled/blinkled.inc</item>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
+	<!-- TODO: Make the blinkled.sh script really usable for start/stop/restart -->
 	<service>
 		<name>blinkled</name>
 		<rcfile>blinkled.sh</rcfile>
 		<executable>blinkled</executable>
-		<description>Blinks LEDs to indicate network activity</description>
+		<description>Network Activity LED Indicator Daemon</description>
 	</service>
 	<fields>
 		<field>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1191,7 +1191,7 @@
 		<name>blinkled</name>
 		<descr>Allows you to use LEDs for network activity on supported platforms (ALIX, WRAP, Soekris, etc)</descr>
 		<category>System</category>
-		<version>0.4.3</version>
+		<version>0.4.4</version>
 		<status>Beta</status>
 		<maintainer>jimp@pfsense.org</maintainer>
 		<required_version>2.2</required_version>


### PR DESCRIPTION
(Resubmit of #921.)

- Code style fixes
- Improve service description.
- Remove blinkled_stop() and blinkled_running() functions, used just once -> pointless.
- Use is_process_running()