### PR TITLE
apcupsd - code style cleanup

### DIFF
--- a/config/apcupsd/apcupsd.conf.php
+++ b/config/apcupsd/apcupsd.conf.php
@@ -1,35 +1,35 @@
 <?php
 /*
-   apcupsd.conf.php
-   part of the apcupsd package for pfSense
-   Copyright (C) 2013 Danilo G. Baio <dbaio@bsd.com.br>
-   All rights reserved.
+	apcupsd.conf.php
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013-2015 Danilo G. Baio <dbaio@bsd.com.br>
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-   Redistribution and use in source and binary forms, with or without
-   modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-   1. Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-   2. Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-   THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-   AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-   AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-   OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-   POSSIBILITY OF SUCH DAMAGE.
-
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
-// create apcupsd.conf
-$apcupsdconf=<<<EOF
+// Create apcupsd.conf
+$apcupsdconf =<<<EOF
 ## apcupsd.conf v1.1 ##
 # 
 #  for apcupsd release 3.14.10 (13 September 2011) - freebsd

--- a/config/apcupsd/apcupsd.inc
+++ b/config/apcupsd/apcupsd.inc
@@ -1,53 +1,48 @@
 <?php
-/* $Id$ */
-/* ========================================================================== */
 /*
-    apcupsd.inc
-    part of the apcupsd package for pfSense
-    Copyright (C) 2013 Danilo G. Baio <dbaio@bsd.com.br>
+	apcupsd.inc
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013-2015 Danilo G. Baio <dbaio@bsd.com.br>
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-    All rights reserved.            
-			                                                                  */
-/* ========================================================================== */
-/*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
 require_once("util.inc");
 require_once("functions.inc");
 require_once("pkg-utils.inc");
 require_once("globals.inc");
 
-function php_install_apcupsd(){
-	sync_package_apcupsd();	
+function php_install_apcupsd() {
+	sync_package_apcupsd();
 	apccontrol_scripts_install();
 }
 
-function php_deinstall_apcupsd(){
+function php_deinstall_apcupsd() {
 	global $config, $g;
 
 	conf_mount_rw();
-	$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
-	if ($pfs_version > 2.0){
+	$pfs_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+	if ($pfs_version == "2.1" || $pfs_version == "2.2") {
 		define('APCUPSD_BASE', '/usr/pbi/apcupsd-' . php_uname("m"));
 	} else {
 		define('APCUPSD_BASE', '/usr/local');
@@ -59,176 +54,171 @@ function php_deinstall_apcupsd(){
 	unlink_if_exists("/var/log/apcupsd/apcupsd.log");
 	unlink_if_exists("/var/run/apcupsd/apcupsd.pid");
 
-	if (is_dir("/var/log/apcupsd"))
-		exec("/bin/rm -r /var/log/apcupsd/");
-	if (is_dir("/var/run/apcupsd"))
-		exec("/bin/rm -r /var/run/apcupsd/");
+	if (is_dir("/var/log/apcupsd")) {
+		exec("/bin/rm -rf /var/log/apcupsd/");
+	}
+	if (is_dir("/var/run/apcupsd")) {
+		exec("/bin/rm -rf /var/run/apcupsd/");
+	}
 
-   conf_mount_ro();
+	conf_mount_ro();
 }
 
-function validate_input_apcupsd($post,&$input_errors){
+function validate_input_apcupsd($post, &$input_errors) {
 
-	if  (isset($post['apcupsdenabled'])){
-	
+	if (isset($post['apcupsdenabled'])) {
 		if ($post['polltime'] != '' && !is_numericint($post['polltime'])) {
-			$input_errors[]='Poll Time is not numeric.';
+			$input_errors[] = 'Poll Time is not numeric.';
 		}
 
 		if ($post['onbatterydelay'] != '' && !is_numericint($post['onbatterydelay'])) {
-			$input_errors[]='OnBattery Delay is not numeric.';
+			$input_errors[] = 'OnBattery Delay is not numeric.';
 		}
 
 		if ($post['batterylevel'] != '' && !is_numericint($post['batterylevel'])) {
-			$input_errors[]='Battery Level is not numeric.';
+			$input_errors[] = 'Battery Level is not numeric.';
 		}
 
 		if ($post['minutes'] != '' && !is_numericint($post['minutes'])) {
-			$input_errors[]='Minutes is not numeric.';
+			$input_errors[] = 'Minutes is not numeric.';
 		}
 
 		if ($post['timeout'] != '' && !is_numericint($post['timeout'])) {
-			$input_errors[]='Timeout is not numeric.';
+			$input_errors[] = 'Timeout is not numeric.';
 		}
 
 		if ($post['annoy'] != '' && !is_numericint($post['annoy'])) {
-			$input_errors[]='Annoy is not numeric.';
+			$input_errors[] = 'Annoy is not numeric.';
 		}
 
 		if ($post['annoydelay'] != '' && !is_numericint($post['annoydelay'])) {
-			$input_errors[]='Annoy Delay is not numeric.';
+			$input_errors[] = 'Annoy Delay is not numeric.';
 		}
 
 		if ($post['killdelay'] != '' && !is_numericint($post['killdelay'])) {
-			$input_errors[]='Kill Delay is not numeric.';
+			$input_errors[] = 'Kill Delay is not numeric.';
 		}
 
 		if ($post['nisip'] != '') {
-			if (!is_ipaddr_configured($post['nisip']) && !preg_match("/(127.0.0.1|0.0.0.0)/",$post['nisip'])) {
-				$input_errors[]='NIS Ip is not a configured IP address.';
+			if (!is_ipaddr_configured($post['nisip']) && !preg_match("/(127.0.0.1|0.0.0.0)/", $post['nisip'])) {
+				$input_errors[] = 'NIS Ip is not a configured IP address.';
 			}
 		}
 
 		if ($post['nisport'] != '') {
 			if (!preg_match("/^\d+$/", $post['nisport'])) {
-				$input_errors[]='NIS Port is not numeric.';
-			}	
+				$input_errors[] = 'NIS Port is not numeric.';
+			}
 		}
 
 		if ($post['emailnotification'] == 'smtpbuiltin') {
-
 			if (empty($post['smtphost'])) {
-					$input_errors[]='SMTP Host cannot be empty if SMTP builtin is enabled.';
+					$input_errors[] = 'SMTP Host cannot be empty if SMTP builtin is enabled.';
 			}
 
 			if (empty($post['smtpport'])) {
-					$input_errors[]='SMTP Port cannot be empty if SMTP builtin is enabled.';
-			}elseif(!is_port($post['smtpport'])){
-					$input_errors[]='SMTP Port is not a valid port.';
+					$input_errors[] = 'SMTP Port cannot be empty if SMTP builtin is enabled.';
+			} elseif (!is_port($post['smtpport'])) {
+				$input_errors[]='SMTP Port is not a valid port.';
 			}
 
 			if (empty($post['smtpfrom'])) {
-					$input_errors[]='From field cannot be empty if SMTP builtin is enabled.';
+					$input_errors[] = 'From field cannot be empty if SMTP builtin is enabled.';
 			}
 
 			if (empty($post['smtpto'])) {
-					$input_errors[]='To field cannot be empty if SMTP builtin is enabled..';
+					$input_errors[] = 'To field cannot be empty if SMTP builtin is enabled.';
 			}
-
 		}
 
-	} // apcupsdenabled
+	}
 }
 
-function sync_package_apcupsd(){
+function sync_package_apcupsd() {
 	global $config, $g;
 
 	conf_mount_rw();
 
-	// check pfsense version
-	$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
-	if ($pfs_version > 2.0){
+	$pfs_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+	if ($pfs_version == "2.1" || $pfs_version == "2.2") {
 		define('APCUPSD_BASE', '/usr/pbi/apcupsd-' . php_uname("m"));
-		}
-	else {
+	} else {
 		define('APCUPSD_BASE', '/usr/local');
 	}
 
 	// check apcupsd settings
-	if (is_array($config['installedpackages']['apcupsd'])){
+	if (is_array($config['installedpackages']['apcupsd'])) {
 		$apcupsd_config = $config['installedpackages']['apcupsd']['config'][0];
-		if ($apcupsd_config['apcupsdenabled']=="on"){
-			$upsname=$apcupsd_config['upsname'];
-			$upscable=$apcupsd_config['upscable'];
-			$upstype=$apcupsd_config['upstype'];
-			$device=($apcupsd_config['device'] != ''? "DEVICE {$apcupsd_config['device']}" : "#DEVICE");
-			$polltime=($apcupsd_config['polltime'] != ''? $apcupsd_config['polltime'] : "60");
-			$onbatterydelay=($apcupsd_config['onbatterydelay'] != ''? $apcupsd_config['onbatterydelay'] : "6");
-			$batterylevel=($apcupsd_config['batterylevel'] != ''? $apcupsd_config['batterylevel'] : "5");
-			$minutes=($apcupsd_config['minutes'] != ''? $apcupsd_config['minutes'] : "3");
-			$timeout=($apcupsd_config['timeout'] != ''? $apcupsd_config['timeout'] : "0");
-			$annoy=($apcupsd_config['annoy'] != ''? $apcupsd_config['annoy'] : "300");
-			$annoydelay=($apcupsd_config['annoydelay'] != ''? $apcupsd_config['annoydelay'] : "60"); 
-			$killdelay=($apcupsd_config['killdelay'] != ''? $apcupsd_config['killdelay'] : "0");
-			$netserver=$apcupsd_config['netserver'];
-			$nisip=($apcupsd_config['nisip'] != ''? $apcupsd_config['nisip'] : "0.0.0.0");
-			$nisport=($apcupsd_config['nisport'] != ''? $apcupsd_config['nisport'] : "3551");
-			$upsclass=$apcupsd_config['upsclass'];
-			$upsmode=$apcupsd_config['upsmode'];
-			$lockfile=($apcupsd_config['lockfile'] != ''? $apcupsd_config['lockfile'] : "/var/tmp");
-			$emailnotification=$apcupsd_config['emailnotification'];
-	
+		if ($apcupsd_config['apcupsdenabled'] == "on") {
+			$upsname = $apcupsd_config['upsname'];
+			$upscable = $apcupsd_config['upscable'];
+			$upstype = $apcupsd_config['upstype'];
+			$device = ($apcupsd_config['device'] != '' ? "DEVICE {$apcupsd_config['device']}" : "#DEVICE");
+			$polltime = $apcupsd_config['polltime'] ?: "60";
+			$onbatterydelay = $apcupsd_config['onbatterydelay'] ?: "6";
+			$batterylevel= $apcupsd_config['batterylevel'] ?: "5";
+			$minutes = $apcupsd_config['minutes'] ?: "3";
+			$timeout = $apcupsd_config['timeout'] ?: "0";
+			$annoy = $apcupsd_config['annoy'] ?: "300";
+			$annoydelay = $apcupsd_config['annoydelay'] ?: "60";
+			$killdelay = $apcupsd_config['killdelay'] ?: "0";
+			$netserver = $apcupsd_config['netserver'];
+			$nisip= $apcupsd_config['nisip'] ?: "0.0.0.0";
+			$nisport = $apcupsd_config['nisport'] ?: "3551";
+			$upsclass = $apcupsd_config['upsclass'];
+			$upsmode = $apcupsd_config['upsmode'];
+			$lockfile= $apcupsd_config['lockfile'] ?: "/var/tmp";
+			$emailnotification = $apcupsd_config['emailnotification'];
+
 			include("/usr/local/pkg/apcupsd.conf.php");
 			file_put_contents(APCUPSD_BASE . "/etc/apcupsd/apcupsd.conf", $apcupsdconf, LOCK_EX);
 		}
 	}
 
-	// RC FILE	
+	// RC FILE
 	$apcupsd_rcfile="/usr/local/etc/rc.d/apcupsd.sh";
-	if (is_array($apcupsd_config) && $apcupsd_config['apcupsdenabled']=="on"){
+	if (is_array($apcupsd_config) && $apcupsd_config['apcupsdenabled']=="on") {
+
 		$apcupsd_start = "echo \"Starting APC UPS Daemon...\"\n";
 		$apcupsd_start .= "	if [ ! -d {$lockfile} ]; then \n";
 		$apcupsd_start .= "		/bin/mkdir -p {$lockfile} \n";
 		$apcupsd_start .= "	fi \n";
 		$apcupsd_start .= "	/bin/rm -f {$lockfile}/*LCK* 2>/dev/null \n";
-		if ($apcupsd_config['killonpowerfail']=="on"){
+		if ($apcupsd_config['killonpowerfail'] == "on") {
 			$apcupsd_start .= "	" . APCUPSD_BASE . "/sbin/apcupsd --kill-on-powerfail";
-		}else{
+		} else {
 			$apcupsd_start .= "	" . APCUPSD_BASE . "/sbin/apcupsd";
 		}
-	
-		$apcupsd_stop  = "echo \"Stopping APC UPS Daemon...\"\n";
+
+		$apcupsd_stop = "echo \"Stopping APC UPS Daemon...\"\n";
 		$apcupsd_stop .= "	/usr/bin/killall apcupsd\n";
 		$apcupsd_stop .= "	/bin/sleep 5";
-	
+
 		/* write out rc.d start/stop file */
 		write_rcfile(array(
-						"file" => "apcupsd.sh",
-						"start" => "$apcupsd_start",
-						"stop" => "$apcupsd_stop"
-				)
+			"file" => "apcupsd.sh",
+			"start" => "$apcupsd_start",
+			"stop" => "$apcupsd_stop"
+			)
 		);
-		mwexec("{$apcupsd_rcfile} restart");	
-	}else{
-		if (file_exists($apcupsd_rcfile)){
-			mwexec("{$apcupsd_rcfile} stop");
-			unlink($apcupsd_rcfile);
-		}
+
+		restart_service("apcupsd");
+
+	} else {
+		stop_service("apcupsd");
+		unlink_if_exists($apcupsd_rcfile);
 	}
 
 	apccontrol_scripts_install($emailnotification);
 	conf_mount_ro();
 }
 
-function apccontrol_scripts_install($emailnotification){
+function apccontrol_scripts_install($emailnotification) {
 	global $config, $g;
 
-	// check pfsense version
-	$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
-	if ($pfs_version > 2.0){
+	if ($pfs_version == "2.1" || $pfs_version == "2.2") {
 		define('APCUPSD_BASE', '/usr/pbi/apcupsd-' . php_uname("m"));
-		}
-	else {
+	} else {
 		define('APCUPSD_BASE', '/usr/local');
 	}
 
@@ -239,21 +229,21 @@ function apccontrol_scripts_install($emailnotification){
 	$apcstatus['changeme'] = "\$HOSTNAME - Emergency! UPS batteries have failed. Change them NOW";
 
 	$apccontrol_scripts = array("offbattery","onbattery","commfailure","commok","changeme");
-	foreach($apccontrol_scripts as $apccontrol_script) {
+	foreach ($apccontrol_scripts as $apccontrol_script) {
 
-		if ($emailnotification == "smtpbuiltin"){
+		if ($emailnotification == "smtpbuiltin") {
 
-			if (is_array($config['installedpackages']['apcupsd'])){
+			if (is_array($config['installedpackages']['apcupsd'])) {
 				$apcupsd_config = $config['installedpackages']['apcupsd']['config'][0];
-				if ($apcupsd_config['apcupsdenabled']=="on"){
-					$smtphost=($apcupsd_config['smtphost'] != ''? $apcupsd_config['smtphost'] : "0.0.0.0");
-					$smtpport=($apcupsd_config['smtpport'] != ''? $apcupsd_config['smtpport'] : "25");
-					$smtpfrom=$apcupsd_config['smtpfrom'];
-					$smtpto=$apcupsd_config['smtpto'];
-					$smtpcc=$apcupsd_config['smtpcc'];
-					if(empty($smtpcc)){
+				if ($apcupsd_config['apcupsdenabled'] == "on") {
+					$smtphost = $apcupsd_config['smtphost'] ?: "0.0.0.0";
+					$smtpport = $apcupsd_config['smtpport'] ?: "25";
+					$smtpfrom = $apcupsd_config['smtpfrom'];
+					$smtpto = $apcupsd_config['smtpto'];
+					$smtpcc = $apcupsd_config['smtpcc'];
+					if (empty($smtpcc)) {
 						$smtpcc_cmd = "";
-					}else{
+					} else {
 						$smtpcc_cmd = "-c {$smtpcc}";
 					}
 				}
@@ -261,7 +251,7 @@ function apccontrol_scripts_install($emailnotification){
 
 			$pfSense_hostname = gethostname();
 
-			$apccontrol_script_file=<<<EOF
+			$apccontrol_script_file =<<<EOF
 #!/bin/sh
 
 HOSTNAME="{$pfSense_hostname}"
@@ -276,8 +266,9 @@ MSG="{$apcstatus["{$apccontrol_script}"]}"
 exit 0
 
 EOF;
-		}else{
-			$apccontrol_script_file=<<<EOF
+
+		} else {
+		$apccontrol_script_file =<<<EOF
 #!/bin/sh
 
 /usr/local/bin/php -f /usr/local/pkg/apcupsd_mail.php {$apccontrol_script} > /dev/null
@@ -292,45 +283,41 @@ EOF;
 
 }
 
-function check_nis_running_apcupsd(){
-   global $config, $g;
+function check_nis_running_apcupsd() {
+	global $config, $g;
 
-   if (is_array($config['installedpackages']['apcupsd'])){
-      $apcupsd_config = $config['installedpackages']['apcupsd']['config'][0];
-
-      if ($apcupsd_config['apcupsdenabled']=="on" && $apcupsd_config['netserver']=="on" )
-         return(true);
-   }
-
-   return(false);
+	if (is_array($config['installedpackages']['apcupsd'])) {
+		$apcupsd_config = $config['installedpackages']['apcupsd']['config'][0];
+		if ($apcupsd_config['apcupsdenabled'] == "on" && $apcupsd_config['netserver'] == "on" ) {
+			return(true);
+		}
+	} else {
+		return(false);
+	}
 }
 
-
-function check_nis_ip_apcupsd(){
-   global $config, $g;
-
-   if (is_array($config['installedpackages']['apcupsd'])){
-      $apcupsd_config = $config['installedpackages']['apcupsd']['config'][0];
-
-      if ($apcupsd_config['apcupsdenabled']=="on" && $apcupsd_config['netserver']=="on" )
-         return($apcupsd_config['nisip']);
-   }
-
-   return(false);
+function check_nis_ip_apcupsd() {
+	global $config, $g;
+	if (is_array($config['installedpackages']['apcupsd'])) {
+		$apcupsd_config = $config['installedpackages']['apcupsd']['config'][0];
+		if ($apcupsd_config['apcupsdenabled']=="on" && $apcupsd_config['netserver']=="on" ) {
+			return($apcupsd_config['nisip']);
+		}
+	} else {
+		return(false);
+	}
 }
 
-function check_nis_port_apcupsd(){
-   global $config, $g;
-
-   if (is_array($config['installedpackages']['apcupsd'])){
-      $apcupsd_config = $config['installedpackages']['apcupsd']['config'][0];
-
-      if ($apcupsd_config['apcupsdenabled']=="on" && $apcupsd_config['netserver']=="on" )
-         return($apcupsd_config['nisport']);
-   }
-
-   return(false);
+function check_nis_port_apcupsd() {
+	global $config, $g;
+	if (is_array($config['installedpackages']['apcupsd'])) {
+		$apcupsd_config = $config['installedpackages']['apcupsd']['config'][0];
+		if ($apcupsd_config['apcupsdenabled']=="on" && $apcupsd_config['netserver']=="on" ) {
+			return($apcupsd_config['nisport']);
+		}
+	} else {
+		return(false);
+	}
 }
 
 ?>
-

--- a/config/apcupsd/apcupsd.xml
+++ b/config/apcupsd/apcupsd.xml
@@ -1,46 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packagegui>
-<copyright>
-	<![CDATA[
+	<copyright>
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    apcupsd.xml
-    part of the apcupsd package for pfSense
-    Copyright (C) 2013 Danilo G. Baio <dbaio@bsd.com.br>
-	
-    All rights reserved.            
-			                                                                  */
-/* ========================================================================== */
+	apcupsd.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013-2015 Danilo G. Baio <dbaio@bsd.com.br>
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
 	]]>
 	</copyright>
 	<name>Apcupsd</name>
 	<title>Services: Apcupsd (General)</title>
 	<category>Monitoring</category>
-	<version>0.3.5</version>
+	<version>0.3.7</version>
 	<include_file>/usr/local/pkg/apcupsd.inc</include_file>
 	<addedit_string>Apcupsd has been created/modified.</addedit_string>
 	<delete_string>Apcupsd has been deleted.</delete_string>
@@ -48,22 +50,18 @@
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.inc</item>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/apcupsd/apcupsd_status.php</item>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.conf.php</item>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/apcupsd/apcupsd_mail.php</item>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<menu>
 		<name>Apcupsd</name>
@@ -103,92 +101,99 @@
 			<fielddescr>UPS Name</fielddescr>
 			<fieldname>upsname</fieldname>
 			<description>Use this to give your UPS a name in log files and such</description>
-         <type>input</type>
-         <size>60</size>
+			<type>input</type>
+			<size>60</size>
 			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>UPS Cable</fielddescr>
 			<fieldname>upscable</fieldname>
-			<description><![CDATA[Defines the type of cable connecting the UPS to your computer.<br>
-<br>
-Possible generic choices for <cable> are:<br>
-  simple, smart, ether, usb<br>
-<br>
-Or a specific cable model number may be used:<br>
-  940-0119A, 940-0127A, 940-0128A, 940-0020B,<br>
-  940-0020C, 940-0023A, 940-0024B, 940-0024C,<br>
-  940-1524C, 940-0024G, 940-0095A, 940-0095B,<br>
-  940-0095C, M-04-02-2000
-			]]></description>
-         <type>input</type>
-         <size>60</size>
+			<description>
+				<![CDATA[
+				Defines the type of cable connecting the UPS to your computer.<br /><br />
+				Possible generic choices for 'cable' are:<br />
+				simple, smart, ether, usb
+				<br /><br/>
+				Or a specific cable model number may be used:<br />
+				940-0119A, 940-0127A, 940-0128A, 940-0020B,<br />
+				940-0020C, 940-0023A, 940-0024B, 940-0024C,<br />
+				940-1524C, 940-0024G, 940-0095A, 940-0095B,<br />
+				940-0095C, M-04-02-2000
+				]]>
+			</description>
+			<type>input</type>
+			<size>60</size>
 			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>UPS Type / Device</fielddescr>
 			<fieldname>upstype</fieldname>
-			<description><![CDATA[To get apcupsd to work, in addition to defining the cable
-above, you must also define a UPSTYPE, which corresponds to
-the type of UPS you have (see the Description for more details).
-You must also specify a DEVICE, sometimes referred to as a port.
-For USB UPSes, please leave the DEVICE directive blank. For
-other UPS types, you must specify an appropriate port or address.<br>
-<br>
-UPSTYPE   DEVICE           Description <br>
-<br>
-<strong>apcsmart  /dev/tty**</strong>       Newer serial character device, appropriate for
-                           SmartUPS models using a serial cable (not USB).<br>
-<br>
-<strong>usb       BLANK</strong>          Most new UPSes are USB. A blank DEVICE
-                           setting enables autodetection, which is
-                           the best choice for most installations.<br>
-<br>
-<strong>net       hostname:port</strong>    Network link to a master apcupsd through apcupsd's
-                           Network Information Server. This is used if the
-                           UPS powering your computer is connected to a
-                           different computer for monitoring.<br>
-<br>
-<strong>snmp      hostname:port:vendor:community</strong>
-                           SNMP network link to an SNMP-enabled UPS device.
-                           Hostname is the ip address or hostname of the UPS
-                           on the network. Vendor can be can be "APC" or
-                           "APC_NOTRAP". "APC_NOTRAP" will disable SNMP trap
-                           catching; you usually want "APC". Port is usually
-                           161. Community is usually "private".<br>
-<br>
-<strong>dumb      /dev/tty**</strong>       Old serial character device for use with
-                           simple-signaling UPSes.<br>
-<br>
-<strong>pcnet     ipaddr:username:passphrase:port</strong>
-                           PowerChute Network Shutdown protocol which can be
-                           used as an alternative to SNMP with the AP9617
-                           family of smart slot cards. ipaddr is the IP
-                           address of the UPS management card. username and
-                           passphrase are the credentials for which the card
-                           has been configured. port is the port number on
-                           which to listen for messages from the UPS, normally
-                           3052. If this parameter is empty or missing, the
-                           default of 3052 will be used.<br>
-<br>
-			]]></description>
-         <type>input</type>
-         <size>60</size>
+			<description>
+				<![CDATA[
+				To get apcupsd to work, in addition to defining the cable above, you must also define a UPSTYPE, which corresponds to&nbsp;
+				the type of UPS you have (see the Description for more details). You must also specify a DEVICE, sometimes referred to as a port.<br />
+				For USB UPSes, please leave the DEVICE directive blank. For other UPS types, you must specify an appropriate port or address.<br /><br />
+				<table>
+				<tr>
+					<th style="text-align: left">UPSTYPE</th>
+					<th style="text-align: left">DEVICE</th>
+					<th style="text-align: left">Description</th>
+				</tr>
+				<tr>
+					<td>apcsmart</td>
+					<td>/dev/tty**</td>
+					<td>Newer serial character device, appropriate for SmartUPS models using a serial cable (not USB).</td>
+				</tr>
+				<tr>
+					<td>usb</td>
+					<td>BLANK</td>
+					<td>Most new UPSes are USB. A blank DEVICE setting enables autodetection, which is the best choice for most installations.</td>
+				</tr>
+				<tr>
+					<td>net</td>
+					<td>hostname:port</td>
+					<td>Network link to a master apcupsd through apcupsd's Network Information Server. This is used if the&nbsp;
+					UPS powering your computer is connected to a different computer for monitoring.</td>
+				</tr>
+				<tr>
+					<td>snmp</td>
+					<td>hostname:port:vendor:community</td>
+					<td>SNMP network link to an SNMP-enabled UPS device. Hostname is the ip address or hostname of the UPS on the network.<br />
+					Vendor can be can be "APC" or "APC_NOTRAP". "APC_NOTRAP" will disable SNMP trap catching; you usually want "APC".<br />
+					Port is usually 161. Community is usually "private".</td>
+				</tr>
+				<tr>
+					<td>dumb</td>
+					<td>/dev/tty**</td>
+					<td>Old serial character device for use with simple-signaling UPSes.</td>
+				</tr>
+				<tr>
+					<td>pcnet</td>
+					<td>ipaddr:username:passphrase:port</td>
+					<td>PowerChute Network Shutdown protocol which can be used as an alternative to SNMP with the AP9617 family of smart slot cards.<br />
+					ipaddr is the IP address of the UPS management card; username and passphrase are the credentials for which the card has been configured.<br />
+					Port is the port number on which to listen for messages from the UPS, normally 3052. If this parameter is empty or missing, the default of 3052 will be used.</td>
+				</tr>
+				</table>
+				]]>
+			</description>
+			<type>input</type>
+			<size>60</size>
 			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Device</fielddescr>
 			<fieldname>device</fieldname>
 			<description></description>
-         <type>input</type>
-         <size>60</size>
+			<type>input</type>
+			<size>60</size>
 		</field>
 		<field>
 			<fielddescr>Poll Time</fielddescr>
 			<fieldname>polltime</fieldname>
-			<description>Interval (in seconds) at which apcupsd polls the UPS for status. Default is 60</description>
-         <type>input</type>
-         <size>10</size>
+			<description>Interval (in seconds) at which apcupsd polls the UPS for status. (Default: 60)</description>
+			<type>input</type>
+			<size>10</size>
 			<default_value>60</default_value>
 		</field>
 		<field>
@@ -200,9 +205,9 @@ UPSTYPE   DEVICE           Description <br>
 		<field>
 			<fielddescr>Lock File</fielddescr>
 			<fieldname>lockfile</fieldname>
-			<description>Path for device lock file. Default is /var/tmp</description>
-         <type>input</type>
-         <size>60</size>
+			<description>Path for device lock file. (Default: /var/tmp)</description>
+			<type>input</type>
+			<size>60</size>
 		</field>
 		<field>
 			<name>Configuration parameters used during power failures</name>
@@ -211,62 +216,65 @@ UPSTYPE   DEVICE           Description <br>
 		<field>
 			<fielddescr>OnBattery Delay</fielddescr>
 			<fieldname>onbatterydelay</fieldname>
-			<description>Time in seconds from when a power failure is detected until we react to it with an onbattery event. Default is 6</description>
-         <type>input</type>
-         <size>10</size>
+			<description>Time in seconds from when a power failure is detected until we react to it with an onbattery event. (Default: 6)</description>
+			<type>input</type>
+			<size>10</size>
 			<default_value>6</default_value>
 		</field>
 		<field>
 			<fielddescr>Battery Level</fielddescr>
 			<fieldname>batterylevel</fieldname>
 			<description>If during a power failure, the remaining battery percentage (as reported by the UPS) is 
-			below or equal to BATTERYLEVEL, apcupsd will initiate a system shutdown. Default is 5</description>
-         <type>input</type>
-         <size>10</size>
+			below or equal to BATTERYLEVEL, apcupsd will initiate a system shutdown. (Default: 5)</description>
+			<type>input</type>
+			<size>10</size>
 			<default_value>5</default_value>
 		</field>
 		<field>
 			<fielddescr>Minutes</fielddescr>
 			<fieldname>minutes</fieldname>
 			<description>If during a power failure, the remaining runtime in minutes (as calculated internally 
-			by the UPS) is below or equal to MINUTES, apcupsd, will initiate a system shutdown. Default is 3</description>
-         <type>input</type>
-         <size>10</size>
+			by the UPS) is below or equal to MINUTES, apcupsd, will initiate a system shutdown. (Default: 3)</description>
+			<type>input</type>
+			<size>10</size>
 			<default_value>3</default_value>
 		</field>
 		<field>
 			<fielddescr>Timeout</fielddescr>
 			<fieldname>timeout</fieldname>
 			<description>If during a power failure, the UPS has run on batteries for TIMEOUT many seconds 
-			or longer, apcupsd will initiate a system shutdown. A value of 0 (default) disables this timer</description>
-         <type>input</type>
-         <size>10</size>
+			or longer, apcupsd will initiate a system shutdown. A value of 0 (default) disables this timer.</description>
+			<type>input</type>
+			<size>10</size>
 			<default_value>0</default_value>
 		</field>
 		<field>
 			<fielddescr>Annoy</fielddescr>
 			<fieldname>annoy</fieldname>
-			<description>Time in seconds between annoying users to signoff prior to system shutdown. 0 disables. Default is 300</description>
-         <type>input</type>
-         <size>10</size>
+			<description>Time in seconds between annoying users to signoff prior to system shutdown. 0 disables. (Default: 300)</description>
+			<type>input</type>
+			<size>10</size>
 			<default_value>300</default_value>
 		</field>
 		<field>
 			<fielddescr>Annoy Delay</fielddescr>
 			<fieldname>annoydelay</fieldname>
-			<description>Initial delay after power failure before warning users to get off the system. Default is 60</description>
-         <type>input</type>
-         <size>10</size>
+			<description>Initial delay after power failure before warning users to get off the system. (Default: 60)</description>
+			<type>input</type>
+			<size>10</size>
 			<default_value>60</default_value>
 		</field>
 		<field>
 			<fielddescr>Kill Delay</fielddescr>
 			<fieldname>killdelay</fieldname>
-			<description>If KILLDELAY is non-zero, apcupsd will continue running after a shutdown has been 
-			requested, and after the specified time in seconds attempt to kill the power. This is for use 
-			on systems where apcupsd cannot regain control after a shutdown. 0 disables (default)</description>
-         <type>input</type>
-         <size>10</size>
+			<description>
+				<![CDATA[
+				If KILLDELAY is non-zero, apcupsd will continue running after a shutdown has been requested, and after the specified time in seconds attempt to kill the power.<br />
+				This is for use on systems where apcupsd cannot regain control after a shutdown. 0 disables (default).
+				]]>
+				</description>
+			<type>input</type>
+			<size>10</size>
 			<default_value>0</default_value>
 		</field>
 		<field>
@@ -277,7 +285,7 @@ UPSTYPE   DEVICE           Description <br>
 			<fielddescr>Net Server</fielddescr>
 			<fieldname>netserver</fieldname>
 			<description>If netstatus is on, a network information server process will be started for serving 
-			the STATUS and EVENT data over the network (used by CGI programs)</description>
+			the STATUS and EVENT data over the network (used by CGI programs).</description>
 			<type>select</type>
 			<default_value>on</default_value>
 			<options>
@@ -286,25 +294,31 @@ UPSTYPE   DEVICE           Description <br>
 			</options>
 		</field>
 		<field>
-			<fielddescr>NIS Ip</fielddescr>
+			<fielddescr>NIS IP</fielddescr>
 			<fieldname>nisip</fieldname>
-			<description>IP address on which NIS server will listen for incoming connections. Default value is 
-			0.0.0.0 which means any incoming request will be serviced. Alternatively, you can configure this 
-			setting to any specific IP address of your server and NIS will listen for connections only on that 
-			interface. Use the loopback address (127.0.0.1) to accept connections only from the local machine</description>
-         <type>input</type>
-         <size>10</size>
+			<description>
+				<![CDATA[
+				IP address on which NIS server will listen for incoming connections. Default value is 0.0.0.0 which means any incoming request will be serviced.<br />
+				Alternatively, you can configure this setting to any specific IP address of your server and NIS will listen for connections only on that interface.<br />
+				Use the loopback address (127.0.0.1) to accept connections only from the local machine.
+				]]>
+				</description>
+			<type>input</type>
+			<size>10</size>
 			<default_value>0.0.0.0</default_value>
 		</field>
 		<field>
 			<fielddescr>NIS Port</fielddescr>
 			<fieldname>nisport</fieldname>
-			<description>Port to use for sending STATUS and EVENTS data over the network.
-			It is not used unless NETSERVER is on. If you change this port,
-			you will need to change the corresponding value in the cgi directory
-			and rebuild the cgi programs. Default is 3551 as registered with the IANA</description>
-         <type>input</type>
-         <size>10</size>
+			<description>
+				<![CDATA[
+				Port to use for sending STATUS and EVENTS data over the network. It is not used unless NETSERVER is on. If you change this port,&nbsp;
+				you will need to change the corresponding value in the CGI directory and rebuild the CGI programs.<br />
+				(Default is 3551 as registered with the IANA.)
+				]]>
+				</description>
+			<type>input</type>
+			<size>10</size>
 			<default_value>3551</default_value>
 		</field>
 		<field>
@@ -314,7 +328,7 @@ UPSTYPE   DEVICE           Description <br>
 		<field>
 			<fielddescr>UPS Class</fielddescr>
 			<fieldname>upsclass</fieldname>
-			<description>Normally standalone unless you share an UPS using an APC ShareUPS card</description>
+			<description>Normally standalone unless you share an UPS using an APC ShareUPS card.</description>
 			<type>select</type>
 			<default_value>standalone</default_value>
 			<options>
@@ -326,7 +340,7 @@ UPSTYPE   DEVICE           Description <br>
 		<field>
 			<fielddescr>UPS Mode</fielddescr>
 			<fieldname>upsmode</fieldname>
-			<description>Normally disable unless you share an UPS using an APC ShareUPS card</description>
+			<description>Normally disable unless you share an UPS using an APC ShareUPS card.</description>
 			<type>select</type>
 			<default_value>disable</default_value>
 			<options>
@@ -339,20 +353,17 @@ UPSTYPE   DEVICE           Description <br>
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>E-mail notification</fielddescr>
+			<fielddescr>E-mail notifications</fielddescr>
 			<fieldname>emailnotification</fieldname>
-			<description><![CDATA[Choose how APCUpsd will send email notifications.<br>
-<br>
-<strong>phpMailer</strong>	- In order to receive e-mail notifications through phpMailer, you need 
-to configure SMTP Email Notifications on Advanced/Notifications section, and also, 
-install mailreport package.<br>
-This feature is currently broken on pfSense 2.2, for more info see pfSense forum: 
-<a href="https://forum.pfsense.org/index.php?topic=89901.0">APCupsd package status for pfSense.</a><br>
-<br>
-<strong>SMTP built-in</strong> - A simple SMTP mail client for apcupsd. 
-It does not have smtp authentication of any kind.
-<br>
-			]]></description>
+			<description>
+				<![CDATA[
+				Choose how APCUpsd will send email notifications.<br /><br />
+				<strong>phpMailer</strong> - In order to receive e-mail notifications through phpMailer, you need to configure SMTP Email Notifications on Advanced/Notifications section,&nbsp;
+				and also install mailreport package.<br />
+				This feature is currently broken on pfSense 2.2; for more info see pfSense forum: <a href="https://forum.pfsense.org/index.php?topic=89901.0">APCupsd package status for pfSense.</a><br /><br />
+				<strong>SMTP built-in</strong> - A simple SMTP mail client for apcupsd. It does not have smtp authentication of any kind.
+				]]>
+			</description>
 			<type>select</type>
 			<default_value>phpmailer</default_value>
 			<options>
@@ -361,51 +372,47 @@ It does not have smtp authentication of any kind.
 			</options>
 		</field>
 		<field>
-			<name>SMTP built-in</name>
+			<name>SMTP built-in settings</name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>SMTP Host</fielddescr>
 			<fieldname>smtphost</fieldname>
 			<description></description>
-         <type>input</type>
-         <size>20</size>
+			<type>input</type>
+			<size>20</size>
 		</field>
 		<field>
 			<fielddescr>SMTP Port</fielddescr>
 			<fieldname>smtpport</fieldname>
 			<description></description>
-         <type>input</type>
-         <size>5</size>
+			<type>input</type>
+			<size>5</size>
 		</field>
 		<field>
 			<fielddescr>From</fielddescr>
 			<fieldname>smtpfrom</fieldname>
 			<description></description>
-         <type>input</type>
-         <size>20</size>
+			<type>input</type>
+			<size>20</size>
 		</field>
 		<field>
 			<fielddescr>To</fielddescr>
 			<fieldname>smtpto</fieldname>
 			<description></description>
-         <type>input</type>
-         <size>20</size>
+			<type>input</type>
+			<size>20</size>
 		</field>
 		<field>
 			<fielddescr>Cc</fielddescr>
 			<fieldname>smtpcc</fieldname>
 			<description></description>
-         <type>input</type>
-         <size>20</size>
+			<type>input</type>
+			<size>20</size>
 		</field>
 	</fields>
 	<custom_php_install_command>php_install_apcupsd();</custom_php_install_command>
-	<custom_php_command_before_form></custom_php_command_before_form>
-	<custom_php_after_head_command></custom_php_after_head_command>
-	<custom_php_after_form_command></custom_php_after_form_command>
 	<custom_php_validation_command>validate_input_apcupsd($_POST, $input_errors);</custom_php_validation_command>
-	<custom_add_php_command></custom_add_php_command>
 	<custom_php_resync_config_command>sync_package_apcupsd();</custom_php_resync_config_command>
 	<custom_php_deinstall_command>php_deinstall_apcupsd();</custom_php_deinstall_command>
 </packagegui>

--- a/config/apcupsd/apcupsd_mail.php
+++ b/config/apcupsd/apcupsd_mail.php
@@ -1,8 +1,9 @@
 <?php
 /*
 	apcupsd_mail.php
-	part of pfSense (https://www.pfsense.org/)
-	Copyright (C) 2014 Danilo G. Baio <dbaio@bsd.com.br>
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2014-2015 Danilo G. Baio <dbaio@bsd.com.br>
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -26,7 +27,6 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require_once("pkg-utils.inc");
 require_once("globals.inc");
 require_once("phpmailer/PHPMailerAutoload.php");
@@ -49,28 +49,31 @@ $apcstatus[emergency] = "Emergency Shutdown. Possible UPS battery failure";
 $apcstatus[changeme] = "Emergency! UPS batteries have failed. Change them NOW";
 $apcstatus[remotedown] = "Remote Shutdown. Beginning Shutdown Sequence";
 
-if (empty($argv[1]) || empty($apcstatus["$argv[1]"]))
+if (empty($argv[1]) || empty($apcstatus["$argv[1]"])) {
 	return;
+}
 
 $apcsubject = $apcstatus["$argv[1]"];
 
-if (empty($config['notifications']['smtp']['ipaddress']))
+if (empty($config['notifications']['smtp']['ipaddress'])) {
 	return;
+}
 
 $mail = new PHPMailer();
 $mail->IsSMTP();
 $mail->Host = $config['notifications']['smtp']['ipaddress'];
 
-if ((isset($config['notifications']['smtp']['ssl']) && $config['notifications']['smtp']['ssl'] != "unchecked") || $config['notifications']['smtp']['ssl'] == "checked")
+if ((isset($config['notifications']['smtp']['ssl']) && $config['notifications']['smtp']['ssl'] != "unchecked") || $config['notifications']['smtp']['ssl'] == "checked") {
 	$mail->SMTPSecure = "ssl";
+}
 
-if ((isset($config['notifications']['smtp']['tls']) && $config['notifications']['smtp']['tls'] != "unchecked") || $config['notifications']['smtp']['tls'] == "checked")
+if ((isset($config['notifications']['smtp']['tls']) && $config['notifications']['smtp']['tls'] != "unchecked") || $config['notifications']['smtp']['tls'] == "checked") {
 	$mail->SMTPSecure = "tls";
+}
 
 $mail->Port = empty($config['notifications']['smtp']['port']) ? 25 : $config['notifications']['smtp']['port'];
 
-if($config['notifications']['smtp']['username'] &&
-   $config['notifications']['smtp']['password']) {
+if ($config['notifications']['smtp']['username'] && $config['notifications']['smtp']['password']) {
 	$mail->SMTPAuth	= true;
 	$mail->Username	= $config['notifications']['smtp']['username'];
 	$mail->Password	= $config['notifications']['smtp']['password'];
@@ -91,7 +94,7 @@ while ($line = fgets($ph)) $mail->Body .= htmlspecialchars($line);
 pclose($ph);
 $mail->Body .= "</pre>";
 
-if(!$mail->Send()) {
+if (!$mail->Send()) {
 	echo "Mailer Error: " . $mail->ErrorInfo;
 }
 

--- a/config/apcupsd/apcupsd_status.php
+++ b/config/apcupsd/apcupsd_status.php
@@ -1,8 +1,9 @@
 <?php
 /*
 	apcupsd_status.php
-	part of pfSense (https://www.pfsense.org/)
-	Copyright (C) 2013 Danilo G. Baio <dbaio@bsd.com.br>
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013-2015 Danilo G. Baio <dbaio@bsd.com.br>
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -26,66 +27,26 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require("guiconfig.inc");
 require_once("apcupsd.inc");
+global $pfs_version;
+$pfs_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
 
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version < 2.0)
-	$one_two = true;
-	
 $pgtitle = "Services: Apcupsd (Status)";
 include("head.inc");
 
-function puts( $arg ) { echo "$arg\n"; }	
+function puts($arg) {
+	echo "$arg\n";
+}
 
-if (isset($_GET['strapcaccess']))
-   $strapcaccess = trim($_GET['strapcaccess']);
+if (isset($_GET['strapcaccess'])) {
+	$strapcaccess = trim($_GET['strapcaccess']);
+}
 
 ?>
 
-<style>
-<!--
-
-input {
-   font-family: courier new, courier;
-   font-weight: normal;
-   font-size: 9pt;
-}
-
-pre {
-   border: 2px solid #435370;
-   background: #F0F0F0;
-   padding: 1em;
-   font-family: courier new, courier;
-   white-space: pre;
-   line-height: 10pt;
-   font-size: 10pt;
-}
-
-.label {
-   font-family: tahoma, verdana, arial, helvetica;
-   font-size: 11px;
-   font-weight: bold;
-}
-
-.button {
-   font-family: tahoma, verdana, arial, helvetica;
-   font-weight: bold;
-   font-size: 11px;
-}
-
--->
-</style>
-</head>
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
-
-	<?php include("fbegin.inc"); ?>
-	
-	<?php if($one_two): ?>
-	<p class="pgtitle"><?=$pgtitle?></font></p>
-	<?php endif; ?>
-
+<?php include("fbegin.inc"); ?>
 
 <div id="mainlevel">
 		<table width="100%" border="0" cellpadding="0" cellspacing="0">
@@ -101,70 +62,79 @@ pre {
 </div>
 
 <div id="mainarea" style="padding-top: 0px; padding-bottom: 0px; ">
-	<table class="tabcont" width="100%" border="0" cellspacing="0" cellpadding="6">
-		<form name="frm_apcupsd_status" method="GET">
+	<form name="frm_apcupsd_status" method="get" action="">
+		<table class="tabcont" width="100%" border="0" cellspacing="0" cellpadding="6">
 			<tr>
 				<td width="14%" valign="top" class="vncellreq">Host:</td>
 				<td width="86%" class="vtable">
-					<input name="strapcaccess" type="text" class="formfld unknown" id="strapcaccess" size="22" value="<? echo "{$strapcaccess}"; ?>">
-					<br/>
+					<input name="strapcaccess" type="text" class="formfld unknown" id="strapcaccess" size="22" value="<? echo "{$strapcaccess}"; ?>" />
+					<br />
 					<span class="vexpl">
-     Default: <b>localhost</b><br/>
-     apcaccess uses apcupsd's inbuilt Network Information Server (NIS) to obtain the current status information <br/>
-     from the UPS on the local or remote computer. It is therefore necessary to have the following configuration directives: <br/>
-     NETSERVER on<br/>
-     NISPORT 3551<br/>
-					<br/>
-					<?php if ($pf_version < 2.2): ?>
-						<input type="Submit" value="Execute" class="formbtn" disabled/>
+     Default: <strong>localhost</strong><br /><br />
+     Note: apcaccess uses apcupsd's inbuilt Network Information Server (NIS) to obtain the current status information<br />
+     from the UPS on the local or remote computer. It is therefore necessary to have the following configuration directives: <br />
+     NETSERVER on<br />
+     NISPORT 3551<br />
+					<br />
+					<?php if ($pfs_version < 2.2): ?>
+						<input type="submit" value="Execute" class="formbtn" disabled="disabled" />
 					<?php else: ?>
-						<input type="Submit" value="Execute" class="formbtn"/>
+						<input type="submit" value="Execute" class="formbtn" />
 					<?php endif; ?>
 					</span>
 				</td>
+		
 			</tr>
-		</form>
 			<tr><td colspan="2">
 <?php
 	$nis_server = check_nis_running_apcupsd();
 
-	if ($pf_version >= 2.2){
-		if($strapcaccess) {
+	if ($pfs_version >= 2.2) {
+		if ($strapcaccess) {
 			echo "Running: apcaccess -h {$strapcaccess} <br/>";
 			puts("<pre>");
 			putenv("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
 			$ph = popen("apcaccess -h {$strapcaccess} 2>&1", "r" );
-			while ($line = fgets($ph)) echo htmlspecialchars($line);
+			while ($line = fgets($ph)) {
+				echo htmlspecialchars($line);
+			}
 			pclose($ph);
 			puts("</pre>");
-		}elseif($nis_server){
-			$nisip=(check_nis_ip_apcupsd() != ''? check_nis_ip_apcupsd() : "0.0.0.0");
-			$nisport=(check_nis_port_apcupsd() != ''? check_nis_port_apcupsd() : "3551");
+		} elseif ($nis_server) {
+			$nisip = (check_nis_ip_apcupsd() != ''? check_nis_ip_apcupsd() : "0.0.0.0");
+			$nisport = (check_nis_port_apcupsd() != '' ? check_nis_port_apcupsd() : "3551");
 			echo "Running: apcaccess -h {$nisip}:{$nisport} <br/>";
 			puts("<pre>");
 			putenv("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
 			$ph = popen("apcaccess -h localhost 2>&1", "r" );
-			while ($line = fgets($ph)) echo htmlspecialchars($line);
+			while ($line = fgets($ph)) {
+				echo htmlspecialchars($line);
+			}
 			pclose($ph);
 			puts("</pre>");
-		}else
-			echo "Network Information Server (NIS) not running, in order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br/>";
-   }else{
-		echo "pfSense version prior to 2.2 runs APCupsd 3.14.10 and apcaccess doesn't accept host parameter. <br/>";
-		if ($nis_server){
+		} else {
+			echo "Network Information Server (NIS) not running; in order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br />";
+		}
+	} else {
+		echo "pfSense version prior to 2.2 runs APCupsd 3.14.10 and apcaccess doesn't accept host parameter. <br />";
+		if ($nis_server) {
 			puts("<pre>");
 			putenv("PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
 			$ph = popen("apcaccess 2>&1", "r" );
-			while ($line = fgets($ph)) echo htmlspecialchars($line);
+			while ($line = fgets($ph)) {
+				echo htmlspecialchars($line);
+			}
 			pclose($ph);
 			puts("</pre>");
-		}else
-			echo "Network Information Server (NIS) not running, in order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br/>";
-   }
+		} else {
+			echo "Network Information Server (NIS) not running, in order to run apcaccess on localhost, you need to enable it on APCupsd General settings. <br />";
+		}
+	}
 
 ?>
 		</td></tr>
 	</table>
+	</form>
 </div>	
 <?php 
 include("fend.inc");

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1683,7 +1683,7 @@
 		<website>http://www.apcupsd.com/</website>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/apcupsd/apcupsd.xml</config_file>
-		<version>apcupsd-3.14.12_1 pkg v0.3.6</version>
+		<version>0.3.7</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<configurationfile>apcupsd.xml</configurationfile>


### PR DESCRIPTION
apcupsd.xml
- Fix copyright header
- Fix indendation
- Fix file permissions (no need for these to be executable)
- Remove useless empty tags
- Attempt to make the descriptions more readable.

apcupsd.inc
- Fix copyright headers
- Code style cleanup
- Use stop_service()/restart_service()
- Fix pfSense version checks

apcupsd.conf.php
- Fix copyright headers

apcupsd_mail.php
- Update copyright headers
- Code style fixes

apcupsd_status.php
- Remove outdated pfSense <=2.0 stuff and other junk
- Fix broken pfS version check
- Code style cleanup
- Valid XHTML

@dbaio - You might want to check this as well. ;)