### PR TITLE
lcdproc-dev localhost fix, remove useless config_(un)lock calls

### DIFF
--- a/config/lcdproc-dev/lcdproc.inc
+++ b/config/lcdproc-dev/lcdproc.inc
@@ -63,16 +63,6 @@
 		fclose($handle);
 		chmod($file, 0755);
 	}
-	function before_form_lcdproc(&$pkg) {
-		global $config;
-		config_lock();
-		config_unlock();
-	}
-	function before_form_lcdproc_screens(&$pkg) {
-		global $config;
-		config_lock();
-		config_unlock();
-	}
 	function validate_form_lcdproc($post, &$input_errors) {
 		if($post['comport']) {
 			switch($post['comport']) {
@@ -150,7 +140,6 @@
 
 		#continue sync package 
 		lcdproc_notice("Sync: Begin package sync");
-		config_lock();
 		$lcdproc_config = $config['installedpackages']['lcdproc']['config'][0];
 		$lcdproc_screens_config = $config['installedpackages']['lcdprocscreens']['config'][0];
 		/* since config is written before this file invoked we don't need to read post data */
@@ -191,7 +180,6 @@
 					break;
 				default:
 					lcdproc_warn("The selected com port is not valid!");
-					config_unlock();
 					return;
 			}
 			$config_text = "[server]\n";
@@ -524,7 +512,6 @@ EOD;
 				conf_mount_ro();
 			}
 		}
-		config_unlock();
 		lcdproc_notice("Sync: End package sync");
 	}
 	function set_lcd_value($fieldname, $max, $default_value) {

--- a/config/lcdproc-dev/lcdproc.inc
+++ b/config/lcdproc-dev/lcdproc.inc
@@ -38,7 +38,7 @@
 	} else {
 		define('LCDPROC_CONFIG','/usr/local/etc/LCDd.conf');
 	}
-	define('LCDPROC_HOST','localhost');
+	define('LCDPROC_HOST','127.0.0.1');
 	define('LCDPROC_PORT','13666');
 	define('LCDPROC_SERVICE_NAME','lcdproc');
 	/* Functions */	

--- a/config/lcdproc-dev/lcdproc.xml
+++ b/config/lcdproc-dev/lcdproc.xml
@@ -2,7 +2,7 @@
 <packagegui>
 	<title>Services: LCDproc 0.5.6 pkg v. 0.9.9</title>
 	<name>lcdproc</name>
-	<version>0.5.6 pkg v. 0.9.9</version>
+	<version>0.9.12</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>
@@ -657,9 +657,6 @@
 			<default_value>default</default_value>
 		</field>		
 	</fields>
-	<custom_php_command_before_form>
-		before_form_lcdproc($pkg);
-	</custom_php_command_before_form>
 	<custom_php_validation_command>
 		validate_form_lcdproc($_POST, $input_errors);
 	</custom_php_validation_command>

--- a/config/lcdproc-dev/lcdproc_screens.xml
+++ b/config/lcdproc-dev/lcdproc_screens.xml
@@ -2,7 +2,7 @@
 <packagegui>
 	<title>Services: LCDproc: Screens</title>
 	<name>lcdproc_screens</name>
-	<version>0.5.5 pkg v. 0.9.4</version>
+	<version>0.9.12</version>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/lcdproc.inc</include_file>
 	<tabs>
@@ -105,9 +105,6 @@
 			<description>If Interface Traffic is enabled, here you specify which interface to monitor</description>
 		</field>				
 	</fields>
-	<custom_php_command_before_form>
-		before_form_lcdproc_screens($pkg);
-	</custom_php_command_before_form>
 	<custom_php_validation_command>
 		validate_form_lcdproc_screens($_POST, $input_errors);
 	</custom_php_validation_command>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1110,7 +1110,7 @@
 		<descr>LCD display driver - development version.</descr>
 		<website>http://www.lcdproc.org/</website>
 		<category>Utility</category>
-		<version>0.9.11</version>
+		<version>0.9.12</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<maintainer>michele@nt2.it</maintainer>


### PR DESCRIPTION
Get fix from #945  into the -dev version as well. (Planning to do a code style cleanup for this one as well, but it takes some time.) Also, remove useless config_(un)lock calls while here.