### PR TITLE
syslog-ng - code style fixes

### DIFF
--- a/config/syslog-ng/syslog-ng.inc
+++ b/config/syslog-ng/syslog-ng.inc
@@ -1,8 +1,9 @@
 <?php
-/* $Id$ */
 /*
 	syslog-ng.inc
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2012 Lance Leger
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -26,7 +27,6 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require_once('globals.inc');
 require_once('config.inc');
 require_once('util.inc');
@@ -34,29 +34,31 @@ require_once('pfsense-utils.inc');
 require_once('pkg-utils.inc');
 require_once('service-utils.inc');
 
-if(!function_exists("filter_configure")) 
+if (!function_exists("filter_configure")) {
 	require_once("filter.inc");
+}
 
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version == "2.1" || $pf_version == "2.2")
+$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+if ($pf_version == "2.1" || $pf_version == "2.2") {
 	define("SYSLOGNG_BASEDIR", "/usr/pbi/syslog-ng-" . php_uname("m") . "/");
-else
+} else {
 	define("SYSLOGNG_BASEDIR", "/usr/local/");
+}
 
 function syslogng_get_real_interface_address($interface) {
 	$interface = convert_friendly_interface_to_real_interface_name($interface);
-	$line = trim(shell_exec("ifconfig $interface | grep inet | grep -v inet6 | awk '{ print \$2, \$4 }'"));
-	list($ip, $netmask) = explode(" ", $line);
-
-	return array($ip, long2ip(hexdec($netmask)));
+	$ip = get_interface_ip($interface);
+	return array($ip);
 }
 
 function syslogng_install_command() {
 	conf_mount_rw();
-	if (is_link("/usr/local/lib/syslog-ng"))
-		unlink_if_exists("/usr/local/lib/syslog-ng");
-	if (!file_exists("/usr/local/lib/syslog-ng"))
+	if (is_link("/usr/local/lib/syslog-ng")) {
+		unlink("/usr/local/lib/syslog-ng");
+	}
+	if (!file_exists("/usr/local/lib/syslog-ng")) {
 		@symlink(SYSLOGNG_BASEDIR . "local/lib/syslog-ng", "/usr/local/lib/syslog-ng");
+	}
 	syslogng_install_cron(true);
 	conf_mount_ro();
 	syslogng_resync();
@@ -64,10 +66,10 @@ function syslogng_install_command() {
 
 function syslogng_deinstall_command() {
 	conf_mount_rw();
-	exec("/usr/local/etc/rc.d/syslog-ng.sh stop");
+	service_stop("syslog-ng");
 	unlink_if_exists("/usr/local/etc/rc.d/syslog-ng.sh");
 	if (is_link("/usr/local/lib/syslog-ng"))
-		unlink_if_exists("/usr/local/lib/syslog-ng");
+		unlink("/usr/local/lib/syslog-ng");
 	syslogng_install_cron(false);
 	unlink_if_exists("/usr/local/etc/logrotate.conf");
 	unlink_if_exists("/usr/local/etc/syslog-ng.conf");
@@ -77,88 +79,95 @@ function syslogng_deinstall_command() {
 
 function syslogng_validate_general($post, &$input_errors) {
 	global $config;
-	
+
 	$objects = $config['installedpackages']['syslogngadvanced']['config'];
-	
-	if(empty($post['interfaces'])) {
+
+	if (empty($post['interfaces'])) {
 		$input_errors[] = 'You must select at least one interface in \'Interfaces\' field';
 	} else {
 		$post['interfaces'] = implode(",", $post['interfaces']);
 	}
-	
-	if(!is_port($post['default_port']))
+
+	if (!is_port($post['default_port'])) {
 		$input_errors[] = 'You must enter a valid port number in the \'Default Port\' field';
-	
+	}
+
 	$sockstat = trim(shell_exec("sockstat -l -P " . $post['default_protocol'] . " -p " . $post['default_port'] . " | grep -v ^USER | grep -v syslog-ng"));
-	if(!empty($sockstat))
+	if (!empty($sockstat)) {
 		$input_errors[] = 'The port specified in the \'Default Port\' field is already in use';
-	
-	if(!preg_match("/^\\/[^?*:;{}\\\\]+[^\\/]$/", $post['default_logdir'])) {
+	}
+
+	if (!preg_match("/^\\/[^?*:;{}\\\\]+[^\\/]$/", $post['default_logdir'])) {
 		$input_errors[] = 'You must enter a valid directory in the \'Default Log Directory\' field';
-	} elseif($post['default_logdir'] == "/var/log") {
+	} elseif ($post['default_logdir'] == "/var/log") {
 		$input_errors[] = 'You must enter a valid directory in the \'Default Log Directory\' field -- /var/log is reserved for pfSense';
 	}
-	
-	if(!preg_match("/^[^\\/?*:;{}\\\\]+$/", $post['default_logfile']))
+
+	if (!preg_match("/^[^\\/?*:;{}\\\\]+$/", $post['default_logfile'])) {
 		$input_errors[] = 'You must enter a valid file in the \'Default Log File\' field';
-	
+	}
+
 	$default_objects = syslogng_build_default_objects($post);
-	
-	if(empty($objects)) {
+
+	if (empty($objects)) {
 		$objects = $default_objects;
 	} else {
 		$objects = syslogng_merge_objects($objects, $default_objects);
 	}
-	
-	if($errors = syslogng_test_object_syntax($objects))
+
+	if ($errors = syslogng_test_object_syntax($objects)) {
 		$input_errors[] = "Syslog-ng syntax test failed:\n" . $errors;
+	}
 }
 
 function syslogng_validate_advanced($post, &$input_errors) {
 	global $config;
-	
+
 	$objects = $config['installedpackages']['syslogngadvanced']['config'];
 
-	if($post['objectname'] == '_DEFAULT') {
+	if ($post['objectname'] == '_DEFAULT') {
 		$input_errors[] = 'Creation or modification of \'_DEFAULT\' objects not permitted. Change default settings under \'General\' tab.';
 	}
-	
+
 	$post['objectparameters'] = base64_encode($post['objectparameters']);
 	$new_object[] = array("objecttype"=>$post['objecttype'], "objectname"=>$post['objectname'], "objectparameters"=>$post['objectparameters']);
-	
-	if(empty($objects)) {
+
+	if (empty($objects)) {
 		$objects = $new_object;
 	} else {
 		$objects = syslogng_merge_objects($objects, $new_object);
 	}
-	
-	if($errors = syslogng_test_object_syntax($objects))
+
+	if ($errors = syslogng_test_object_syntax($objects)) {
 		$input_errors[] = "Syslog-ng syntax test failed:\n" . $errors;
+	}
 }
 
 function syslogng_install_cron($should_install) {
-	global $config, $g;
-	
-	if($g['booting']==true) 
+	global $config;
+
+	if (platform_booting()) {
 		return;
-	
-	if(!$config['cron']['item'])
+	}
+
+	if (!$config['cron']['item']) {
 		return;
+	}
 
 	$x=0;
 	$rotate_job_id=-1;
 	$rotate_is_installed = false;
-	
-	foreach($config['cron']['item'] as $item) {
-		if(strstr($item['task_name'], "syslogng_rotate_logs")) {
+
+	foreach ($config['cron']['item'] as $item) {
+		if (strstr($item['task_name'], "syslogng_rotate_logs")) {
 			$rotate_job_id = $x;
 		}
 		$x++;
 	}
 	$need_write = false;
-	switch($should_install) {
+	switch ($should_install) {
 		case true:
-			if($rotate_job_id < 0) {
+			if ($rotate_job_id < 0) {
 				$cron_item = array();
 				$cron_item['task_name'] = "syslogng_rotate_logs";
 				$cron_item['minute'] = "0";
@@ -167,21 +176,21 @@ function syslogng_install_cron($should_install) {
 				$cron_item['month'] = "*";
 				$cron_item['wday'] = "*";
 				$cron_item['who'] = "root";
-				$cron_item['command'] = "/usr/bin/nice -n20 " . SYSLOGNG_BASEDIR .  "local/sbin/logrotate /usr/local/etc/logrotate.conf";
+				$cron_item['command'] = "/usr/bin/nice -n20 " . SYSLOGNG_BASEDIR . "local/sbin/logrotate /usr/local/etc/logrotate.conf";
 				$config['cron']['item'][] = $cron_item;
 				$need_write = true;
 			}
-			if($need_write) {
+			if ($need_write) {
 				parse_config(true);
 				write_config("Adding syslog-ng Cron Jobs");
 			}
 		break;
 		case false:
-			if($rotate_job_id >= 0) {
+			if ($rotate_job_id >= 0) {
 				unset($config['cron']['item'][$rotate_job_id]);
 				$need_write = true;
 			}
-			if($need_write) {
+			if ($need_write) {
 				parse_config(true);
 				write_config("Removing syslog-ng Cron Jobs");
 			}
@@ -192,17 +201,17 @@ function syslogng_install_cron($should_install) {
 
 function syslogng_build_default_objects($settings) {
 	$default_objects = array();
-	
+
 	$interfaces = $settings['interfaces'];
 	$default_protocol = $settings['default_protocol'];
 	$default_port = $settings['default_port'];
 	$default_logdir = $settings['default_logdir'];
 	$default_logfile = $settings['default_logfile'];
-	
+
 	$default_objects[0] = array("objecttype"=>"source", "objectname"=>"_DEFAULT", "objectparameters"=>"{ internal(); syslog(transport($default_protocol) port($default_port)");
 	foreach (explode(",", $interfaces) as $interface) {
 		$interface_address = syslogng_get_real_interface_address($interface);
-		if($interface_address[0]) {
+		if ($interface_address[0]) {
 			$default_objects[0]['objectparameters'] .= " ip({$interface_address[0]})";
 		}
 	}
@@ -212,51 +221,52 @@ function syslogng_build_default_objects($settings) {
 	$default_objects[1]['objectparameters'] = base64_encode($default_objects[1]['objectparameters']);
 	$default_objects[2] = array("objecttype"=>"log", "objectname"=>"_DEFAULT", "objectparameters"=>"{ source(_DEFAULT); destination(_DEFAULT); };");
 	$default_objects[2]['objectparameters'] = base64_encode($default_objects[2]['objectparameters']);
-	
+
 	return $default_objects;
 }
 
 
-function syslogng_merge_objects($objects1, $objects2)
-{
-	foreach($objects2 as $object2) {
+function syslogng_merge_objects($objects1, $objects2) {
+
+	foreach ($objects2 as $object2) {
 		$match = 0;
-		foreach($objects1 as &$object1) {
-			if(($object2['objecttype'] == $object1['objecttype']) && ($object2['objectname'] == $object1['objectname'])) {
+		foreach ($objects1 as &$object1) {
+			if (($object2['objecttype'] == $object1['objecttype']) && ($object2['objectname'] == $object1['objectname'])) {
 				$object1 = $object2;
 				$match = 1;
 			}
 		}
-		if($match == 0)
+		if ($match == 0) {
 			array_push($objects1, $object2);
+		}
 	}
 
 	return $objects1;
 }
 
 function syslogng_test_object_syntax($objects) {
-	exec("mv /usr/local/etc/syslog-ng.conf /usr/local/etc/syslog-ng.conf.backup");
+	rename("/usr/local/etc/syslog-ng.conf", "/usr/local/etc/syslog-ng.conf.backup");
 	syslogng_build_conf($objects);
 	$errors = trim(shell_exec('/usr/local/sbin/syslog-ng --syntax-only 2>&1'));
-	exec("mv /usr/local/etc/syslog-ng.conf /usr/local/etc/syslog-ng.conf.tested");
-	exec("mv /usr/local/etc/syslog-ng.conf.backup /usr/local/etc/syslog-ng.conf");
-	
+	rename("/usr/local/etc/syslog-ng.conf", "/usr/local/etc/syslog-ng.conf.tested");
+	rename("/usr/local/etc/syslog-ng.conf.backup", "/usr/local/etc/syslog-ng.conf");
+
 	return $errors;
 }
 
 function syslogng_get_log_files($objects) {
 	$log_files = array();
-	
-	foreach($objects as $object) {
-		if($object['objecttype'] == 'destination') {
+
+	foreach ($objects as $object) {
+		if ($object['objecttype'] == 'destination') {
 			preg_match("/\bfile\b\(['\"]([^'\"]*)['\"]/", base64_decode($object['objectparameters']), $match);
-			if($match) {
+			if ($match) {
 				$log_file = $match[1];
 				array_push($log_files, $log_file);
 			}
 		}
 	}
-	
+
 	return $log_files;
 }
 
@@ -264,15 +274,15 @@ function syslogng_build_conf($objects) {
 	$conf = "# This file is automatically generated by pfSense\n";
 	$conf .= "# Do not edit manually !\n";
 	$conf .= "@version:3.6\n";
-	
-	foreach($objects as $object) {
-		if($object['objecttype'] == 'log' || $object['objecttype'] == 'options') {
+
+	foreach ($objects as $object) {
+		if ($object['objecttype'] == 'log' || $object['objecttype'] == 'options') {
 			$conf .= $object['objecttype'] . " " . base64_decode($object['objectparameters']) . "\n";
 		} else {
 			$conf .= $object['objecttype'] . " " . $object['objectname'] . " " . base64_decode($object['objectparameters']) . "\n";
 		}
 	}
-	
+
 	file_put_contents('/usr/local/etc/syslog-ng.conf', $conf);
 }
 
@@ -287,7 +297,7 @@ function syslogng_build_logrotate_conf($settings, $objects) {
 
 	$log_files = syslogng_get_log_files($objects);
 
-	foreach($log_files as $log_file) {
+	foreach ($log_files as $log_file) {
 		$conf .= "$log_file ";
 	}
 
@@ -295,9 +305,9 @@ function syslogng_build_logrotate_conf($settings, $objects) {
 	$conf .= "\trotate $max_archives\n";
 	$conf .= "\t$archive_frequency\n";
 
-	if($compress_archives == 'on') {
+	if ($compress_archives == 'on') {
 		$conf .= "\tcompress\n";
-		if($compress_type == 'bz2') {
+		if ($compress_type == 'bz2') {
 			$conf .= "\tcompresscmd bzip2\n";
 		}
 	}
@@ -312,103 +322,113 @@ function syslogng_build_logrotate_conf($settings, $objects) {
 
 function syslogng_generate_rules($type) {
 	global $config;
-	
+
 	$settings = $config['installedpackages']['syslogng']['config'][0];
-	
+
 	$interfaces = ($settings['interfaces'] ? $settings['interfaces'] : 'lan');
 	$default_protocol = ($settings['default_protocol'] ? $settings['default_protocol'] : 'udp');
 	$default_port = ($settings['default_port'] ? $settings['default_port'] : 5140);
-	
+
 	$rules = "";
-	switch($type) {
+	switch ($type) {
 		case 'rule':
 			foreach ($interfaces as $interface) {
 				$rules .= "pass in quick on $interface proto $default_protocol from any to !($interface) port $default_port no state label\n";
 			}
 			break;
 	}
-	
+
 	return $rules;
 }
-	
+
 function syslogng_resync() {
 	global $config;
 	conf_mount_rw();
-	
+
 	$settings = $config['installedpackages']['syslogng']['config'][0];
 	$objects = $config['installedpackages']['syslogngadvanced']['config'];
-	
-	if(!isset($settings['enable']))
+
+	if (!isset($settings['enable'])) {
 		$settings['enable'] = 'off';
-	if(!isset($settings['interfaces']))
+	}
+	if (!isset($settings['interfaces'])) {
 		$settings['interfaces'] = 'lan';
-	if(!isset($settings['default_protocol']))
+	}
+	if (!isset($settings['default_protocol'])) {
 		$settings['default_protocol'] = 'udp';
-	if(!isset($settings['default_port']))
+	}
+	if (!isset($settings['default_port'])) {
 		$settings['default_port'] = 5140;
-	if(!isset($settings['default_logdir']))
+	}
+	if (!isset($settings['default_logdir'])) {
 		$settings['default_logdir'] = '/var/syslog-ng';
-	if(!isset($settings['default_logfile']))
+	}
+	if (!isset($settings['default_logfile'])) {
 		$settings['default_logfile'] = 'default.log';
-	if(!isset($settings['archive_frequency']))
+	}
+	if (!isset($settings['archive_frequency'])) {
 		$settings['archive_frequency'] = 'daily';
-	if(!isset($settings['compress_archives']))
+	}
+	if (!isset($settings['compress_archives'])) {
 		$settings['compress_archives'] = 'on';
-	if(!isset($settings['compress_type']))
+	}
+	if (!isset($settings['compress_type'])) {
 		$settings['compress_type'] = 'gz';
-	if(!isset($settings['max_archives']))
+	}
+	if (!isset($settings['max_archives'])) {
 		$settings['max_archives'] = 30;
-	
+	}
+
 	$default_objects = syslogng_build_default_objects($settings);
-	
-	if(empty($objects)) {
+
+	if (empty($objects)) {
 		$objects = $default_objects;
 	} else {
 		$objects = syslogng_merge_objects($objects, $default_objects);
 	}
-	
-	$sort = array(); 
-	foreach($objects as $k=>$v) { 
-	    $sort['objecttype'][$k] = $v['objecttype']; 
-	    $sort['objectname'][$k] = $v['objectname']; 
-	} 
-	array_multisort($sort['objecttype'], SORT_ASC, $sort['objectname'], SORT_ASC, $objects); 
+
+	$sort = array();
+	foreach ($objects as $k=>$v) {
+		$sort['objecttype'][$k] = $v['objecttype'];
+		$sort['objectname'][$k] = $v['objectname'];
+	}
+	array_multisort($sort['objecttype'], SORT_ASC, $sort['objectname'], SORT_ASC, $objects);
 
 	syslogng_build_conf($objects);
 	syslogng_build_logrotate_conf($settings, $objects);
 
 	$config['installedpackages']['syslogng']['config'][0] = $settings;
 	$config['installedpackages']['syslogngadvanced']['config'] = $objects;
-	
-	if($settings['enable'] == 'on') {
-		if(!file_exists($settings['default_logdir'])) {
+
+	if ($settings['enable'] == 'on') {
+		if (!file_exists($settings['default_logdir'])) {
 			exec("mkdir -p " . $settings['default_logdir']);
 		}
-		
+
 		syslogng_write_rcfile();
-		
-		if(!is_service_running('syslog-ng')) {
+
+		if (!is_service_running('syslog-ng')) {
 			log_error("Starting syslog-ng");
-			exec("/usr/local/etc/rc.d/syslog-ng.sh start");
+			start_service("syslog-ng");
 		} else {
 			log_error("Reloading syslog-ng for configuration sync");
-			exec("/usr/local/etc/rc.d/syslog-ng.sh restart");
+			restart_service("syslog-ng");
 		}
-	
+
 		// Sleep for a couple seconds to give syslog-ng a chance to fire up fully.
 		for ($i=0; $i < 10; $i++) {
-			if(!is_service_running('syslog-ng'))
+			if (!is_service_running('syslog-ng')) {
 				sleep(1);
+			}
 		}
 	} else {
-		if(is_service_running('syslog-ng')) {
+		if (is_service_running('syslog-ng')) {
 			log_error("Stopping syslog-ng");
-			exec("/usr/local/etc/rc.d/syslog-ng.sh stop");
-			
+			stop_service("syslog-ng");
 			unlink_if_exists("/usr/local/etc/rc.d/syslog-ng.sh");
 		}
 	}
-	
+
 	write_config();
 	conf_mount_ro();
 	filter_configure();

--- a/config/syslog-ng/syslog-ng.xml
+++ b/config/syslog-ng/syslog-ng.xml
@@ -2,47 +2,47 @@
 <!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
 <?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-        <copyright>
-        <![CDATA[
+	<copyright>
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    syslog-ng.xml
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2012 Lance Leger
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
+	syslog-ng.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Lance Leger
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
-        </copyright>
-    <description>Describe your package here</description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>Syslog-ng</name>
-	<version>3.5.4.1_1 pkg.v.1.0.1</version>
+	<version>1.0.8</version>
 	<title>Services: Syslog-ng</title>
 	<include_file>/usr/local/pkg/syslog-ng.inc</include_file>
 	<menu>
@@ -72,18 +72,15 @@
 		</tab>
 	</tabs>
 	<additional_files_needed>
-	    <prefix>/usr/local/pkg/</prefix>
-	    <chmod>0755</chmod>
-	    <item>https://packages.pfsense.org/packages/config/syslog-ng/syslog-ng.inc</item>
+		<prefix>/usr/local/pkg/</prefix>
+		<item>https://packages.pfsense.org/packages/config/syslog-ng/syslog-ng.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
-	    <prefix>/usr/local/pkg/</prefix>
-	    <chmod>0755</chmod>
+		<prefix>/usr/local/pkg/</prefix>
 		<item>https://packages.pfsense.org/packages/config/syslog-ng/syslog-ng_advanced.xml</item>
-	</additional_files_needed>
+		</additional_files_needed>
 	<additional_files_needed>
-	    <prefix>/usr/local/www/</prefix>
-	    <chmod>0755</chmod>
+		<prefix>/usr/local/www/</prefix>
 		<item>https://packages.pfsense.org/packages/config/syslog-ng/syslog-ng_log_viewer.php</item>
 	</additional_files_needed>
 	<fields>
@@ -108,8 +105,8 @@
 			<type>select</type>
 			<value>udp</value>
 			<options>
-			    <option><name>UDP</name><value>udp</value></option>
-			    <option><name>TCP</name><value>tcp</value></option>
+				<option><name>UDP</name><value>udp</value></option>
+				<option><name>TCP</name><value>tcp</value></option>
 			</options>
 			<required/>
 		</field>
@@ -144,7 +141,7 @@
 			<type>select</type>
 			<value>daily</value>
 			<options>
-			    <option><name>Daily</name><value>daily</value></option>
+				<option><name>Daily</name><value>daily</value></option>
 				<option><name>Weekly</name><value>weekly</value></option>
 				<option><name>Monthly</name><value>monthly</value></option>
 			</options>
@@ -163,8 +160,8 @@
 			<type>select</type>
 			<value>gz</value>
 			<options>
-			    <option><name>Gzip</name><value>gz</value></option>
-			    <option><name>Bzip2</name><value>bz2</value></option>
+				<option><name>Gzip</name><value>gz</value></option>
+				<option><name>Bzip2</name><value>bz2</value></option>
 			</options>
 		</field>
 		<field>
@@ -175,7 +172,7 @@
 			<default_value>30</default_value>
 			<required/>
 		</field>
-    </fields>
+	</fields>
 	<custom_php_validation_command>
 		syslogng_validate_general($_POST, $input_errors);
 	</custom_php_validation_command>
@@ -188,5 +185,7 @@
 	<custom_php_deinstall_command>
 		syslogng_deinstall_command();
 	</custom_php_deinstall_command>
-    <filter_rules_needed>syslogng_generate_rules</filter_rules_needed>
+	<filter_rules_needed>
+		syslogng_generate_rules();
+	</filter_rules_needed>
 </packagegui>

--- a/config/syslog-ng/syslog-ng_advanced.xml
+++ b/config/syslog-ng/syslog-ng_advanced.xml
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-        <copyright>
-        <![CDATA[
+	<copyright>
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    syslog-ng_advanced.xml
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2012 Lance Leger
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
+	syslog-ng_advanced.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Lance Leger
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
-        </copyright>
-    <description>Describe your package here</description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>Syslog-ng Advanced</name>
-	<version>0.1.0</version>
+	<version>1.0.8</version>
 	<title>Services: Syslog-ng Advanced</title>
 	<include_file>/usr/local/pkg/syslog-ng.inc</include_file>
 	<delete_string>An object has been deleted.</delete_string>

--- a/config/syslog-ng/syslog-ng_log_viewer.php
+++ b/config/syslog-ng/syslog-ng_log_viewer.php
@@ -1,37 +1,32 @@
 <?php
-/* $Id$ */
-/* ========================================================================== */
 /*
-    syslog-ng_log_viewer.xml
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2012 Lance Leger
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
-/*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	syslog-ng_log_viewer.php
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Lance Leger
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
 require("guiconfig.inc");
 require("/usr/local/pkg/syslog-ng.inc");
 
@@ -41,50 +36,56 @@ $default_logfile = $config['installedpackages']['syslogng']['config'][0]['defaul
 $compress_archives = $config['installedpackages']['syslogng']['config'][0]['compress_archives'];
 $compress_type = $config['installedpackages']['syslogng']['config'][0]['compress_type'];
 
-if($_POST['logfile'])
+if ($_POST['logfile']) {
 	$logfile = $_POST['logfile'];
-else
+} else {
 	$logfile = $default_logdir . "/" . $default_logfile;
- 
-if($_POST['limit'])
+}
+
+if ($_POST['limit']) {
 	$limit = intval($_POST['limit']);
-else
+} else {
 	$limit = "10";
+}
 
-if($_POST['archives'])
+if ($_POST['archives']) {
 	$archives = true;
+}
 
-if($_POST['filter'])
+if ($_POST['filter']) {
 	$filter = $_POST['filter'];
+}
 
-if($_POST['not'])
+if ($_POST['not']) {
 	$not = true;
+}
 
 $log_messages = array();
-if(file_exists($logfile) && (filesize($logfile) > 0)) {
+if (file_exists($logfile) && (filesize($logfile) > 0)) {
 	$grep = "grep -ih";
-	
-	if(($compress_archives == 'on') && glob($logfile . "*" . $compress_type) && $archives) {
+
+	if (($compress_archives == 'on') && glob($logfile . "*" . $compress_type) && $archives) {
 		if($compress_type == 'bz2') {
 			$grep = "bzgrep -ih";
 		} else {
 			$grep = "zgrep -ih";
 		}
 	}
-	
-	if(isset($filter) && $not) {
+
+	if (isset($filter) && $not) {
 		$grepcmd = "$grep -v '$filter' $logfile";
 	} else {
 		$grepcmd = "$grep '$filter' $logfile";
 	}
-	
-	if($archives)
+
+	if ($archives) {
 		$grepcmd = $grepcmd . "*";
-	
+	}
+
 	$log_lines = trim(shell_exec("$grepcmd | wc -l"));
 	$log_output = trim(shell_exec("$grepcmd | sort -M | tail -n $limit"));
-	
-	if(!empty($log_output)) {
+
+	if (!empty($log_output)) {
 		$log_messages = explode("\n", $log_output);
 		$log_messages_count = sizeof($log_messages);
 	}
@@ -92,7 +93,7 @@ if(file_exists($logfile) && (filesize($logfile) > 0)) {
 
 $pgtitle = "Services: Syslog-ng Log Viewer";
 include("head.inc");
-?>                                                                          
+?>
 <body link="#000000" vlink="#000000" alink="#000000">
 <?php include("fbegin.inc"); ?>
 <?php if ($savemsg) print_info_box($savemsg); ?>
@@ -107,11 +108,11 @@ include("head.inc");
 	display_top_tabs($tab_array);
 ?>
 	</td></tr>
-  	<tr><td>
+	<tr><td>
 	<div id="mainarea">
-		<table id="maintable" name="maintable" class="tabcont" width="100%" border="0" cellpadding="0" cellspacing="0">
+		<table id="maintable" class="tabcont" width="100%" border="0" cellpadding="0" cellspacing="0">
 			<tr><td>
-			
+
 			<table>
 				<tr><td width="22%">Log File</td><td width="78%"><select name="logfile">
 				<?php
@@ -143,7 +144,7 @@ include("head.inc");
 				<?php
 				if(!empty($log_messages)) {
 					echo "<tr><td class=\"listtopic\">Showing $log_messages_count of $log_lines messages</td></tr>\n";
-					foreach($log_messages as $log_message) {	
+					foreach($log_messages as $log_message) {
 						echo "<tr><td class=\"listr\">$log_message</td></tr>\n";
 					}
 				} else {
@@ -156,7 +157,7 @@ include("head.inc");
 				<tr><td width="22%">Inverse Filter (NOT)</td><td width="78%"><input type="checkbox" name="not" <?php if($not) echo " CHECKED"; ?> /></td></tr>
 				<tr><td colspan="2"><input type="submit" value="Refresh" /></td></tr>
 			</table>
-	
+
 			</td></tr>
 		</table>
 	</div>
@@ -165,3 +166,4 @@ include("head.inc");
 </form>
 <?php include("fend.inc"); ?>
 </body>
+</html>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1495,7 +1495,7 @@
 		<website>http://www.balabit.com/network-security/syslog-ng/</website>
 		<descr>Syslog-ng syslog server. This service is not intended to replace the default pfSense syslog server but rather acts as an independent syslog server.</descr>
 		<category>Services</category>
-		<version>1.0.7</version>
+		<version>1.0.8</version>
 		<status>ALPHA</status>
 		<required_version>2.2</required_version>
 		<depends_on_package_pbi>syslog-ng-3.6.2_3-##ARCH##.pbi</depends_on_package_pbi>


### PR DESCRIPTION
syslog-ng.xml
- Fix copyright header
- Fix indentation
- Fix permissions
- Sanitize package version and make it consistent across XML files

syslog-ng_advanced.xml
- Fix copyright header
- Sanitize package version and make it consistent across XML files

syslog-ng.inc
- Update copyright header
- Code style fixes
- Fix indentation
- Use get_interface_ip() instead of parsing ifconfig output
- Use {start,stop,restart}_service() instead of exec()
- Use rename() instead of mv.
- Use platform_booting() to check whether system is booting

syslog-ng_log_viewer.php
- Fix copyright header
- Code style and indentation fixes
- Valid XHTML