### PR TITLE
sshdcond - fix sshdcond_sync_on_changes() logic

### DIFF
--- a/config/sshdcond/sshdcond.inc
+++ b/config/sshdcond/sshdcond.inc
@@ -117,19 +117,22 @@ function sshdcond_custom_php_write_config() {
 function sshdcond_sync_on_changes() {
 	global $config, $g;
 
-	if (is_array($config['installedpackages']['sshdcondsync'])) {
-		if (!$config['installedpackages']['sshdcondsync']['config'][0]['synconchanges']) {
-			return;
-		}
-	}
-
-	log_error("[sshdcond] xmlrpc sync is starting.");
-	foreach ($config['installedpackages']['sshdcondsync']['config'] as $rs) {
-		foreach($rs['row'] as $sh) {
-			$sync_to_ip = $sh['ipaddress'];
-			$password = $sh['password'];
-			if ($password && $sync_to_ip) {
-				sshdcond_do_xmlrpc_sync($sync_to_ip, $password);
+	if (!is_array($config['installedpackages']['sshdcondsync'])) {
+		/* Basically, this package was never configured */
+		return;
+	} elseif (!$config['installedpackages']['sshdcondsync']['config'][0]['synconchanges']) {
+		/* Package is configured but XMLRPC sync is disabled */
+		return;
+	} else {
+		/* Do XMLRPC sync */
+		log_error("[sshdcond] xmlrpc sync is starting.");
+		foreach ($config['installedpackages']['sshdcondsync']['config'] as $rs) {
+			foreach($rs['row'] as $sh) {
+				$sync_to_ip = $sh['ipaddress'];
+				$password = $sh['password'];
+				if ($password && $sync_to_ip) {
+					sshdcond_do_xmlrpc_sync($sync_to_ip, $password);
+				}
 			}
 		}
 	}

--- a/config/sshdcond/sshdcond.inc
+++ b/config/sshdcond/sshdcond.inc
@@ -135,8 +135,8 @@ function sshdcond_sync_on_changes() {
 				}
 			}
 		}
+		log_error("[sshdcond] xmlrpc sync is ending.");
 	}
-	log_error("[sshdcond] xmlrpc sync is ending.");
 }
 
 /* Do the actual XMLRPC sync. */

--- a/config/sshdcond/sshdcond.inc
+++ b/config/sshdcond/sshdcond.inc
@@ -117,26 +117,26 @@ function sshdcond_custom_php_write_config() {
 function sshdcond_sync_on_changes() {
 	global $config, $g;
 
+	/* Basically, this package was never configured */
 	if (!is_array($config['installedpackages']['sshdcondsync'])) {
-		/* Basically, this package was never configured */
 		return;
-	} elseif (!$config['installedpackages']['sshdcondsync']['config'][0]['synconchanges']) {
-		/* Package is configured but XMLRPC sync is disabled */
+	}
+	/* Package is configured but XMLRPC sync is disabled */
+	if (!isset($config['installedpackages']['sshdcondsync']['config'][0]['synconchanges'])) {
 		return;
-	} else {
-		/* Do XMLRPC sync */
-		log_error("[sshdcond] xmlrpc sync is starting.");
-		foreach ($config['installedpackages']['sshdcondsync']['config'] as $rs) {
-			foreach($rs['row'] as $sh) {
-				$sync_to_ip = $sh['ipaddress'];
-				$password = $sh['password'];
-				if ($password && $sync_to_ip) {
-					sshdcond_do_xmlrpc_sync($sync_to_ip, $password);
-				}
+	}
+	/* Do XMLRPC sync */
+	log_error("[sshdcond] xmlrpc sync is starting.");
+	foreach ($config['installedpackages']['sshdcondsync']['config'] as $rs) {
+		foreach($rs['row'] as $sh) {
+			$sync_to_ip = $sh['ipaddress'];
+			$password = $sh['password'];
+			if ($password && $sync_to_ip) {
+				sshdcond_do_xmlrpc_sync($sync_to_ip, $password);
 			}
 		}
-		log_error("[sshdcond] xmlrpc sync is ending.");
 	}
+	log_error("[sshdcond] xmlrpc sync is ending.");
 }
 
 /* Do the actual XMLRPC sync. */

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1350,7 +1350,7 @@
 			]]>
 		</descr>
 		<category>Enhancements</category>
-		<version>1.0.2</version>
+		<version>1.0.3</version>
 		<status>Beta</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/sshdcond/sshdcond.xml</config_file>


### PR DESCRIPTION
When you install but never configure this package, on boot you get this warning:
```
 Starting package SSHDCond...
Warning: Invalid argument supplied for foreach() in /usr/local/pkg/sshdcond.inc on line 127
done.
```

Problem being that the whole function logic is wrong. Trying to fix here. (Comments included in the code, hopefully the logic is clear and correct now.)