### PR TITLE
sshdcond.inc - check whether XMLRPC sync is enabled before sync

### DIFF
--- a/config/sshdcond/sshdcond.inc
+++ b/config/sshdcond/sshdcond.inc
@@ -124,12 +124,14 @@ function sshdcond_sync_on_changes() {
 	}
 
 	log_error("[sshdcond] xmlrpc sync is starting.");
-	foreach ($config['installedpackages']['sshdcondsync']['config'] as $rs) {
-		foreach($rs['row'] as $sh) {
-			$sync_to_ip = $sh['ipaddress'];
-			$password = $sh['password'];
-			if ($password && $sync_to_ip) {
-				sshdcond_do_xmlrpc_sync($sync_to_ip, $password);
+	if (is_array($config['installedpackages']['sshdcondsync'])) {
+		foreach ($config['installedpackages']['sshdcondsync']['config'] as $rs) {
+			foreach($rs['row'] as $sh) {
+				$sync_to_ip = $sh['ipaddress'];
+				$password = $sh['password'];
+				if ($password && $sync_to_ip) {
+					sshdcond_do_xmlrpc_sync($sync_to_ip, $password);
+				}
 			}
 		}
 	}

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1350,7 +1350,7 @@
 			]]>
 		</descr>
 		<category>Enhancements</category>
-		<version>1.0.2</version>
+		<version>1.0.3</version>
 		<status>Beta</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/sshdcond/sshdcond.xml</config_file>


### PR DESCRIPTION
```
Starting package SSHDCond...
Warning: Invalid argument supplied for foreach() in /usr/local/pkg/sshdcond.inc on line 127
done.
```

Note: The commit message is wrong, I got confused by having a broken "fix" here locally with a missing closing }