### PR TITLE
nrpe2 - code style fixes

### DIFF
--- a/config/nrpe2/nrpe2.inc
+++ b/config/nrpe2/nrpe2.inc
@@ -1,42 +1,49 @@
 <?php
+/*
+	nrpe2.inc
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2009 Erik Kristensen <erik@erikkristensen.com>
+	Copyright (C) 2011-2013 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-/**
- * Author: Erik Kristensen
- * Email: erik@erikkristensen.com
- *
- * Developed for: pfSense.com
- *
- * Copyright (c) 2009, pfSense.com
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in thedocumentation and/or other materials provided with the distribution.
- * Neither the name of the <ORGANIZATION> nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- */
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
 require_once('filter.inc');
 
-$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
+global $pfs_version;
+$pfs_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
 
-if ($pfs_version == "2.0") {
-	define('NRPE_BASE', '/usr/local');
-} else {
+if ($pfs_version == "2.1" || $pfs_version == "2.2") {
 	define('NRPE_BASE', '/usr/pbi/nrpe-' . php_uname("m"));
+} else {
+	define('NRPE_BASE', '/usr/local');
 }
 
-if ($pfs_version == "2.1")
+if ($pfs_version == "2.1") {
 	define('NRPE_BINARY', NRPE_BASE . "/sbin/nrpe2");
-else
+} else {
 	define('NRPE_BINARY', "/usr/local/sbin/nrpe2");
+}
 
 define('NRPE_CONFIG_DIR', NRPE_BASE . '/etc');
 define('NRPE_RCFILE', '/usr/local/etc/rc.d/nrpe2.sh');
@@ -202,22 +209,21 @@ connection_timeout=300
 {$commands}
 EOD;
 	if (defined($config['installedpackages']['nrpe2']['config'][0]['server_address'])) {
-                $server_address = $config['installedpackages']['nrpe2']['config'][0]['server_address'];
-                $nrpe_cfg .= "server_address={$server_address}";
-        }
+		$server_address = $config['installedpackages']['nrpe2']['config'][0]['server_address'];
+		$nrpe_cfg .= "server_address={$server_address}";
+	}
 	fwrite($fd, $nrpe_cfg);
 	fclose($fd);
 	conf_mount_ro();
 }
 
 function nrpe2_custom_php_service() {
-	global $g, $config;
+	global $config;
 
 	if ($config['installedpackages']['nrpe2']['config'][0]['enabled'] == "on") {
-		exec(NRPE_RCFILE . " restart");
-	}
-	else {
-		exec(NRPE_RCFILE . " stop");
+		restart_service("nrpe2");
+	} else {
+		stop_service("nrpe2");
 	}
 }
 

--- a/config/nrpe2/nrpe2.xml
+++ b/config/nrpe2/nrpe2.xml
@@ -1,9 +1,50 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
+	<copyright>
+	<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
+/*
+	nrpe2.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2009 Erik Kristensen
+	Copyright (C) 2011-2013 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<description>Nagios NRPEv2</description>
-	<requirements>Describe your package requirements here</requirements>
 	<name>nrpe2</name>
-	<version>2.2</version>
+	<version>2.2.1</version>
 	<title>NRPEv2</title>
 	<aftersaveredirect>/pkg_edit.php?xml=nrpe2.xml&amp;id=0</aftersaveredirect>
 	<include_file>/usr/local/pkg/nrpe2.inc</include_file>
@@ -22,7 +63,6 @@
 	<configpath>installedpackages->package->nrpe2</configpath>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/nrpe2/nrpe2.inc</item>
 	</additional_files_needed>
 	<fields>
@@ -34,7 +74,7 @@
 		<field>
 			<fielddescr>Enabled</fielddescr>
 			<fieldname>enabled</fieldname>
-			<description>Check this to enable NRPE daemon</description>
+			<description>Check this to enable NRPE daemon.</description>
 			<type>checkbox</type>
 		</field>
 		<field>
@@ -52,20 +92,20 @@
 		<field>
 			<fielddescr>Bind IP Address</fielddescr>
 			<fieldname>server_address</fieldname>
-			<description>Set this to the IP address of the interface you want the daemon to listen on. (optional)</description>
+			<description>Set this to the IP address of the interface you want the daemon to listen on. (Optional)</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>Nagios Server(s)</fielddescr>
 			<fieldname>allowed_hosts</fieldname>
-			<description>IP Address of Nagios server, usualy a single IP, but if multiple delimit by comma</description>
+			<description>IP Address of Nagios server. Usually a single IP; multiple IPs must be delimited by comma.</description>
 			<type>input</type>
 			<required/>
 		</field>
 		<field>
 			<fielddescr>Allow Arguments (dont_blame_nrpe)</fielddescr>
 			<fieldname>dont_blame_nrpe</fieldname>
-			<description>Check this to enable accept NRPE arguments (Default: 0)</description>
+			<description>Check this to enable accept NRPE arguments. (Default: 0)</description>
 			<type>checkbox</type>
 		</field>
 
@@ -118,7 +158,7 @@
 				<rowhelperfield>
 					<fielddescr>Extra Options (Example: -s Z \$ARG1\$ \$ARG2\$)</fielddescr>
 					<fieldname>extra</fieldname>
-					<description>Warning! Use at your own risk, incorrect settings here may prevent NRPE from starting!</description>
+					<description><![CDATA[<strong>Warning! Use at your own risk, incorrect settings here may prevent NRPE from starting!</strong>]]></description>
 					<type>input</type>
 					<size>25</size>
 				</rowhelperfield>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1280,7 +1280,7 @@
 		<config_file>https://packages.pfsense.org/packages/config/nrpe2/nrpe2.xml</config_file>
 		<version>2.15_5 v2.2_4</version>
 		<status>Beta</status>
-		<required_version>2.2</required_version>
+		<required_version>2.2.1</required_version>
 		<maintainer>erik@erikkristensen.com</maintainer>
 		<configurationfile>nrpe2.xml</configurationfile>
 		<maximum_version>2.2.999</maximum_version>


### PR DESCRIPTION
nrpe2.xml
- Add copyright header (from git history)
- Nuke useless tags and fix file permissions.
- Descriptions cosmetics.

nrpe2.inc
- Fix copyright header
- Code style
- FIx NRPE_BASE for pfSense 2.3
- Use restart_service() and stop_service() instead of calling the shell script directly