### PR TITLE
arpwatch - code style cleanup

### DIFF
--- a/config/arpwatch/arpwatch.xml
+++ b/config/arpwatch/arpwatch.xml
@@ -152,4 +152,9 @@
 		@link("/usr/sbin/sm.php", "/usr/sbin/sendmail");
 	]]>
 	</custom_php_install_command>
+	<custom_php_resync_config_command>
+	<![CDATA[
+		sync_package_arpwatch();
+	]]>
+	</custom_php_resync_config_command>
 </packagegui>

--- a/config/arpwatch/arpwatch.xml
+++ b/config/arpwatch/arpwatch.xml
@@ -1,28 +1,30 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
 	<copyright>
 	<![CDATA[
-/* ==========================================================================
+/* $Id$ */
+/* ====================================================================================== */
 /*
 	arpwatch.xml
-	part of pfSense (https://www.pfsense.org)
-	Copyright (C) 2007-2014 Electric Sheep Fencing LP
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2007-2015 Electric Sheep Fencing LP
 	All rights reserved.
-
-										*/
-/* ==========================================================================	*/
+*/
+/* ====================================================================================== */
 /*
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:
 
-	 1. Redistributions of source code must retain the above copyright notice,
-	this list of conditions and the following disclaimer.
 
-	 2. Redistributions in binary form must reproduce the above copyright
-	notice, this list of conditions and the following disclaimer in the
-	documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
 
 	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
 	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
@@ -34,15 +36,13 @@
 	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
-										*/
-/* ==========================================================================	*/
+*/
+/* ====================================================================================== */
 	]]>
 	</copyright>
 	<description>ARP Monitoring Daemon</description>
-	<requirements>None</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>arpwatch</name>
-	<version>2.1.a14 pkg v1.1.1</version>
+	<version>1.1.2</version>
 	<title>arpwatch: Settings</title>
 	<aftersaveredirect>pkg_edit.php?xml=arpwatch.xml&amp;id=0</aftersaveredirect>
 	<menu>
@@ -71,12 +71,12 @@
 	<configpath>installedpackages->package->$packagename->configuration->settings</configpath>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>a+rx</chmod>
+		<chmod>0755</chmod>
 		<item>https://packages.pfsense.org/packages/config/arpwatch/arpwatch_reports.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/sbin/</prefix>
-		<chmod>a+rx</chmod>
+		<chmod>0755</chmod>
 		<item>https://packages.pfsense.org/packages/config/arpwatch/sm.php</item>
 	</additional_files_needed>
 	<fields>
@@ -90,33 +90,45 @@
 			<fielddescr>Enable E-mail Notifications</fielddescr>
 			<fieldname>enable_email</fieldname>
 			<type>checkbox</type>
-			<description>Sends an E-mail notification for each new station and ARP change as they are seen &lt;strong&gt;instead of&lt;/strong&gt; local reports.&lt;br/&gt;NOTE: Only works on pfSense 2.1 or later. &lt;br/&gt;NOTE 2: Disables local reports which rely on arpwatch debug mode, which does not work with e-mail notifications.&lt;br/&gt;Configure SMTP and address settings in System &gt; Advanced on the Notifications tab</description>
+			<description>
+			<![CDATA[
+			Sends an E-mail notification for each new station and ARP change as they are seen <strong>, instead of</strong> local reports.<br />
+			NOTE: Disables local reports which rely on arpwatch debug mode, which does not work with e-mail notifications.<br />
+			Configure SMTP and address settings in System - Advanced on the Notifications tab.
+			]]>
+			</description>
 		</field>
 	</fields>
 	<custom_php_global_functions>
 	<![CDATA[
 	function sync_package_arpwatch() {
 		global $config;
-		$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 		conf_mount_rw();
 		config_lock();
 		$log_file = "/var/log/arp.dat";
-		if($_POST['interface'] != "") {
+
+		/* E-mail notifications setup */
+		$mail = "";
+		$debug = "";
+		if (isset($_POST['enable_email']) || ($config['installedpackages']['arpwatch']['config'][0]['enable_email'] == "on")) {
+			if (!empty($config['notifications']['smtp']['notifyemailaddress'])) {
+				$mail = " -m \"{$config['notifications']['smtp']['notifyemailaddress']}\"";
+			}
+		} else {
+			$debug = "-d";
+		}
+
+		/* Listening interface setup */
+		if ($_POST['interface'] != "") {
 			$int = $_POST['interface'];
 		} else {
 			$int = $config['installedpackages']['arpwatch']['config'][0]['interface'];
 		}
-		$mail = "";
-		$debug = "";
-		if(($pf_version > 2.0) && (isset($_POST['enable_email']) || ($config['installedpackages']['arpwatch']['config'][0]['enable_email'] == "on"))) {
-			if (!empty($config['notifications']['smtp']['notifyemailaddress']))
-				$mail = " -m \"{$config['notifications']['smtp']['notifyemailaddress']}\"";
-		} else {
-			$debug = "-d";
-		}
 		$int = convert_friendly_interface_to_real_interface_name($int);
-		$start = "touch {$log_file}\n";
-		$start .= "/usr/local/sbin/arpwatch {$debug} -f {$log_file} {$mail} -i {$int} > /var/log/arpwatch.reports 2>&amp;1 &amp;";
+
+		/* Create init script */
+		$start = "/usr/bin/touch {$log_file}\n";
+		$start .= "/usr/local/sbin/arpwatch {$debug} -f {$log_file} {$mail} -i {$int} > /var/log/arpwatch.reports 2>&1 &";
 		$stop = "/usr/bin/killall arpwatch";
 		write_rcfile(array(
 			"file" => "arpwatch.sh",
@@ -124,6 +136,7 @@
 			"stop" =>  $stop
 			)
 		);
+
 		restart_service("arpwatch");
 		conf_mount_ro();
 		config_unlock();

--- a/config/arpwatch/arpwatch.xml
+++ b/config/arpwatch/arpwatch.xml
@@ -104,7 +104,6 @@
 	function sync_package_arpwatch() {
 		global $config;
 		conf_mount_rw();
-		config_lock();
 		$log_file = "/var/log/arp.dat";
 
 		/* E-mail notifications setup */
@@ -139,7 +138,6 @@
 
 		restart_service("arpwatch");
 		conf_mount_ro();
-		config_unlock();
 	}
 	]]>
 	</custom_php_global_functions>

--- a/config/arpwatch/arpwatch_reports.php
+++ b/config/arpwatch/arpwatch_reports.php
@@ -1,61 +1,65 @@
 #!/usr/local/bin/php
 <?php
 /*
-	$Id$
+	arpwatch_reports.php
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2005 Colin Smith
+	Copyright (C) 2007-2015 ESF, LLC
+	All rights reserved.
 
-        arpwatch_reports.php
-        Copyright (C) 2005 Colin Smith
-        All rights reserved.
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
-
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require_once("guiconfig.inc");
 require_once("service-utils.inc");
 
 $logfile = "/var/log/arp.dat";
 
 if ($_POST['clear']) {
-        stop_service("arpwatch");
+	conf_mount_rw();
+	stop_service("arpwatch");
 	unlink_if_exists($logfile);
 	touch($logfile);
 	start_service("arpwatch");
+	conf_mount_ro();
 }
 
-if(file_exists($logfile)) {
+if (file_exists($logfile)) {
 	$rawrep = file($logfile);
-	foreach($rawrep as $line) {
-	      	$todo = preg_split('/\s/', $line);
+	foreach ($rawrep as $line) {
+		$todo = preg_split('/\s/', $line);
 		$rawmac = explode(":", trim($todo[0]));
-		foreach($rawmac as $set) $mac[] = str_pad($set, 2, "0", STR_PAD_LEFT);
+		foreach ($rawmac as $set) {
+			$mac[] = str_pad($set, 2, "0", STR_PAD_LEFT);
+		}
 		$newmac = implode(":", $mac);
-	        $report[$todo[1]][] = array(
-	                                        "mac" => $newmac,
-	                                        "timestamp" => trim($todo[2]),
-	                                        "hostname" => trim($todo[3]) ? trim($todo[3]) : "Unknown"
-	                        );
+		$report[$todo[1]][] = array(
+			"mac" => $newmac,
+			"timestamp" => trim($todo[2]),
+			"hostname" => trim($todo[3]) ? trim($todo[3]) : "Unknown"
+			);
 		unset($mac);
 	}
 }
+
 $pgtitle = "arpwatch: Reports";
 include("head.inc");
 
@@ -64,23 +68,23 @@ include("head.inc");
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 <?php include("fbegin.inc"); ?>
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
-        <tr>
-                <td>
+	<tr>
+		<td>
 <?php
-        $tab_array = array();
-        $tab_array[] = array("Settings", false, "pkg_edit.php?xml=arpwatch.xml&id=0");
+	$tab_array = array();
+	$tab_array[] = array("Settings", false, "pkg_edit.php?xml=arpwatch.xml&id=0");
 	$tab_array[] = array("Reports", true, "arpwatch_reports.php");
 	display_top_tabs($tab_array);
 ?>
-                </td>
-        </tr>
-        <tr>
-                <td>
-                        <div id="mainarea">
-                        <table class="tabcont" width="100%" border="0" cellspacing="0" cellpadding="0">
-                                <tr>
-                                        <td colspan="4" class="listtopic">arp.dat entries</td>
-                                </tr>
+		</td>
+	</tr>
+	<tr>
+		<td>
+			<div id="mainarea">
+			<table class="tabcont" width="100%" border="0" cellspacing="0" cellpadding="0">
+				<tr>
+					<td colspan="4" class="listtopic">arp.dat entries</td>
+				</tr>
 				<tr>
 					<td width="15%" class="listhdrr">IP</td>
 					<td width="25%" class="listhdrr">Timestamp</td>
@@ -88,14 +92,14 @@ include("head.inc");
 					<td width="45%" class="listhdrr">Hostname</td>
 				</tr>
 				<?php
-					if($report)
-						foreach($report as $ip => $rawentries) {
+					if ($report) {
+						foreach ($report as $ip => $rawentries) {
 							$printip = true;
 							$entries = $rawentries;
 							sort($entries);
-							foreach($entries as $entry) {
+							foreach ($entries as $entry) {
 								echo '<tr>';
-								if($printip) {
+								if ($printip) {
 									echo '<td class="listlr">' . $ip . '</td>';
 									$stampclass = "listr";
 									$printip = false;
@@ -111,17 +115,21 @@ include("head.inc");
 								echo '</tr>';
 							}
 						}
+					}
 				?>
-                                <tr>
-                                        <td>
-                                                <br>
-                                                <form action="arpwatch_reports.php" method="post">
-                                                <input name="clear" type="submit" class="formbtn" value="Clear log">
-                                                </form>
-                                        </td>
-                                </tr>
-                        </table>
-                </div>
-                </td>
-        </tr>
+				<tr>
+					<td>
+						<br />
+						<form action="arpwatch_reports.php" method="post">
+						<input name="clear" type="submit" class="formbtn" value="Clear log" />
+						</form>
+					</td>
+				</tr>
+			</table>
+		</div>
+		</td>
+	</tr>
 </table>
+<?php include("fend.inc"); ?>
+</body>
+</html>

--- a/config/arpwatch/sm.php
+++ b/config/arpwatch/sm.php
@@ -1,33 +1,49 @@
 #!/usr/local/bin/php -q
 <?php
+/*
+	sm.php
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
 require_once("config.inc");
 require_once("globals.inc");
 require_once("notices.inc");
 
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if (($pf_version < 2.1)) {
-	$error = "Sending e-mail on this version of pfSense is not supported. Please use pfSense 2.1 or later";
-	log_error($error);
-	echo "{$error}\n";
-	return;
-}
-
 $options = getopt("s::");
-
 $message = "";
 
-if($options['s'] <> "") {
+if ($options['s'] <> "") {
 	$subject = $options['s'];
 }
 
-
 $in = file("php://stdin");
-foreach($in as $line){
+foreach ($in as $line) {
 	$line = trim($line);
-	if (       (substr($line, 0, 6) == "From: ")
-		|| (substr($line, 0, 6) == "Date: ")
-		|| (substr($line, 0, 4) == "To: "))
+	if ((substr($line, 0, 6) == "From: ") || (substr($line, 0, 6) == "Date: ") || (substr($line, 0, 4) == "To: ")) {
 		continue;
+	}
 	if (empty($subject) && (substr($line, 0, 9) == "Subject: ")) {
 		$subject = substr($line, 9);
 		continue;
@@ -35,8 +51,10 @@ foreach($in as $line){
 	$message .= "$line\n";
 }
 
-if (!empty($subject))
+if (!empty($subject)) {
 	send_smtp_message($message, $subject);
-else
+} else {
 	send_smtp_message($message);
+}
+
 ?>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1137,7 +1137,7 @@
 		<build_pbi>
 			<port>net-mgmt/arpwatch</port>
 		</build_pbi>
-		<version>2.1.a15_8 pkg v1.1.2</version>
+		<version>1.1.3</version>
 		<status>ALPHA</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/arpwatch/arpwatch.xml</config_file>


### PR DESCRIPTION
arpwatch.xml
- Fix copyright header
- Fix chmod
- Remove obsolete pfSense version check
- Code style cleanup
- Remove useless config_(un)lock calls
- Add custom_php_resync_config_command

sm.php
- Add missing copyright header
- Remove obsolete pfSense version check
- Code style cleanup

arpwatch_reports.php
- Fix copyright header
- Fix nanobsd
- Code style
- Fix XHTML