### PR TITLE
tftp - major package code cleanup

### DIFF
--- a/config/tftp2/tftp.inc
+++ b/config/tftp2/tftp.inc
@@ -1,23 +1,21 @@
 <?php
-/* $Id$ */
 /*
-/* ========================================================================== */
-/*
-	tftp_inc.php
+	tftp.inc
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2008 Mark J Crane
+	Copyright (C) 2011 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
-*/
-/* ========================================================================== */
-/*
+
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:
 
 	1. Redistributions of source code must retain the above copyright notice,
-		this list of conditions and the following disclaimer.
+	   this list of conditions and the following disclaimer.
 
 	2. Redistributions in binary form must reproduce the above copyright
-		notice, this list of conditions and the following disclaimer in the
-		documentation and/or other materials provided with the distribution.
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
 	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
 	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
@@ -30,98 +28,60 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
-function tftp_guid() {
-	if (function_exists('com_create_guid')){
-		return com_create_guid();
-	}else{
-		mt_srand((double)microtime()*10000);//optional for php 4.2.0 and up.
-		$charid = strtoupper(md5(uniqid(rand(), true)));
-		$hyphen = chr(45);// "-"
-		$uuid = chr(123)// "{"
-				.substr($charid, 0, 8).$hyphen
-				.substr($charid, 8, 4).$hyphen
-				.substr($charid,12, 4).$hyphen
-				.substr($charid,16, 4).$hyphen
-				.substr($charid,20,12)
-				.chr(125);// "}"
-		return $uuid;
-	}
-}
-
-function tftp_pkg_is_service_running($servicename) {
-	exec("/bin/ps ax | awk '{ print $5 }'", $psout);
-	array_shift($psout);
-	foreach($psout as $line) {
-		$ps[] = trim(array_pop(explode(' ', array_pop(explode('/', $line)))));
-	}
-	if(is_service_running($servicename, $ps) or is_process_running($servicename) ) {
-		return true;
-	}
-	else {
-		return false;
-	}
-}
-
-function tftp_byte_convert( $bytes ) {
-
-	if ($bytes<=0)
+function tftp_byte_convert($bytes) {
+	if ($bytes <= 0) {
 		return '0 Byte';
-
-	$convention=1000; //[1000->10^x|1024->2^x]
-	$s=array('B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB');
-	$e=floor(log($bytes,$convention));
-	return round($bytes/pow($convention,$e),2).' '.$s[$e];
+	}
+	$convention = 1000;
+	$s = array('B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB');
+	$e = floor(log($bytes, $convention));
+	return round($bytes/pow($convention, $e), 2) . ' ' . $s[$e];
 }
 
 function tftp_install_command() {
 	global $config;
+
+	$tftpdir = "/tftpboot";
+	$tftpbackup = "/root/backup/tftp.bak.tgz";
+
+	// Create the directories if required
 	conf_mount_rw();
+	safe_mkdir("{$tftpdir}", 0777);
+	safe_mkdir("/root/backup/");
 
-	if (!is_dir('/tftpboot')) {
-		// Create the directory
-		exec("mkdir /tftpboot");
-
-		//Set the directory permissions
-		exec("chmod -R 777 /tftpboot");
+	// Restore backup if it exists
+	if (file_exists($tftpbackup)) {
+		system("/usr/bin/tar xvpfz {$tftpbackup} -C /");
+		system("/bin/chmod -R 0744 {$tftpdir}/*");
+		unset($tftpbackup);
 	}
-
-	if (!is_dir('/root/backup/')) {
-		// Create the backup directory
-		exec("mkdir /root/backup/");
-	}
-
-	// if backup file exists restore it
-	$filename = 'tftp.bak.tgz';
-
-	//extract a specific directory to /usr/local/freeswitch
-	if (file_exists('/root/backup/'.$filename)) {
-		system('cd /; tar xvpfz /root/backup/tftp.bak.tgz');
-		system('chmod -R 744 /tftpboot/*');
-		unset($filename);
-	}
+	conf_mount_ro();
 }
 
 function tftp_deinstall_command() {
-
-	//exec("rm -R /tftpboot");
+	conf_mount_rw();
 	unlink_if_exists("/usr/local/etc/rc.d/tftp.sh");
 	unlink_if_exists("/tmp/pkg_mgr_tftp.log");
+	conf_mount_ro();
 }
 
 function tftp_generate_rules($type) {
 	global $config, $FilterIflist;
-	if ($type != "nat")
+
+	if ($type != "nat") {
 		return;
+	}
+
 	// Open inetd.conf write handle
-	$inetd_fd = fopen("/var/etc/inetd.conf","a+");
-	/* add tftp daemon */
+	$inetd_fd = fopen("/var/etc/inetd.conf", "a+");
+	// Add tftp daemon
 	fwrite($inetd_fd, "tftp\t\tdgram\tudp\twait\t\troot\t/usr/libexec/tftpd\ttftpd /tftpboot\n");
-	fclose($inetd_fd);		// Close file handle
+	// Close file handle
+	fclose($inetd_fd);
 
 	if (!empty($config['installedpackages']['tftpd']['config'][0]['tftpdinterface'])) {
 		$tftpifs = explode(",", $config['installedpackages']['tftpd']['config'][0]['tftpdinterface']);
-		foreach($tftpifs as $tftpif) {
+		foreach ($tftpifs as $tftpif) {
 			if ($FilterIflist[$tftpif]) {
 				log_error("Adding TFTP nat rules");
 				$natrules .= "rdr pass on {$FilterIflist[$tftpif]['if']} proto udp from any to {$FilterIflist[$tftpif]['ip']} port 69 -> 127.0.0.1 port 69\n";

--- a/config/tftp2/tftp.xml
+++ b/config/tftp2/tftp.xml
@@ -2,44 +2,46 @@
 <!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
-        <copyright>
-        <![CDATA[
+	<copyright>
+	<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    tftp.xml
-    Copyright (C) 2008 Mark J Crane
-    All rights reserved.
-                                                                                  */
-/* ========================================================================== */
+	tftp.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2008 Mark J Crane
+	Copyright (C) 2011 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
-        </copyright>
-    <description></description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>tftp Settings</name>
 	<version>2.0</version>
 	<title>TFTP: Settings</title>
@@ -65,12 +67,10 @@
 	<configpath>installedpackages->$packagename</configpath>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 		<item>https://packages.pfsense.org/packages/config/tftp2/tftp.inc</item>
 	</additional_files_needed>	
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>0755</chmod>
 		<item>https://packages.pfsense.org/packages/config/tftp2/tftp_files.php</item>
 	</additional_files_needed>	
 	<custom_php_install_command>
@@ -79,5 +79,7 @@
 	<custom_php_deinstall_command>
 		tftp_deinstall_command();
 	</custom_php_deinstall_command>
-	<filter_rules_needed>tftp_generate_rules</filter_rules_needed>
+	<filter_rules_needed>
+		tftp_generate_rules
+	</filter_rules_needed>
 </packagegui>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -329,7 +329,7 @@
 		<pkginfolink/>
 		<port_category>ftp</port_category>
 		<config_file>https://packages.pfsense.org/packages/config/tftp2/tftp.xml</config_file>
-		<version>2.1</version>
+		<version>2.2</version>
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<configurationfile>tftp.xml</configurationfile>


### PR DESCRIPTION
tftp.xml:
- fix copyright header
- fix file permissions
- indentation

tftp.inc:
- Fix copyright header
- Remove unused functions
- Use safe_mkdir() 
- Improve the backup restore code
- Indentation and code style fixes

tftp_files.php
- fix copyright header
- fix code indentation
- XHTML valid code
- make it possible to actually unset the selected TFTPD interfaces
