### PR TITLE
backup package - cleanup round two

### DIFF
--- a/config/backup/backup.inc
+++ b/config/backup/backup.inc
@@ -1,14 +1,11 @@
 <?php
-/* $Id$ */
-/*
-/* ========================================================================== */
 /*
 	backup.inc
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2008 Mark J Crane
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
-*/
-/* ========================================================================== */
-/*
+
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:
 
@@ -30,23 +27,7 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
-
-if (!function_exists("byte_convert")) {
-	function byte_convert( $bytes ) {
-		if ($bytes <= 0) {
-			return '0 Byte';
-		}
-
-		$convention = 1000; //[1000->10^x|1024->2^x]
-		$s = array('B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB');
-		$e = floor(log($bytes, $convention));
-		return round($bytes/pow($convention, $e), 2) . ' ' . $s[$e];
-	}
-}
-
-function backup_sync_package_php() {
-
+function backup_sync_package() {
 	global $config;
 	if ($config['installedpackages']['backup']['config'] != "") {
 		conf_mount_rw();
@@ -65,26 +46,12 @@ function backup_sync_package_php() {
 	}
 }
 
-function backup_sync_package() {
-	global $config;
-	backup_sync_package_php();
-}
-
-
 function backup_install_command() {
-
-	global $config;
 	conf_mount_rw();
-
-	//create the backup directory
-	if (!is_dir('/root/backup/')) {
-		@mkdir("/root/backup/");
-	}
-
+	// Create the backup directory
+	safe_mkdir("/root/backup/");
 	backup_sync_package();
-
 	conf_mount_ro();
-
 }
 
 ?>

--- a/config/backup/backup.php
+++ b/config/backup/backup.php
@@ -1,8 +1,9 @@
 <?php
-/* $Id$ */
 /*
 	backup.php
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2008 Mark J Crane
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -26,11 +27,14 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
+require_once("guiconfig.inc");
+require_once("/usr/local/pkg/backup.inc");
 
-require("guiconfig.inc");
-require("/usr/local/pkg/backup.inc");
-
+global $config, $backup_dir, $backup_filename, $backup_path;
 $a_backup = &$config['installedpackages']['backup']['config'];
+$backup_dir = "/root/backup";
+$backup_filename = "pfsense.bak.tgz";
+$backup_path = "{$backup_dir}/{$backup_filename}";
 
 if ($_GET['act'] == "del") {
 	if ($_GET['type'] == 'backup') {
@@ -49,31 +53,29 @@ if ($_GET['a'] == "download") {
 	if ($_GET['t'] == "backup") {
 		conf_mount_rw();
 
-		$tmp = '/root/backup/';
-		$filename = 'pfsense.bak.tgz';
-		//system('cd /usr/local/;tar cvzf /root/backup/pfsense.bak.tgz freeswitch');
-
 		$i = 0;
 		if (count($a_backup) > 0) {
-			$backup_cmd = 'tar --create --verbose --gzip --file '.$tmp.$filename.' --directory / ';
+			/* Do NOT remove the trailing space after / from $backup_cmd below!!! */
+			$backup_cmd = "/usr/bin/tar --create --verbose --gzip --file {$backup_path} --directory / ";
 			foreach ($a_backup as $ent) {
 				if ($ent['enabled'] == "true") {
-					//htmlspecialchars($ent['name']);
-					//htmlspecialchars($ent['path']);
-					//htmlspecialchars($ent['description']);
-					$backup_cmd .= htmlspecialchars($ent['path']).' ';
+					$backup_cmd .= htmlspecialchars($ent['path']) . ' ';
 				}
 				$i++;
 			}
-			//echo $backup_cmd; //exit;
 			system($backup_cmd);
 		}
 
 		session_cache_limiter('public');
-		$fd = fopen($tmp.$filename, "rb");
+		$fd = fopen("{$backup_path}", "rb");
+		header("Content-Type: application/force-download");
 		header("Content-Type: binary/octet-stream");
-		header("Content-Length: " . filesize($tmp.$filename));
-		header('Content-Disposition: attachment; filename="' . $filename . '"');
+		header("Content-Type: application/download");
+		header("Content-Description: File Transfer");
+		header('Content-Disposition: attachment; filename="' . $backup_filename . '"');
+		header("Cache-Control: no-cache, must-revalidate");
+		header("Expires: Sat, 26 Jul 1997 05:00:00 GMT");
+		header("Content-Length: " . filesize($backup_path));
 		fpassthru($fd);
 
 		conf_mount_ro();
@@ -83,17 +85,13 @@ if ($_GET['a'] == "download") {
 
 if ($_GET['a'] == "other") {
 	if ($_GET['t'] == "restore") {
-		conf_mount_rw();
-		$tmp = '/root/backup/';
-		$filename = 'pfsense.bak.tgz';
-
-		//extract the tgz file
-		if (file_exists('/root/backup/'.$filename)) {
-			//echo "The file $filename exists";
-			system('cd /; tar xvpfz /root/backup/'.$filename.' ');
-			header( 'Location: backup.php?savemsg=Backup+has+been+restored.' ) ;
+		// Extract the tgz file
+		if (file_exists($backup_path)) {
+			conf_mount_rw();
+			system("/usr/bin/tar -xpzC / -f {$backup_path}");
+			header("Location: backup.php?savemsg=Backup+has+been+restored.");
 		} else {
-			header( 'Location: backup.php?savemsg=Restore+failed.+Backup+file+not+found.' ) ;
+			header("Location: backup.php?savemsg=Restore+failed.+Backup+file+not+found.");
 		}
 		conf_mount_ro();
 		exit;
@@ -102,21 +100,20 @@ if ($_GET['a'] == "other") {
 
 if (($_POST['submit'] == "Upload") && is_uploaded_file($_FILES['ulfile']['tmp_name'])) {
 	conf_mount_rw();
-	$filename = 'pfsense.bak.tgz';
-	move_uploaded_file($_FILES['ulfile']['tmp_name'], "/root/backup/" . $filename);
-	$savemsg = "Uploaded file to /root/backup/" . htmlentities($_FILES['ulfile']['name']);
-	system('cd /; tar xvpfz /root/backup/'.$filename.' ');
+	move_uploaded_file($_FILES['ulfile']['tmp_name'], "{$backup_path}");
+	$savemsg = "Uploaded file to {$backup_dir}" . htmlentities($_FILES['ulfile']['name']);
+	system("/usr/bin/tar -xpzC / -f {$backup_path}");
 	conf_mount_ro();
 }
 
+$pgtitle = "Backup: Files &amp; Directories";
 include("head.inc");
 
 ?>
 
-
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 <?php include("fbegin.inc"); ?>
-<p class="pgtitle">Backup: Files & Directories</p>
+
 
 <?php
 if ($_GET["savemsg"]) {
@@ -143,16 +140,12 @@ if ($_GET["savemsg"]) {
 
 	<table width="100%" border="0" cellpadding="0" cellspacing="0">
 	<tr>
-		<td>
-			<p>
-			Use this to tool to backup files and directories. The following directories
-			are recommended for backup.
-
+		<td>Use this to tool to backup files and directories. The following directories are recommended for backup:
 			<table>
-			<tr><td><strong>pfSense Config</strong></td><td>/cf/conf</td></tr>
-			<tr><td><strong>RRD Graph Data Files</strong></td><td>/var/db/rrd</td></tr>
+				<tr><td></td><td></td></tr>
+				<tr><td><strong>pfSense Config</strong></td><td>/cf/conf</td></tr>
+				<tr><td><strong>RRD Graph Data Files</strong></td><td>/var/db/rrd</td></tr>
 			</table>
-			</p>
 		</td>
 	</tr>
 	</table>
@@ -161,73 +154,65 @@ if ($_GET["savemsg"]) {
 	<br/>
 
 	<div id="niftyOutter">
-
-	<form action="backup.php" method="POST" enctype="multipart/form-data" name="frmUpload" onSubmit="">
-		<table width='100%' width='690' cellpadding='0' cellspacing='0' border='0'>
+	<form action="backup.php" method="post" enctype="multipart/form-data" name="frmUpload" onsubmit="">
+		<table width='690' cellpadding='0' cellspacing='0' border='0'>
 		<tr><td align='left' colspan='4'><strong>Upload and Restore</strong></td></tr>
 		<tr>
 			<td colspan='2'>Use this to upload and restore your backup file.</td>
 			<td align="right">File to upload:</td>
 			<td width='50%' valign="top" align='right' class="label">
-				<input name="ulfile" type="file" class="button" id="ulfile">
+				<input name="ulfile" type="file" class="button" id="ulfile" />
 			</td>
 			<td valign="top" class="label">
-				<input name="submit" type="submit"  class="button" id="upload" value="Upload">
+				<input name="submit" type="submit" class="button" id="upload" value="Upload" />
 			</td>
 		</tr>
 		</table>
 		<br />
 		<br />
-	</div>
 	</form>
+	</div>
 
+	<table width='690' cellpadding='0' cellspacing='0' border='0'>
+	<tr>
+		<td width='80%'>
+		<strong>Backup / Restore</strong><br />
+		The 'Backup' button compresses the directories that are listed below to /root/backup/pfsense.bak.tgz; after that it presents the file for download.<br />
+		If the backup file does not exist in /root/backup/pfsense.bak.tgz then the 'Restore' button will be hidden.<br /><br /><br />
+		</td>
+		<td width='20%' valign='middle' align='right'>
+			<input type='button' value='Backup' onclick="document.location.href='backup.php?a=download&amp;t=backup';" />
+			<?php
+				if (file_exists($backup_path)) {
+					echo "\t<input type='button' value='Restore' onclick=\"document.location.href='backup.php?a=other&amp;t=restore';\" />\n";
+				}
+			?>
+		</td>
+	</tr>
+	</table>
+	<br /><br />
+
+
+	<form action='backup.php' method='post' name='iform' id='iform'>
 
 <?php
-	echo "<table width='690' cellpadding='0' cellspacing='0' border='0'>\n";
-	echo "<tr>\n";
-	echo "<td width='80%'>\n";
-	echo "<b>Backup / Restore</b><br />\n";
-	echo "The 'backup' button will tar gzip the directories that are listed below to /root/backup/pfsense.bak.tgz it then presents a file to download. \n";
-	echo "If the backup file does not exist in /root/backup/pfsense.bak.tgz then the 'restore' button will be hidden. \n";
-	echo "<br /><br />\n";
-	echo "</td>\n";
-	echo "<td width='20%' valign='middle' align='right'>\n";
-	echo "  <input type='button' value='backup' onclick=\"document.location.href='backup.php?a=download&t=backup';\" />\n";
-	if (file_exists('/root/backup/pfsense.bak.tgz')) {
-	  echo "  <input type='button' value='restore' onclick=\"document.location.href='backup.php?a=other&t=restore';\" />\n";
-	}
-	echo "</td>\n";
-	echo "</tr>\n";
-	echo "</table>\n";
-	echo "<br /><br />\n\n";
-
-
-echo "  <form action='backup.php' method='post' name='iform' id='iform'>\n";
-
-
 if ($config_change == 1) {
-    write_config();
-    $config_change = 0;
+	write_config();
+	$config_change = 0;
 }
-
-//if ($savemsg) print_info_box($savemsg);
-//if (file_exists($d_hostsdirty_path)): echo"<p>";
-//print_info_box_np("This is an info box.");
-//echo"<br />";
-//endif;
-
 ?>
 
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 	<tr>
-		<td width="30%" class="listhdrr">Name</td>
-		<td width="20%" class="listhdrr">Enabled</td>
+		<td width="20%" class="listhdrr">Name</td>
+		<td width="25%" class="listhdrr">Path</td>
+		<td width="5%" class="listhdrr">Enabled</td>
 		<td width="40%" class="listhdr">Description</td>
 		<td width="10%" class="list">
 			<table border="0" cellspacing="0" cellpadding="1">
 				<tr>
 					<td width="17"></td>
-					<td valign="middle"><a href="backup_edit.php"><img src="/themes/<?= $g['theme']; ?>/images/icons/icon_plus.gif" width="17" height="17" border="0"></a></td>
+					<td valign="middle"><a href="backup_edit.php"><img src="/themes/<?= $g['theme']; ?>/images/icons/icon_plus.gif" alt="" width="17" height="17" border="0" /></a></td>
 				</tr>
 			</table>
 		</td>
@@ -246,16 +231,19 @@ if ($config_change == 1) {
 			<?=$ent['name'];?>&nbsp;
 		</td>
 		<td class="listr" ondblclick="document.location='backup_edit.php?id=<?=$i;?>';">
+			<?=$ent['path'];?>&nbsp;
+		</td>
+		<td class="listr" ondblclick="document.location='backup_edit.php?id=<?=$i;?>';">
 			<?=$ent['enabled'];?>&nbsp;
 		</td>
 		<td class="listbg" ondblclick="document.location='backup_edit.php?id=<?=$i;?>';">
-			<font color="#FFFFFF"><?=htmlspecialchars($ent['description']);?>&nbsp;
+			<font color="#FFFFFF"><?=htmlspecialchars($ent['description']);?>&nbsp;</font>
 		</td>
-		<td valign="middle" nowrap class="list">
+		<td valign="middle" nowrap="nowrap" class="list">
 			<table border="0" cellspacing="0" cellpadding="1">
 				<tr>
-					<td valign="middle"><a href="backup_edit.php?id=<?=$i;?>"><img src="/themes/<?= $g['theme']; ?>/images/icons/icon_e.gif" width="17" height="17" border="0"></a></td>
-					<td><a href="backup_edit.php?type=backup&act=del&id=<?=$i;?>" onclick="return confirm('Do you really want to delete this?')"><img src="/themes/<?= $g['theme']; ?>/images/icons/icon_x.gif" width="17" height="17" border="0"></a></td>
+					<td valign="middle"><a href="backup_edit.php?id=<?=$i;?>"><img src="/themes/<?= $g['theme']; ?>/images/icons/icon_e.gif" alt="" width="17" height="17" border="0" /></a></td>
+					<td><a href="backup_edit.php?type=backup&amp;act=del&amp;id=<?=$i;?>" onclick="return confirm('Do you really want to delete this?')"><img src="/themes/<?= $g['theme']; ?>/images/icons/icon_x.gif" alt="" width="17" height="17" border="0" /></a></td>
 				</tr>
 			</table>
 		</td>
@@ -267,12 +255,12 @@ if ($config_change == 1) {
 	?>
 
 	<tr>
-		<td class="list" colspan="3"></td>
+		<td class="list" colspan="4"></td>
 		<td class="list">
 			<table border="0" cellspacing="0" cellpadding="1">
 				<tr>
 					<td width="17"></td>
-					<td valign="middle"><a href="backup_edit.php"><img src="/themes/<?= $g['theme']; ?>/images/icons/icon_plus.gif" width="17" height="17" border="0"></a></td>
+					<td valign="middle"><a href="backup_edit.php"><img src="/themes/<?= $g['theme']; ?>/images/icons/icon_plus.gif" alt="" width="17" height="17" border="0" /></a></td>
 				</tr>
 			</table>
 		</td>
@@ -283,17 +271,9 @@ if ($config_change == 1) {
 		<td class="list"></td>
 	</tr>
 </table>
-
 </form>
 
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
+<br />
 
 </td>
 </tr>

--- a/config/backup/backup.xml
+++ b/config/backup/backup.xml
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-		<![CDATA[
+	<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
 	backup.xml
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2008 Mark J Crane
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:
+
 
 	1. Redistributions of source code must retain the above copyright notice,
 	   this list of conditions and the following disclaimer.
@@ -22,6 +25,7 @@
 	2. Redistributions in binary form must reproduce the above copyright
 	   notice, this list of conditions and the following disclaimer in the
 	   documentation and/or other materials provided with the distribution.
+
 
 	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
 	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
@@ -34,14 +38,12 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-/* ========================================================================== */
-		]]>
+/* ====================================================================================== */
+	]]>
 	</copyright>
 	<description>Backup</description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>Backup Settings</name>
-	<version>0.1.8</version>
+	<version>0.1.9</version>
 	<title>Settings</title>
 	<include_file>/usr/local/pkg/backup.inc</include_file>
 	<menu>
@@ -53,53 +55,24 @@
 	</menu>
 	<tabs>
 		<tab>
-			<text>Settings</text>
-			<url>/pkg_edit.php?xml=backup.xml&amp;id=0</url>
-			<active/>
-		</tab>
-		<tab>
-			<text>Settings</text>
-			<url>/packages/backup.php</url>
+			<text>Backup</text>
+			<url>/packages/backup/backup.php</url>
 			<active/>
 		</tab>
 	</tabs>
 	<configpath>installedpackages->package->$packagename->configuration->backup</configpath>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/backup/backup.xml</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 		<item>https://packages.pfsense.org/packages/config/backup/backup.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/packages/backup/</prefix>
-		<chmod>0755</chmod>
 		<item>https://packages.pfsense.org/packages/config/backup/backup.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/packages/backup/</prefix>
-		<chmod>0755</chmod>
 		<item>https://packages.pfsense.org/packages/config/backup/backup_edit.php</item>
 	</additional_files_needed>
-	<fields>
-		<field>
-			<fielddescr>Example Variable One</fielddescr>
-			<fieldname>var1</fieldname>
-			<description>Enter the variable one here.</description>
-			<type>input</type>
-		</field>
-		<field>
-			<fielddescr>Example Variable Two</fielddescr>
-			<fieldname>var1</fieldname>
-			<description>Enter the variable one here.</description>
-			<type>input</type>
-		</field>
-	</fields>
-	<custom_add_php_command>
-	</custom_add_php_command>
 	<custom_php_resync_config_command>
 		backup_sync_package();
 	</custom_php_resync_config_command>

--- a/config/backup/backup_edit.php
+++ b/config/backup/backup_edit.php
@@ -1,9 +1,9 @@
 <?php
-/* $Id$ */
 /*
-
 	backup_edit.php
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2008 Mark J Crane
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -27,9 +27,8 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
-require("guiconfig.inc");
-require("/usr/local/pkg/backup.inc");
+require_once("guiconfig.inc");
+require_once("/usr/local/pkg/backup.inc");
 
 
 $a_backup = &$config['installedpackages']['backup']['config'];
@@ -63,7 +62,7 @@ if (isset($id) && $a_backup[$id]) {
 }
 
 if ($_POST) {
-
+	/* TODO - This needs some basic input validation for the path at least */
 	unset($input_errors);
 	$pconfig = $_POST;
 
@@ -76,10 +75,10 @@ if ($_POST) {
 		$ent['description'] = $_POST['description'];
 
 		if (isset($id) && $a_backup[$id]) {
-			//update
+			// update
 			$a_backup[$id] = $ent;
 		} else {
-			//add
+			// add
 			$a_backup[] = $ent;
 		}
 
@@ -91,23 +90,22 @@ if ($_POST) {
 	}
 }
 
+$pgtitle = "Backup: Edit";
 include("head.inc");
 
 ?>
 
-<script type="text/javascript" language="JavaScript">
-
+<body link="#0000CC" vlink="#0000CC" alink="#0000CC">
+<?php include("fbegin.inc"); ?>
+<script type="text/javascript">
+//<![CDATA[
 function show_advanced_config() {
 	document.getElementById("showadvancedbox").innerHTML = '';
 	aodiv = document.getElementById('showadvanced');
 	aodiv.style.display = "block";
+}
+//]]>
 </script>
-
-<body link="#0000CC" vlink="#0000CC" alink="#0000CC">
-<?php include("fbegin.inc"); ?>
-<p class="pgtitle">Backup: Edit</p>
-<?php if ($input_errors) print_input_errors($input_errors); ?>
-
 
 <div id="mainlevel">
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
@@ -124,16 +122,6 @@ function show_advanced_config() {
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 	<tr>
 		<td class="tabcont" >
-
-			<!--
-			<table width="100%" border="0" cellpadding="6" cellspacing="0">
-			  <tr>
-				<td><p><span class="vexpl"><span class="red"><strong>PHP<br>
-					</strong></span>
-					</p></td>
-			  </tr>
-			</table>
-			-->
 			<br />
 
 			<form action="backup_edit.php" method="post" name="iform" id="iform">
@@ -142,67 +130,60 @@ function show_advanced_config() {
 					<tr>
 						<td width="25%" valign="top" class="vncellreq">Name</td>
 						<td width="75%" class="vtable">
-							<input name="name" type="text" class="formfld" id="name" size="40" value="<?=htmlspecialchars($pconfig['name']);?>">
+							<input name="name" type="text" class="formfld" id="name" size="40" value="<?=htmlspecialchars($pconfig['name']);?>" />
 						</td>
 					</tr>
 
 					<tr>
 						<td width="22%" valign="top" class="vncellreq">Path</td>
 						<td width="78%" class="vtable">
-							<input name="path" type="text" class="formfld" id="path" size="40" value="<?=htmlspecialchars($pconfig['path']);?>">
+							<input name="path" type="text" class="formfld" id="path" size="40" value="<?=htmlspecialchars($pconfig['path']);?>" />
 						</td>
 					</tr>
 					<tr>
 						<td width="22%" valign="top" class="vncellreq">Enabled</td>
 						<td width="78%" class="vtable">
 							<?php
-							echo "              <select name='enabled' class='formfld'>\n";
-							echo "                <option></option>\n";
+							echo "<select name='enabled' class='formfld'>\n";
+							echo "\t\t\t\t\t\t\t\t<option></option>\n";
 							switch (htmlspecialchars($pconfig['enabled'])) {
 								case "true":
-									echo "              <option value='true' selected='yes'>true</option>\n";
-									echo "              <option value='false'>false</option>\n";
+									echo "\t\t\t\t\t\t\t\t<option value='true' selected='selected'>true</option>\n";
+									echo "\t\t\t\t\t\t\t\t<option value='false'>false</option>\n";
 									break;
-								case "false":
-									echo "              <option value='true'>true</option>\n";
-									echo "              <option value='false' selected='yes'>false</option>\n";
 
+								case "false":
+									echo "\t\t\t\t\t\t\t\t<option value='true'>true</option>\n";
+									echo "\t\t\t\t\t\t\t\t<option value='false' selected='selected'>false</option>\n";
 									break;
+
 								default:
-									echo "              <option value='true' selected='yes'>true</option>\n";
-									echo "              <option value='false'>false</option>\n";
+									echo "\t\t\t\t\t\t\t\t<option value='true' selected='selected'>true</option>\n";
+									echo "\t\t\t\t\t\t\t\t<option value='false'>false</option>\n";
 							}
-							echo "              </select>\n";
+							echo "\t\t\t\t\t\t\t</select>\n";
 							?>
 						</td>
 					</tr>
 					<tr>
 						<td width="25%" valign="top" class="vncellreq">Description</td>
 						<td width="75%" class="vtable">
-							<input name="description" type="text" class="formfld" id="description" size="40" value="<?=htmlspecialchars($pconfig['description']);?>">
-							<br><span class="vexpl">Enter the description here.<br></span>
+							<input name="description" type="text" class="formfld" id="description" size="40" value="<?=htmlspecialchars($pconfig['description']);?>" /><br/>
+							<span class="vexpl">Enter the description here.<br /></span>
 						</td>
 					</tr>
 
 					<tr>
 						<td valign="top">&nbsp;</td>
 						<td>
-							<input name="Submit" type="submit" class="formbtn" value="Save"> <input class="formbtn" type="button" value="Cancel" onclick="history.back()">
+							<input name="Submit" type="submit" class="formbtn" value="Save" />&nbsp;<input class="formbtn" type="button" value="Cancel" onclick="history.back()" />
 							<?php if (isset($id) && $a_backup[$id]): ?>
-								<input name="id" type="hidden" value="<?=$id;?>">
+								<input name="id" type="hidden" value="<?=$id;?>" />
 							<?php endif; ?>
 						</td>
 					</tr>
 				</table>
 			</form>
-
-			<br>
-			<br>
-			<br>
-			<br>
-			<br>
-			<br>
-
 		</td>
 	</tr>
 </table>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -363,7 +363,7 @@
 		<descr>Tool to Backup and Restore files and directories.</descr>
 		<category>System</category>
 		<config_file>https://packages.pfsense.org/packages/config/backup/backup.xml</config_file>
-		<version>0.1.8</version>
+		<version>0.1.9</version>
 		<status>Beta</status>
 		<required_version>2.2</required_version>
 		<maintainer>markjcrane@gmail.com</maintainer>


### PR DESCRIPTION
backup.xml
- Removed self-referencing additional_files_needed 
- Fix copyright header
- Remove pointless/unused tags
- Remove WTF &lt;fields&gt; copy/paste code coming from god knows where
- Removed no-op duplicated &lt;tab&gt; and fix the url in the other one
- Fix files permissions

backup.inc
- Fix copyright header
- Removed unused byte_convert() function
- Rename backup_sync_package_php() to backup_sync_package() and get rid of the original backup_sync_package()  which only called the other one.

backup.php, backup_edit.php
- Clean up obvious leftover crap
- XHTML valid code