### PR TITLE
haproxy-devel - fix file permissions

### DIFF
--- a/config/haproxy-devel/haproxy.xml
+++ b/config/haproxy-devel/haproxy.xml
@@ -3,44 +3,44 @@
 <?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
         <copyright>
-        <![CDATA[
+	<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    haproxy.xml
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2009 Scott Ullrich
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
+	backup.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2009 Scott Ullrich
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
-        </copyright>
-    <description>Describe your package here</description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>haproxy</name>
 	<version>1.0</version>
 	<title>HAProxy</title>
@@ -75,72 +75,58 @@
 	<configpath>installedpackages->haproxy->config</configpath>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/pkg/haproxy.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/www/haproxy_listeners.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/www/haproxy_listeners_edit.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/www/haproxy_global.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/www/haproxy_files.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/www/haproxy_pools.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/www/haproxy_pool_edit.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/www/haproxy_stats.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/www/haproxy_templates.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/pkg/haproxy_socketinfo.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/pkg/haproxy_xmlrpcsyncclient.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/pkg/haproxy_htmllist.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/pkg/haproxy_utils.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/widgets/widgets/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/www/widgets/widgets/haproxy.widget.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
@@ -150,31 +136,20 @@
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/pkg/pkg_haproxy_tabs.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/pkg/haproxy_upgrade_config.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/javascript/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/haproxy-devel/www/javascript/haproxy_geturl.js</item>
 	</additional_files_needed>
-	<custom_delete_php_command>
-	</custom_delete_php_command>
-	<custom_add_php_command>
-	</custom_add_php_command>
-	<custom_php_resync_config_command>
-	</custom_php_resync_config_command>
 	<custom_php_install_command>
 		haproxy_custom_php_install_command();
 	</custom_php_install_command>
 	<custom_php_deinstall_command>
 		haproxy_custom_php_deinstall_command();
 	</custom_php_deinstall_command>
-	<custom_php_command_before_form>	
-	</custom_php_command_before_form>
 </packagegui>

--- a/config/haproxy-devel/haproxy.xml
+++ b/config/haproxy-devel/haproxy.xml
@@ -7,7 +7,7 @@
 /* $Id$ */
 /* ====================================================================================== */
 /*
-	backup.xml
+	haproxy.xml
 	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2009 Scott Ullrich
 	Copyright (C) 2015 ESF, LLC
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>haproxy</name>
-	<version>1.0</version>
+	<version>0.28</version>
 	<title>HAProxy</title>
 	<aftersaveredirect>/pkg_edit.php?xml=haproxy_pools.php</aftersaveredirect>
 	<include_file>/usr/local/pkg/haproxy.inc</include_file>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -185,7 +185,7 @@
 		</descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>0.27</version>
+		<version>0.28</version>
 		<status>Release</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>


### PR DESCRIPTION
Updated copyright header and nuked useless unused tags while here.

I bumped the package version. Thinking about this, these broken permissions have potential security impact.