### PR TITLE
quagga_ospfd - fix file permissions

### DIFF
--- a/config/quagga_ospfd/quagga_ospfd.xml
+++ b/config/quagga_ospfd/quagga_ospfd.xml
@@ -1,32 +1,70 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
+	<copyright>
+	<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
+/*
+	quagga_ospfd.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012-2015 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>quagga_ospfd</name>
-	<version>0.6.5</version>
+	<version>0.6.6</version>
 	<title>Services: Quagga OSPFd</title>
 	<include_file>/usr/local/pkg/quagga_ospfd.inc</include_file>
 	<aftersaveredirect>pkg_edit.php?xml=quagga_ospfd.xml&amp;id=0</aftersaveredirect>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>644</chmod>
 		<item>https://packages.pfsense.org/packages/config/quagga_ospfd/quagga_ospfd.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>644</chmod>
 		<item>https://packages.pfsense.org/packages/config/quagga_ospfd/quagga_ospfd_interfaces.xml</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>644</chmod>
 		<item>http://www.pfsense.com/packages/config/quagga_ospfd/quagga_ospfd_raw.xml</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>644</chmod>
 		<item>https://packages.pfsense.org/packages/config/quagga_ospfd/status_ospfd.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/bin/</prefix>
-		<chmod>777</chmod>
+		<chmod>755</chmod>
 		<item>https://packages.pfsense.org/packages/config/quagga_ospfd/quaggactl</item>
 	</additional_files_needed>
 	<menu>
@@ -76,11 +114,7 @@
 		<field>
 			<fielddescr>Master Password</fielddescr>
 			<fieldname>password</fieldname>
-			<description>
-				<![CDATA[
-					Password to access the Zebra and OSPF management daemons. Required.
-				]]>
-			</description>
+			<description>Password to access the Zebra and OSPF management daemons. Required.</description>
 			<type>input</type>
 			<required/>
 		</field>
@@ -101,7 +135,8 @@
 			<fieldname>routerid</fieldname>
 			<description>
 				<![CDATA[
-					Specify the Router ID. RID is the highest logical (loopback) IP address configured on a router. For more information on router identifiers see <a target='_new' href='http://en.wikipedia.org/wiki/Open_Shortest_Path_First'>wikipedia</a>. 
+				Specify the Router ID. RID is the highest logical (loopback) IP address configured on a router.<br />
+				For more information on router identifiers see <a href='http://en.wikipedia.org/wiki/Open_Shortest_Path_First'>wikipedia</a>.
 				]]>
 			</description>
 			<type>input</type>
@@ -111,7 +146,8 @@
 			<fieldname>area</fieldname>
 			<description>
 				<![CDATA[
-					OSPFd area for this instance of OSPF. For more information on Areas see <a target='_new'  href='http://en.wikipedia.org/wiki/Open_Shortest_Path_First#Area_types'>wikipedia</a>.
+				OSPFd area for this instance of OSPF.<br />
+				For more information on Areas see <a href='http://en.wikipedia.org/wiki/Open_Shortest_Path_First#Area_types'>wikipedia</a>.
 				]]>
 			</description>
 			<type>input</type>
@@ -151,19 +187,29 @@
 		<field>
 			<fielddescr>SPF Hold Time</fielddescr>
 			<fieldname>spfholdtime</fieldname>
-			<description>Set the SPF holdtime in MILLIseconds.  The minimum time between two consecutive shortest path first calculations.  The default value is 5 seconds; the valid range is 1-5 seconds.</description>
+			<description>
+				<![CDATA[
+				Set the SPF holdtime in <strong>milli</strong>seconds. The minimum time between two consecutive shortest path first calculations.<br />
+				The default value is 5 seconds; the valid range is 1-5 seconds.
+				]]>
+				</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>SPF Delay</fielddescr>
 			<fieldname>spfdelay</fieldname>
-			<description>Set SPF delay in MILLIseconds.  The delay between receiving an update to the link state database and starting the shortest path first calculation.  The default value is 1; valid range is 1-10 seconds.</description>
+			<description>
+				<![CDATA[
+				Set SPF delay in <strong>milli</strong>seconds. The delay between receiving an update to the link state database and starting the shortest path first calculation.<br />
+				The default value is 1; valid range is 1-10 seconds.
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
 			<fielddescr>RFC 1583 compatible</fielddescr>
 			<fieldname>rfc1583</fieldname>
-			<description>If set to yes, decisions regarding AS-external routes are evaluated according to RFC 1583.  The default is no.</description>
+			<description>If set to yes, decisions regarding AS-external routes are evaluated according to RFC 1583. The default is no.</description>
 			<type>checkbox</type>
 		</field>
 		<field>
@@ -202,7 +248,12 @@
 		<field>
 			<fielddescr>CARP Status IP</fielddescr>
 			<fieldname>carpstatusip</fieldname>
-			<description>IP address used to determine the CARP status. When the VIP is in BACKUP status, quagga will not be started. &lt;br/&gt;NOTE: Requires changes to /etc/rc.carpmaster to start quagga and /etc/rc.carpbackup to stop quagga or it will not be fully effective.</description>
+			<description>
+				<![CDATA[
+				IP address used to determine the CARP status. When the VIP is in BACKUP status, quagga will not be started.<br />
+				NOTE: Requires changes to /etc/rc.carpmaster to start quagga and /etc/rc.carpbackup to stop quagga or it will not be fully effective.
+				]]>
+			</description>
 			<type>input</type>
 			<size>25</size>
 		</field>

--- a/config/quagga_ospfd/quagga_ospfd_interfaces.xml
+++ b/config/quagga_ospfd/quagga_ospfd_interfaces.xml
@@ -1,12 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
+	<copyright>
+	<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
+/*
+	quagga_ospfd_interfaces.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012-2015 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>quagga_ospfd_interfaces</name>
-	<version>0.1</version>
+	<version>0.6.6</version>
 	<title>Services: Quagga OSPFd</title>
 	<include_file>/usr/local/pkg/quagga_ospfd.inc</include_file>
 	<aftersaveredirect>pkg.php?xml=quagga_ospfd_interfaces.xml</aftersaveredirect>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>077</chmod>
 		<item>https://packages.pfsense.org/packages/config/quagga_ospfd/quagga_ospfd.inc</item>
 	</additional_files_needed>
 	<menu>
@@ -17,23 +58,23 @@
 		<url>/pkg_edit.php?xml=quagga_ospfd.xml&amp;id=0</url>
 	</menu>
 	<tabs>
-	<tab>
-		<text>Global Settings</text>
-		<url>pkg_edit.php?xml=quagga_ospfd.xml&amp;id=0</url>
-	</tab>
-	<tab>
-		<text>Interface Settings</text>
-		<url>pkg.php?xml=quagga_ospfd_interfaces.xml</url>
-		<active/>
-	</tab>
-	<tab>
-		<text>Raw Config</text>
-		<url>pkg_edit.php?xml=quagga_ospfd_raw.xml&amp;id=0</url>
-	</tab>
-	<tab>
-		<text>Status</text>
-		<url>/status_ospfd.php</url>
-	</tab>	
+		<tab>
+			<text>Global Settings</text>
+			<url>pkg_edit.php?xml=quagga_ospfd.xml&amp;id=0</url>
+		</tab>
+		<tab>
+			<text>Interface Settings</text>
+			<url>pkg.php?xml=quagga_ospfd_interfaces.xml</url>
+			<active/>
+		</tab>
+		<tab>
+			<text>Raw Config</text>
+			<url>pkg_edit.php?xml=quagga_ospfd_raw.xml&amp;id=0</url>
+		</tab>
+		<tab>
+			<text>Status</text>
+			<url>/status_ospfd.php</url>
+		</tab>	
 	</tabs>
 	<adddeleteeditpagefields>
 		<columnitem>
@@ -87,7 +128,7 @@
 		<field>
 			<fielddescr>Interface is Passive</fielddescr>
 			<fieldname>passive</fieldname>
-			<description>Prevent transmission and reception of OSPF packets on this interface.  The specified interface will be announced as a stub network.</description>
+			<description>Prevent transmission and reception of OSPF packets on this interface. The specified interface will be announced as a stub network.</description>
 			<type>checkbox</type>
 		</field>
 		<field>
@@ -112,7 +153,10 @@
 			<fielddescr>Router Priority</fielddescr>
 			<fieldname>routerpriorityelections</fieldname>
 			<description>
-					Router priority when participating in elections for DR (Default 1) Valid range is 0-255.  0 will cause the router to not participate in election.
+				<![CDATA[
+				Router priority when participating in elections for DR (Default 1)<br />
+				Valid range is 0-255. 0 will cause the router to not participate in election.
+				]]>
 			</description>
 			<type>input</type>
 		</field>

--- a/config/quagga_ospfd/quagga_ospfd_raw.xml
+++ b/config/quagga_ospfd/quagga_ospfd_raw.xml
@@ -1,12 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
+	<copyright>
+	<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
+/*
+	quagga_ospfd_raw.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012-2015 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>quagga_ospfd_raw</name>
-	<version>0.1</version>
+	<version>0.6.6</version>
 	<title>Services: Quagga OSPFd</title>
 	<include_file>/usr/local/pkg/quagga_ospfd.inc</include_file>
 	<aftersaveredirect>pkg_edit.php?xml=quagga_ospfd_raw.xml&amp;id=0</aftersaveredirect>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>077</chmod>
 		<item>http://www.pfsense.com/packages/config/quagga_ospfd/quagga_ospfd.inc</item>
 	</additional_files_needed>
 	<menu>
@@ -17,23 +58,23 @@
 		<url>/pkg_edit.php?xml=quagga_ospfd.xml&amp;id=0</url>
 	</menu>
 	<tabs>
-	<tab>
-		<text>Global Settings</text>
-		<url>pkg_edit.php?xml=quagga_ospfd.xml&amp;id=0</url>
-	</tab>
-	<tab>
-		<text>Interface Settings</text>
-		<url>pkg.php?xml=quagga_ospfd_interfaces.xml</url>
-	</tab>
-	<tab>
-		<text>Raw Config</text>
-		<url>pkg_edit.php?xml=quagga_ospfd_raw.xml&amp;id=0</url>
-		<active/>
-	</tab>
-	<tab>
-		<text>Status</text>
-		<url>/status_ospfd.php</url>
-	</tab>	
+		<tab>
+			<text>Global Settings</text>
+			<url>pkg_edit.php?xml=quagga_ospfd.xml&amp;id=0</url>
+		</tab>
+		<tab>
+			<text>Interface Settings</text>
+			<url>pkg.php?xml=quagga_ospfd_interfaces.xml</url>
+		</tab>
+		<tab>
+			<text>Raw Config</text>
+			<url>pkg_edit.php?xml=quagga_ospfd_raw.xml&amp;id=0</url>
+			<active/>
+		</tab>
+		<tab>
+			<text>Status</text>
+			<url>/status_ospfd.php</url>
+		</tab>	
 	</tabs>
 	<service>
 		<name>Quagga OSPFd</name>
@@ -49,7 +90,12 @@
 		<field>
 			<fielddescr>ospfd.conf</fielddescr>
 			<fieldname>ospfd</fieldname>
-			<description>Note: Once you click "Save" below, the assistant (in the "Global Settings" and "Interface Settings" tabs above) will be overridden with whatever you type here. To get back the assisted config save this form below once with both empty input fields.</description>
+			<description>
+				<![CDATA[
+				Note: Once you click "Save" below, the assistant (in the "Global Settings" and "Interface Settings" tabs above) will be overridden with whatever you type here.<br />
+				To get back the assisted config save this form below once with both empty input fields.
+				]]>
+			</description>
 			<type>textarea</type>
 			<encoding>base64</encoding>
 			<rows>30</rows>
@@ -58,7 +104,12 @@
 		<field>
 			<fielddescr>zebra.conf</fielddescr>
 			<fieldname>zebra</fieldname>
-			<description>Note: Once you click "Save" below, the assistant (in the "Global Settings" and "Interface Settings" tabs above) will be overridden with whatever you type here. To get back the assisted config save this form below once with both empty input fields.</description>
+			<description>
+				<![CDATA[
+				Note: Once you click "Save" below, the assistant (in the "Global Settings" and "Interface Settings" tabs above) will be overridden with whatever you type here.<br />
+				To get back the assisted config save this form below once with both empty input fields.
+				]]>
+			</description>
 			<type>textarea</type>
 			<encoding>base64</encoding>
 			<rows>30</rows>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1378,7 +1378,7 @@
 			]]>
 		</descr>
 		<maintainer>jimp@pfsense.org</maintainer>
-		<version>0.6.5</version>
+		<version>0.6.6</version>
 		<category>Routing</category>
 		<status>BETA</status>
 		<depends_on_package_pbi>quagga-0.99.23.1_2-##ARCH##.pbi</depends_on_package_pbi>


### PR DESCRIPTION
0644 is default -> pointless. The shell script does not need to be world-writeable. 
Added copyright header, and improved descriptions readability while here.