### PR TITLE
snort - fix copyright headers, XML cleanup

### DIFF
--- a/config/snort/snort.xml
+++ b/config/snort/snort.xml
@@ -3,51 +3,50 @@
 <?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-        <![CDATA[
+	<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    authng.xml
-    part of pfSense (https://www.pfsense.org)
-    Copyright (C) 2007 to whom it may belong
-    All rights reserved.
-
-    Based on m0n0wall (http://m0n0.ch/wall)
-    Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
+	snort.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2009-2010 Robert Zelaya
+	Copyright (C) 2011-2012 Ermal Luçi
+	Copyright (C) 2013-2015 Bill Meeks
+	Copyright (C) 2015 Electric Sheep Fencing LP
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
 	</copyright>
 	<description>Snort IDS/IPS Package</description>
-	<requirements>None</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>Snort</name>
-	<version>2.9.7.3</version>
-	<title>Services:2.9.7.3 pkg v3.2.6</title>
+	<version>3.2.6</version>
+	<title>Services: Snort IDS</title>
 	<include_file>/usr/local/pkg/snort/snort.inc</include_file>
 	<menu>
 		<name>Snort</name>
@@ -65,258 +64,206 @@
 	</tabs>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_check_cron_misc.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_conf_template.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_migrate_config.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_post_install.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_sync.xml</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/deprecated_rules</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_alerts.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_barnyard.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_blocked.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_define_servers.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_download_rules.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_download_updates.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_check_for_rule_updates.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_defs.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_interfaces.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_interfaces_edit.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_interfaces_global.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_rules.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_rules_edit.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_rulesets.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_preprocessors.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_passlist.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_passlist_edit.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_interfaces_suppress.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_interfaces_suppress_edit.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_list_view.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_rules_flowbits.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_edit_hat_data.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_frag3_engine.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_stream5_engine.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_httpinspect_engine.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_ftp_client_engine.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_ftp_server_engine.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_import_aliases.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_select_alias.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/etc/inc/priv/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort.priv.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_ip_reputation.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_ip_list_mgmt.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_iprep_list_browser.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_interface_logs.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_log_mgmt.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_sid_mgmt.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/snort/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_generate_conf.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/widgets/javascript/</prefix>
-		<chmod>0644</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_alerts.js</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/widgets/widgets/</prefix>
-		<chmod>0644</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/snort_alerts.widget.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/widgets/include/</prefix>
-		<chmod>0644</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/widget-snort.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/var/db/snort/sidmods/</prefix>
-		<chmod>0644</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/disablesid-sample.conf</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/var/db/snort/sidmods/</prefix>
-		<chmod>0644</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/enablesid-sample.conf</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/var/db/snort/sidmods/</prefix>
-		<chmod>0644</chmod>
 		<item>https://packages.pfsense.org/packages/config/snort/modifysid-sample.conf</item>
 	</additional_files_needed>
 	<fields>
 	</fields>
-	<custom_add_php_command>
-	</custom_add_php_command>
 	<custom_php_resync_config_command>
 		<![CDATA[
 		sync_snort_package_config();

--- a/config/snort/snort_sync.xml
+++ b/config/snort/snort_sync.xml
@@ -1,52 +1,50 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-  <copyright>
-<![CDATA[
+	<copyright>
+	<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-snortsync.xml
-part of pfSense (http://www.pfSense.com)
-Copyright (C) 2013 Marcello Coutinho
-based on pfblocker_sync.xml
-All rights reserved.
-
-Based on m0n0wall (http://m0n0.ch/wall)
-Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-All rights reserved.
+	snort.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013 Marcello Coutinho
+	Copyright (C) 2014-2015 Bill Meeks
+	Copyright (C) 2015 Electric Sheep Fencing LP
+	All rights reserved.
 */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code MUST retain the above copyright notice,
-this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form MUST reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
-/* ========================================================================== */
-]]></copyright>
-	<description><![CDATA[Describe your package here]]></description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
+/* ====================================================================================== */
+	]]>
+	</copyright>
+	<description>Snort: XMLRPC Sync</description>
 	<name>snortsync</name>
-	<version>1.0</version>
+	<version>3.2.6</version>
 	<title>Snort: XMLRPC Sync</title>
 	<include_file>/usr/local/pkg/snort/snort.inc</include_file>
 	<tabs>


### PR DESCRIPTION
Get rid of loads of bad 077 chmods, also no need to chmod 0644 which is default.
Nuke useless, unused XML tags
Fix title and make version consistent.

Done here; not touching anything else here since it's very actively maintained.

@bmeeks8 Hope you don't mind this very small cleanup. ;)