### PR TITLE
remove useless config_(un)lock calls

### DIFF
--- a/config/autoconfigbackup/autoconfigbackup.inc
+++ b/config/autoconfigbackup/autoconfigbackup.inc
@@ -188,8 +188,6 @@ function upload_config($reasonm = "") {
 
 				// Mount RW (if needed)
 				conf_mount_rw();
-				// Lock config
-				config_lock();
 
 				$notice_text = "Beginning https://portal.pfsense.org configuration backup.";
 				log_error($notice_text);
@@ -254,8 +252,6 @@ function upload_config($reasonm = "") {
 					update_filter_reload_status($notice_text);	
 				}
 
-				// Unlock config
-				config_unlock();
 				// Mount image RO (if needed)
 				conf_mount_ro();
 

--- a/config/bandwidthd/bandwidthd.inc
+++ b/config/bandwidthd/bandwidthd.inc
@@ -51,14 +51,12 @@ function is_blank($value) {
 
 function bandwidthd_install_deinstall() {
 	conf_mount_rw();
-	config_lock();
 	exec("rm -f /usr/local/etc/rc.d/bandwidthd*");
 	exec("rm -rf " . PKG_BANDWIDTHD_BASE . "/htdocs");
 	exec("rm -f /usr/local/www/bandwidthd");
 	// Remove the cron job, if it is there
 	install_cron_job("/bin/kill -HUP `cat /var/run/bandwidthd.pid`", false);
 	conf_mount_ro();
-	config_unlock();
 }
 
 function bandwidthd_install_config() {
@@ -71,7 +69,6 @@ function bandwidthd_install_config() {
 	$bandwidthd_runtime_library_env = PKG_BANDWIDTHD_RUNTIME_LIBRARY_ENV;
 
 	conf_mount_rw();
-	config_lock();
 
 	/* user defined values */
 	$bandwidthd_config = $config['installedpackages']['bandwidthd']['config'][0];
@@ -391,7 +388,6 @@ EOD;
 		install_cron_job("/bin/kill -HUP `cat /var/run/bandwidthd.pid`", false);
 	}
 	conf_mount_ro();
-	config_unlock();
 	stop_service("bandwidthd");
 	if ($bandwidthd_enable) {
 		start_service("bandwidthd");

--- a/config/darkstat/darkstat.xml
+++ b/config/darkstat/darkstat.xml
@@ -262,7 +262,6 @@
 	<![CDATA[
 		function sync_package_darkstat() {
 			conf_mount_rw();
-			config_lock();
 			global $config, $darkstat_config;
 			$darkstat_config =& $config['installedpackages']['darkstat']['config'][0];
 
@@ -353,7 +352,6 @@
 				restart_service("darkstat");
 			}
 
-			config_unlock();
 			conf_mount_ro();
 		}
 

--- a/config/ftpproxy/ftpproxy.inc
+++ b/config/ftpproxy/ftpproxy.inc
@@ -31,7 +31,6 @@
 */
 function sync_package_ftpproxy() {
 	conf_mount_rw();
-	config_lock();
 	global $config;
 	$cf = $config['installedpackages']['ftpclientproxy']['config'][0];
 
@@ -85,7 +84,6 @@ function sync_package_ftpproxy() {
 	);
 	restart_service("ftp-proxy");
 	conf_mount_ro();
-	config_unlock();
 	filter_configure();
 }
 

--- a/config/haproxy-legacy/haproxy_frontends.php
+++ b/config/haproxy-legacy/haproxy_frontends.php
@@ -45,9 +45,7 @@ if ($_POST) {
 
 	if ($_POST['apply']) {
 		$retval = 0;
-		config_lock();
 		$retval = haproxy_configure();
-		config_unlock();
 		$savemsg = get_std_save_message($retval);
 		unlink_if_exists($d_haproxyconfdirty_path);
 	}

--- a/config/haproxy-legacy/haproxy_servers.php
+++ b/config/haproxy-legacy/haproxy_servers.php
@@ -46,9 +46,7 @@ if ($_POST) {
 
 	if ($_POST['apply']) {
 		$retval = 0;
-		config_lock();
 		$retval = haproxy_configure();
-		config_unlock();
 		$savemsg = get_std_save_message($retval);
 		unlink_if_exists($d_haproxyconfdirty_path);
 	}

--- a/config/haproxy/haproxy_listeners.php
+++ b/config/haproxy/haproxy_listeners.php
@@ -45,9 +45,7 @@ if ($_POST) {
 
 	if ($_POST['apply']) {
 		$retval = 0;
-		config_lock();
 		$retval = haproxy_configure();
-		config_unlock();
 		$savemsg = get_std_save_message($retval);
 		unlink_if_exists($d_haproxyconfdirty_path);
 	}

--- a/config/haproxy/haproxy_pools.php
+++ b/config/haproxy/haproxy_pools.php
@@ -49,9 +49,7 @@ if ($_POST) {
 
 	if ($_POST['apply']) {
 		$retval = 0;
-		config_lock();
 		$retval = haproxy_configure();
-		config_unlock();
 		$savemsg = get_std_save_message($retval);
 		unlink_if_exists($d_haproxyconfdirty_path);
 	}

--- a/config/imspector/imspector.inc
+++ b/config/imspector/imspector.inc
@@ -177,8 +177,7 @@
 			
 		/*continue sync process*/
 		log_error("Imspector: Saving changes.");
-		config_lock();
-			
+
 		/* remove existing rules */
 		exec('/sbin/pfctl -a imspector -Fr > /dev/null');
 		exec('/sbin/pfctl -a imspector -Fn > /dev/null');	
@@ -408,8 +407,7 @@ EOD;
 				imspector_action('restart');
 				}	
 		}	
-		config_unlock();
-		
+
 		/*check xmlrpc sync*/
 		imspector_sync_on_changes();		
 	}

--- a/config/ntop2/ntop.xml
+++ b/config/ntop2/ntop.xml
@@ -103,7 +103,6 @@
 	<![CDATA[
 	function sync_package_ntop() {
 		conf_mount_rw();
-		config_lock();
 		global $config;
 		global $input_errors;
 		if ($_POST) {
@@ -149,7 +148,6 @@
 		sleep(2);
 		start_service("ntop");
 		conf_mount_ro();
-		config_unlock();
 	}
 	]]>
 	</custom_php_global_functions>

--- a/config/ntopng/ntopng.xml
+++ b/config/ntopng/ntopng.xml
@@ -143,7 +143,6 @@
 			return;
 		}
 		conf_mount_rw();
-		config_lock();
 		global $config;
 		global $input_errors;
 		global $pf_version, $scripts_path, $fonts_path;
@@ -263,7 +262,6 @@
 		mwexec_bg("{$redis_path}/redis-cli SET user.admin.password " . escapeshellarg($password));
 		mwexec_bg("{$redis_path}/redis-cli save");
 		conf_mount_ro();
-		config_unlock();
 	}
 	function ntopng_update_geoip() {
 		$fetchcmd = "/usr/bin/fetch";

--- a/config/nut/nut.inc
+++ b/config/nut/nut.inc
@@ -498,8 +498,6 @@ EOD;
 		global $config;
 		global $input_errors;
 
-		config_lock();
-
 		stop_service("nut");
 
 		/* create state path */
@@ -542,7 +540,5 @@ EOD;
 			exec('/bin/rm -rf /var/db/nut');
 			conf_mount_ro();
 		}
-
-		config_unlock();
 	}
 ?>

--- a/config/pfflowd/pfflowd.xml
+++ b/config/pfflowd/pfflowd.xml
@@ -122,7 +122,6 @@
 		<![CDATA[
 		function sync_package_pfflowd() {
 			conf_mount_rw();
-			config_lock();
 			global $config;
 			foreach ($config['installedpackages']['pfflowd']['config'] as $cf) {
 				if ($cf['host'] != "") {
@@ -152,7 +151,6 @@
 				}
 			}
 			conf_mount_ro();
-			config_unlock();
 		}
 
 		function validate_form_pfflowd($post, &$input_errors) {

--- a/config/softflowd/softflowd.xml
+++ b/config/softflowd/softflowd.xml
@@ -183,7 +183,6 @@
 		<![CDATA[
 		function sync_package_softflowd() {
 			conf_mount_rw();
-			config_lock();
 			global $config;
 			$cf = $config['installedpackages']['softflowd']['config'][0];
 			$interface_list = explode(",", $cf['interface']);
@@ -249,7 +248,6 @@
 				}
 			}
 			conf_mount_ro();
-			config_unlock();
 		}
 
 		function validate_form_softflowd($post, &$input_errors) {

--- a/config/spamd/spamd_db_ext.php
+++ b/config/spamd/spamd_db_ext.php
@@ -165,7 +165,6 @@ if($_GET['whitelist'] <> "") {
 }
 
 function delete_from_spamd_db($srcip) {
-	config_lock();
 	$fd = fopen("/tmp/execcmds", "w");
 	fwrite($fd, "#!/bin/sh\n");	
 	fwrite($fd, "/usr/local/sbin/spamdb -d {$srcip}\n");
@@ -178,7 +177,6 @@ function delete_from_spamd_db($srcip) {
 	system("/bin/sh /tmp/execcmds");
 	mwexec("/usr/bin/killall -HUP spamlogd");
 	mwexec("/sbin/pfctl -q -t blacklist -T replace -f /var/db/blacklist.txt");
-	config_unlock();
 }
 
 function basic_auth_prompt(){
@@ -189,17 +187,14 @@ function basic_auth_prompt(){
 }
 
 function add_to_blacklist($srcip) {
-	config_lock();
 	$fd = fopen("/var/db/blacklist.txt", "a");
 	fwrite($fd, "{$srcip}\n");
 	fclose($fd);
 	mwexec("/sbin/pfctl -q -t spamd -T add -f /var/db/blacklist.txt");
 	mwexec("/sbin/pfctl -q -t blacklist -T add -f /var/db/blacklist.txt");
-	config_unlock();
 }
 
 function delete_from_blacklist($srcip) {
-	config_lock();
 	$blacklist = split("\n", file_get_contents("/var/db/blacklist.txt"));
 	$fd = fopen("/var/db/blacklist.txt", "w");
 	foreach($blacklist as $bl) {
@@ -210,11 +205,9 @@ function delete_from_blacklist($srcip) {
 	fclose($fd);
 	mwexec("/sbin/pfctl -q -t spamd -T delete $srcip");
 	mwexec("/sbin/pfctl -q -t blacklist -T replace -f /var/db/blacklist.txt");
-	config_unlock();
 }
 
 function delete_from_whitelist($srcip) {
-	config_lock();
 	$whitelist = split("\n", file_get_contents("/var/db/whitelist.txt"));
 	$fd = fopen("/var/db/whitelist.txt", "w");
 	foreach($whitelist as $wl) {
@@ -225,7 +218,6 @@ function delete_from_whitelist($srcip) {
 	fclose($fd);
 	mwexec("/sbin/pfctl -q -t spamd -T delete $srcip");
 	mwexec("/sbin/pfctl -q -t whitelist -T replace -f /var/db/whitelist.txt");
-	config_unlock();
 }
 
 function hup_spamd() {

--- a/config/spamd/spamd_verify_to_address.php
+++ b/config/spamd/spamd_verify_to_address.php
@@ -114,9 +114,7 @@ foreach($grey_hosts as $grey) {
             if($debug)
                 echo "/usr/local/sbin/spamdb -a \"<$email_to>\" -T\n";
             exec("/usr/local/sbin/spamdb -a \"<$email_to>\" -T");
-            config_lock();
             system("echo $server_ip >> /var/db/blacklist.txt");
-            config_unlock();
             $result = mwexec("/usr/local/sbin/spamdb -a $server_ip -t");
         } else {
             if($debug)

--- a/config/squid/squid_auth.inc
+++ b/config/squid/squid_auth.inc
@@ -35,8 +35,7 @@ function global_eval_auth_options()
 {
 	global $config;
 	conf_mount_rw();
-	config_lock();
-	
+
 	switch ($config['installedpackages']['squidauth']['config'][0]['auth_method']) {
 		case "none":
 			dynamic_auth_content("pkg_edit");
@@ -69,7 +68,6 @@ function global_eval_auth_options()
 			break;
 	}
 	
-	config_unlock();
 	conf_mount_ro();
 	
 } /* end function global_eval_auth_options */

--- a/config/squid/squid_ng.inc
+++ b/config/squid/squid_ng.inc
@@ -38,7 +38,6 @@ function global_write_squid_config()
 {
 	global $config;
 	conf_mount_rw();
-	config_lock();
 
     /* define squid configuration file in variable for replace function */
     $squidconfig = "/usr/local/etc/squid/squid.conf";
@@ -791,7 +790,6 @@ function global_write_squid_config()
 	fclose($fout);
 
 	conf_mount_ro();
-	config_unlock();
 
 	touch($squidconfig);
 } /* end function write_squid_config */
@@ -1032,7 +1030,6 @@ function write_static_squid_config() {
 function mod_htpasswd() {
 	global $config;
 	conf_mount_rw();
-	config_lock();
 
 	if (!file_exists("/usr/local/etc/squid/advanced/ncsa")) mwexec("mkdir -p /usr/local/etc/squid/advanced/ncsa");
 
@@ -1048,7 +1045,6 @@ function mod_htpasswd() {
 	fclose($passfile);
 
 	conf_mount_ro();
-	config_unlock();
 }
 
 function generate_htpasswd($username, $password) {

--- a/config/squid3/31/squid_auth.inc
+++ b/config/squid3/31/squid_auth.inc
@@ -35,8 +35,7 @@ function global_eval_auth_options()
 {
 	global $config;
 	conf_mount_rw();
-	config_lock();
-	
+
 	switch ($config['installedpackages']['squidauth']['config'][0]['auth_method']) {
 		case "none":
 			dynamic_auth_content("pkg_edit");
@@ -69,7 +68,6 @@ function global_eval_auth_options()
 			break;
 	}
 	
-	config_unlock();
 	conf_mount_ro();
 	
 } /* end function global_eval_auth_options */

--- a/config/squid3/31/squid_ng.inc
+++ b/config/squid3/31/squid_ng.inc
@@ -38,7 +38,6 @@ function global_write_squid_config()
 {
 	global $config;
 	conf_mount_rw();
-	config_lock();
 
     /* define squid configuration file in variable for replace function */
     $squidconfig = "/usr/local/etc/squid/squid.conf";
@@ -791,7 +790,6 @@ function global_write_squid_config()
 	fclose($fout);
 
 	conf_mount_ro();
-	config_unlock();
 
 	touch($squidconfig);
 } /* end function write_squid_config */
@@ -1032,7 +1030,6 @@ function write_static_squid_config() {
 function mod_htpasswd() {
 	global $config;
 	conf_mount_rw();
-	config_lock();
 
 	if (!file_exists("/usr/local/etc/squid/advanced/ncsa")) mwexec("mkdir -p /usr/local/etc/squid/advanced/ncsa");
 
@@ -1048,7 +1045,6 @@ function mod_htpasswd() {
 	fclose($passfile);
 
 	conf_mount_ro();
-	config_unlock();
 }
 
 function generate_htpasswd($username, $password) {

--- a/config/squid3/33/squid_auth.inc
+++ b/config/squid3/33/squid_auth.inc
@@ -35,8 +35,7 @@ function global_eval_auth_options()
 {
 	global $config;
 	conf_mount_rw();
-	config_lock();
-	
+
 	switch ($config['installedpackages']['squidauth']['config'][0]['auth_method']) {
 		case "none":
 			dynamic_auth_content("pkg_edit");
@@ -69,7 +68,6 @@ function global_eval_auth_options()
 			break;
 	}
 	
-	config_unlock();
 	conf_mount_ro();
 	
 } /* end function global_eval_auth_options */

--- a/config/squid3/33/squid_ng.inc
+++ b/config/squid3/33/squid_ng.inc
@@ -38,7 +38,6 @@ function global_write_squid_config()
 {
 	global $config;
 	conf_mount_rw();
-	config_lock();
 
     /* define squid configuration file in variable for replace function */
     $squidconfig = "/usr/local/etc/squid/squid.conf";
@@ -791,7 +790,6 @@ function global_write_squid_config()
 	fclose($fout);
 
 	conf_mount_ro();
-	config_unlock();
 
 	touch($squidconfig);
 } /* end function write_squid_config */
@@ -1032,7 +1030,6 @@ function write_static_squid_config() {
 function mod_htpasswd() {
 	global $config;
 	conf_mount_rw();
-	config_lock();
 
 	if (!file_exists("/usr/local/etc/squid/advanced/ncsa")) mwexec("mkdir -p /usr/local/etc/squid/advanced/ncsa");
 
@@ -1048,7 +1045,6 @@ function mod_htpasswd() {
 	fclose($passfile);
 
 	conf_mount_ro();
-	config_unlock();
 }
 
 function generate_htpasswd($username, $password) {

--- a/config/strikeback/strikeback.inc
+++ b/config/strikeback/strikeback.inc
@@ -44,7 +44,6 @@ function php_install_command_sb()
 
 	global $config;
 	conf_mount_rw();
-	config_lock();
 
 	if (!is_dir('/usr/local/www/packages/')) {
 		exec("mkdir /usr/local/www/packages/");
@@ -105,7 +104,6 @@ function php_install_command_sb()
 	exec("mv /usr/local/www/packages/strikeback/43132.png /usr/local/www/packages/strikeback/color.png");
 
 	conf_mount_ro();
-	config_unlock();
 }
 
 

--- a/config/stunnel/stunnel.inc
+++ b/config/stunnel/stunnel.inc
@@ -122,7 +122,6 @@ function stunnel_delete($config) {
 function stunnel_save($config) {
 	$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg']='';
 	conf_mount_rw();
-	config_lock();
 	if (!file_exists(STUNNEL_ETCDIR))
 		@mkdir(STUNNEL_ETCDIR, 0755, true);
 	$fout = fopen(STUNNEL_ETCDIR . "/stunnel.conf","w");
@@ -148,7 +147,6 @@ function stunnel_save($config) {
 	}
 	fclose($fout);
 	conf_mount_ro();
-	config_unlock();
 	system("/usr/local/etc/rc.d/stunnel.sh stop 2>/dev/null");
 	system("/usr/local/etc/rc.d/stunnel.sh start 2>/dev/null");
 }
@@ -221,7 +219,6 @@ function stunnel_install() {
 	unlink_if_exists("/usr/local/etc/rc.d/stunnel");
 	
 	conf_mount_rw();
-	config_lock();
 	$fout = fopen(STUNNEL_ETCDIR . "/stunnel.conf","w");
 	fwrite($fout, "cert = " . STUNNEL_ETCDIR . "/stunnel.pem \n");
 	fwrite($fout, "chroot = /var/tmp/stunnel \n");
@@ -238,7 +235,6 @@ function stunnel_install() {
 	}
 	fclose($fout);
 	conf_mount_ro();
-	config_unlock();
 }
 
 function stunnel_deinstall() {

--- a/config/tinydns/tinydns.inc
+++ b/config/tinydns/tinydns.inc
@@ -420,7 +420,7 @@ function tinydns_setup_ping_items() {
 		log_error("Could not open {$g['vardb_path']}/pkgpinghosts for writing.");
 		return;
 	}
-	config_lock();
+
 	/*   write out each ip address so ping_hosts.sh can begin monitoring ip
 	 *   status and create a database of the status information that we can use.
 	 */
@@ -484,7 +484,6 @@ function tinydns_setup_ping_items() {
 		}
 	}
 	fclose($fd);
-	config_unlock();
 }
 
 function tinydns_create_zone_file() {
@@ -492,7 +491,6 @@ function tinydns_create_zone_file() {
 	conf_mount_rw();
 	if(file_exists("/tmp/config.cache"))
 		unlink("/tmp/config.cache");
-	config_lock();
 	if(file_exists("{$g['varrun_path']}/service/tinydns/root/data"))
 		exec("rm -f {$g['varrun_path']}/service/tinydns/root/data");
 	if(!is_dir("{$g['varrun_path']}/service/tinydns/root"))
@@ -648,7 +646,6 @@ function tinydns_create_zone_file() {
 	fclose($fd);
 	/* tell tinydns to reload zone file */
 	exec("cd {$g['varrun_path']}/service/tinydns/root && /usr/local/bin/tinydns-data");
-	config_unlock();
 	conf_mount_ro();
 }
 

--- a/config/widentd/widentd.xml
+++ b/config/widentd/widentd.xml
@@ -102,7 +102,6 @@
 	<![CDATA[
 	function sync_package_widentd() {
 		conf_mount_rw();
-		config_lock();
 		global $config;
 
 		/* Write widentd.sh */
@@ -128,7 +127,6 @@
 		} else {
 			restart_service("widentd");
 		}
-		config_unlock();
 		conf_mount_ro();
 	}
 


### PR DESCRIPTION
This function does nothing but return. (No version bumps here, would be a waste of time to make people reinstall because of this.)