### PR TITLE
bacula-client - code style fixes

### DIFF
--- a/config/bacula-client/bacula-client.inc
+++ b/config/bacula-client/bacula-client.inc
@@ -1,128 +1,118 @@
 <?php
-
-/* ========================================================================== */
 /*
-    bacula-client.inc
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2012 Marcio Carlos Braga Antao
-    Copyright (C) 2012-2013 Marcello Coutinho
-    All rights reserved.
+	bacula-client.inc
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Marcio Carlos Braga Antao
+	Copyright (C) 2012-2013 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-    Based on m0n0wall (http://m0n0.ch/wall)
-    Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
-/*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code MUST retain the above copyright notice,
-        this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form MUST reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
- require_once("config.inc");
- require_once("util.inc");
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+require_once("config.inc");
+require_once("util.inc");
 
- $pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version > 2.0)
+$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+if ($pf_version == "2.1" || $pf_version == "2.2") {
 	define('BACULA_LOCALBASE', '/usr/pbi/bacula-' . php_uname("m"));
-else
+} else {
 	define('BACULA_LOCALBASE','/usr/local');
-
+}
 define('BACULA_STARTUP_SCRIPT', '/usr/local/etc/rc.d/bacula-fd.sh');
 
-function baculaclient_custom_php_install_command(){
-	global $g, $config;
+function baculaclient_custom_php_install_command() {
 	baculaclient_custom_php_write_config();
 }
 
 function baculaclient_custom_php_deinstall_command(){
-	global $g, $config;
-
 	conf_mount_rw();
 
-	// 1. Delete our config file
-	unlink_if_exists(BACULA_LOCALBASE."/etc/bacula/bacula-fd.conf");
+	// Delete our config file
+	unlink_if_exists(BACULA_LOCALBASE . "/etc/bacula/bacula-fd.conf");
+	// Stop service and delete our rc file
+	stop_service("bacula-client");
+	unlink_if_exists(BACULA_STARTUP_SCRIPT);
 
-	// 2. Re-run sshd config generation script
-	exec(BACULA_STARTUP_SCRIPT . " stop");
 	conf_mount_ro();
 }
 
 function baculaclient_custom_php_write_config(){
-	global $g, $config;
+	global $config, $LocalDirector;
 	conf_mount_rw();
-	//check config_file
-	$startup_file=BACULA_LOCALBASE . "/etc/rc.d/bacula-fd";
-	if (file_exists($startup_file)){
-		$startup_script=file_get_contents($startup_file);
-		$startup_script=preg_replace("/NO/","YES",$startup_script);
-		$startup_script=preg_replace("@/usr/local/etc/bacula-fd.conf@",BACULA_LOCALBASE."/etc/bacula/bacula-fd.conf",$startup_script);
-		$startup_script=preg_replace("@/usr/local/etc/bacula/bacula-fd.conf@",BACULA_LOCALBASE."/etc/bacula/bacula-fd.conf",$startup_script);
-		file_put_contents(BACULA_STARTUP_SCRIPT,$startup_script,LOCK_EX);
-		// Ensure bacula-fd has a+rx
-		exec("chmod a+rx " . BACULA_STARTUP_SCRIPT);
-		}
 
-	//check config
-	if (is_array($config['installedpackages']['baculaclient']['config'])){
+	// Check config_file
+	$startup_file = BACULA_LOCALBASE . "/etc/rc.d/bacula-fd";
+	if (file_exists($startup_file)) {
+		$startup_script = file_get_contents($startup_file);
+		$startup_script = preg_replace("/NO/","YES", $startup_script);
+		$startup_script = preg_replace("@/usr/local/etc/bacula-fd.conf@", BACULA_LOCALBASE . "/etc/bacula/bacula-fd.conf", $startup_script);
+		$startup_script = preg_replace("@/usr/local/etc/bacula/bacula-fd.conf@", BACULA_LOCALBASE . "/etc/bacula/bacula-fd.conf", $startup_script);
+		file_put_contents(BACULA_STARTUP_SCRIPT, $startup_script, LOCK_EX);
+		// Ensure bacula-fd is executable
+		chmod(BACULA_STARTUP_SCRIPT, 0755);
+	}
+
+	// Check config
+	if (is_array($config['installedpackages']['baculaclient']['config'])) {
 		$baculaclient_conf="";
 		foreach ($config['installedpackages']['baculaclient']['config'] as $bc) {
-			// create Director
-			switch ($bc['type']){
-			case "Director":
-				$baculaclient_conf .= "Director { \n\tName = {$bc['director']}-dir #{$bc['description']}\n\tPassword = \"{$bc['password']}\"\n}\n";
-				Break;
-			case "Monitor":
-				$baculaclient_conf .= "Director { \n\tName = {$bc['director']}-mon #{$bc['description']}\n\tPassword = \"{$bc['password']}\"\n\tMonitor = yes\n}\n";
-				break;
-			case "Local":
-				$baculaclient_conf .= "Director { \n\tName = {$bc['director']}-dir #{$bc['description']}\n\tPassword = \"{$bc['password']}\"\n}\n";
-				$baculaclient_conf .= "Director { \n\tName = {$bc['director']}-mon #{$bc['description']}\n\tPassword = \"{$bc['password']}\"\n\tMonitor = yes\n}\n";
-				$LocalDirector = $bc['director'];
-				}
-
+			// Create Director
+			switch ($bc['type']) {
+				case "Director":
+					$baculaclient_conf .= "Director { \n\tName = {$bc['director']}-dir #{$bc['description']}\n\tPassword = \"{$bc['password']}\"\n}\n";
+					break;
+				case "Monitor":
+					$baculaclient_conf .= "Director { \n\tName = {$bc['director']}-mon #{$bc['description']}\n\tPassword = \"{$bc['password']}\"\n\tMonitor = yes\n}\n";
+					break;
+				case "Local":
+					$baculaclient_conf .= "Director { \n\tName = {$bc['director']}-dir #{$bc['description']}\n\tPassword = \"{$bc['password']}\"\n}\n";
+					$baculaclient_conf .= "Director { \n\tName = {$bc['director']}-mon #{$bc['description']}\n\tPassword = \"{$bc['password']}\"\n\tMonitor = yes\n}\n";
+					$LocalDirector = $bc['director'];
 			}
 
-		// create Messages
+		}
+
+		// Create Messages
 		if (!empty($LocalDirector)) {
 			$baculaclient_conf .= "Messages { \n\tName = Standard \n\tdirector  = {$LocalDirector}-dir = all, !skipped, !restored\n}\n";
 		}
-		// create FielDaemon
-
-		if (is_array($config['installedpackages']['baculaclientfd']['config'])){
-			$port = $config['installedpackages']['baculaclientfd']['config'][0]['port'];
-			$jobs = $config['installedpackages']['baculaclientfd']['config'][0]['jobs'];
-			}
-		else{
-			$port="9102";
-			$jobs="20";
-			}
+		// Create FileDaemon
+		if (is_array($config['installedpackages']['baculaclientfd']['config'])) {
+			$port = $config['installedpackages']['baculaclientfd']['config'][0]['port'] ?: '9102';
+			$jobs = $config['installedpackages']['baculaclientfd']['config'][0]['jobs'] ?: '20';
+		}
 		if (!empty($LocalDirector)) {
 			$baculaclient_conf .= "FileDaemon { \n\tName = {$LocalDirector}-fd #\n\tFDport = {$port}\n\tWorkingDirectory = /var/db/bacula\n\tPid Directory = /var/run\n\tMaximum Concurrent Jobs = {$jobs}\n}\n";
 		}
 
-		file_put_contents(BACULA_LOCALBASE."/etc/bacula/bacula-fd.conf",$baculaclient_conf,LOCK_EX);
-		exec(BACULA_STARTUP_SCRIPT . " restart");
-		// Mount Read-only
-		conf_mount_ro();
+		// Write config file and start service
+		file_put_contents(BACULA_LOCALBASE . "/etc/bacula/bacula-fd.conf", $baculaclient_conf, LOCK_EX);
+		if (!empty($LocalDirector)) {
+			restart_service("bacula-client");
+		} else {
+			log_error("[bacula-client] You need at least one local Director in order to run bacula-client.");
 		}
-	}
 
-	?>
+		conf_mount_ro();
+	}
+}
+?>

--- a/config/bacula-client/bacula-client.xml
+++ b/config/bacula-client/bacula-client.xml
@@ -1,81 +1,77 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-<copyright>
-        <![CDATA[
+	<copyright>
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    bacula-client.xml
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) Marcio Carlos Braga Antao
-    Copyright (C) 2012 Marcello Coutinho
-    All rights reserved.
-
-    Based on m0n0wall (http://m0n0.ch/wall)
-    Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
+	bacula-client.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) Marcio Carlos Braga Antao
+	Copyright (C) 2012 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
-        </copyright>
-    <description>Client Install for Bacula 5.2.6 Backup</description>
-    <requirements>Bacula Server Installed in or network</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
+	<requirements>Bacula Server Installed on your network.</requirements>
 	<name>baculaclient</name>
-	<version>5.2.6</version>
-	<title>Bacula-Client: Setting</title>
-    <aftersaveredirect>/pkg.php?xml=bacula-client.xml</aftersaveredirect>
+	<version>1.0.8</version>
+	<title>Bacula Client: Settings</title>
+	<aftersaveredirect>/pkg.php?xml=bacula-client.xml</aftersaveredirect>
 	<include_file>/usr/local/pkg/bacula-client.inc</include_file>
 	<configpath>installedpackages->package->baculaclient</configpath>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 		<item>https://packages.pfsense.org/packages/config/bacula-client/bacula-client.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 		<item>https://packages.pfsense.org/packages/config/bacula-client/bacula-client_fd.xml</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>0755</chmod>
 		<item>https://packages.pfsense.org/packages/config/bacula-client/bacula-client_view_config.php</item>
 	</additional_files_needed>
 	<menu>
-		<name>Bacula-client</name>
-		<tooltiptext>bacula backup client</tooltiptext>
+		<name>Bacula Client</name>
+		<tooltiptext>Bacula Backup Client</tooltiptext>
 		<section>Services</section>
 		<configfile>bacula-client.xml</configfile>
 	</menu>
 	<service>
 		<rcfile>bacula-fd.sh</rcfile>
-		<name>Bacula-client</name>
+		<name>bacula-client</name>
 		<executable>bacula-fd</executable>
-		<description>bacula backup client</description>
+		<description>Bacula Backup Client</description>
 	</service>
 	<tabs>
 		<tab>
@@ -104,20 +100,20 @@
 		<columnitem>
 			<fielddescr>Description</fielddescr>
 			<fieldname>description</fieldname>
-		</columnitem>	
+		</columnitem>
 	</adddeleteeditpagefields>
 	<fields>
 		<field>
 			<type>listtopic</type>
 			<fieldname>directors</fieldname>
 			<name>Directors</name>
-		</field>	
+		</field>
 		<field>
 			<fielddescr>Director Name</fielddescr>
 			<fieldname>director</fieldname>
 			<type>input</type>
 			<size>60</size>
-			<description>Name of director</description>
+			<description>Enter name for the Director.</description>
 			<required/>
 		</field>
 		<field>
@@ -132,7 +128,7 @@
 			<fieldname>password</fieldname>
 			<type>password</type>
 			<size>30</size>
-			<description><![CDATA[Enter password for Director use to Access.]]></description>
+			<description>Enter password used for Director access.</description>
 		</field>
 		<field>
 			<fielddescr>Director type</fielddescr>
@@ -143,20 +139,17 @@
 					<option><name>Local</name><value>Local</value></option>
 					<option><name>Monitor</name><value>Monitor</value></option>
 				</options>
-			<description>Director Type. You need at least one local director.</description>
+			<description>
+				<![CDATA[
+				Select director type.<br />
+				<strong>NOTE: You need at least one local Director.</strong>
+				]]>
+			</description>
 		</field>
 	</fields>
 	<custom_php_install_command>
 		baculaclient_custom_php_install_command();
 	</custom_php_install_command>
-	<custom_php_command_before_form>
-	</custom_php_command_before_form>
-	<custom_php_validation_command>
-	</custom_php_validation_command>
-	<custom_delete_php_command>
-	</custom_delete_php_command>	
-	<custom_add_php_command>
-	</custom_add_php_command>	
 	<custom_php_resync_config_command>
 		baculaclient_custom_php_write_config();
 	</custom_php_resync_config_command>

--- a/config/bacula-client/bacula-client_fd.xml
+++ b/config/bacula-client/bacula-client_fd.xml
@@ -1,53 +1,52 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-    <copyright>
-        <![CDATA[
+	<copyright>
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    bacula-client_df.xml
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2012 Marcio Carlos Braga Antao
-    Copyright (C) 2012 Marcello Coutinho
-    All rights reserved.
-
-    Based on m0n0wall (http://m0n0.ch/wall)
-    Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
+	bacula-client.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) Marcio Carlos Braga Antao
+	Copyright (C) 2012 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
-        </copyright>
-    <description>Client Install for Bacula 5.2.6 Backup</description>
-    <requirements>Bacula Server Installed in or network</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
+	<requirements>Bacula Server Installed on your network.</requirements>
 	<name>baculaclientfd</name>
-	<version>5.2.6</version>
-	<title>Bacula-Client: FileDaemon Setting</title>
-    <aftersaveredirect>/pkg_edit.php?xml=bacula-client_fd.xml</aftersaveredirect>
+	<version>1.0.8</version>
+	<title>Bacula Client: FileDaemon Settings</title>
+	<aftersaveredirect>/pkg_edit.php?xml=bacula-client_fd.xml</aftersaveredirect>
 	<include_file>/usr/local/pkg/bacula-client.inc</include_file>
 	<configpath>installedpackages->package->baculaclient</configpath>
 	<tabs>
@@ -76,7 +75,7 @@
 			<fieldname>port</fieldname>
 			<type>input</type>
 			<size>4</size>
-			<description>Port for a File Daemon. Default : 9102 </description>
+			<description>Port for a File Daemon. (Default: 9102)</description>
 			<required/>
 		</field>
 		<field>
@@ -85,23 +84,14 @@
 			<type>input</type>
 			<size>3</size>
 			<required/>
-			<description>Maximum Concurrent Jobs. Default : 20</description>
+			<description>Maximum Concurrent Jobs. (Default: 20)</description>
 		</field>
 
 	</fields>
-	
 	<custom_php_install_command>
 		baculaclient_custom_php_install_command();
 	</custom_php_install_command>
-	<custom_php_command_before_form>
-	</custom_php_command_before_form>
-	<custom_php_validation_command>
-	</custom_php_validation_command>
-	<custom_delete_php_command>
-	</custom_delete_php_command>	
-	<custom_add_php_command>
-	</custom_add_php_command>	
 	<custom_php_resync_config_command>
-			baculaclient_custom_php_write_config();
+		baculaclient_custom_php_write_config();
 	</custom_php_resync_config_command>
 </packagegui>

--- a/config/bacula-client/bacula-client_view_config.php
+++ b/config/bacula-client/bacula-client_view_config.php
@@ -1,9 +1,9 @@
 <?php
 /*
 	bacula-client_view_config.php
-	part of pfSense (https://www.pfsense.org/)
-	Copyright (C) 2010 Scott Ullrich <sullrich@gmail.com>
-	Copyright (C) 2012 M�rcio Carlos Ant�o
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Marcio Carlos Braga Antao
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -27,33 +27,26 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require("guiconfig.inc");
 
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version < 2.0)
-	$one_two = true;
-
-if ($pf_version > 2.0)
+$$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+if ($pf_version == "2.1" || $pf_version == "2.2") {
 	define('BACULA_LOCALBASE', '/usr/pbi/bacula-' . php_uname("m"));
-else
+} else {
 	define('BACULA_LOCALBASE','/usr/local');
+}
 
 $pgtitle = "Bacula-Client: View Configuration";
 include("head.inc");
 
 ?>
+
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 <?php include("fbegin.inc"); ?>
-
-<?php if($one_two): ?>
-<p class="pgtitle"><?=$pgtitle?></font></p>
-<?php endif; ?>
 
 <?php if ($savemsg) print_info_box($savemsg); ?>
 
 <form action="bacula-client_view_config.php" method="post">
-	
 <div id="mainlevel">
 	<table width="100%" border="0" cellpadding="0" cellspacing="0">
 		<tr><td>
@@ -65,27 +58,24 @@ include("head.inc");
 	display_top_tabs($tab_array);
 ?>
 		</td></tr>
- 		<tr>
-    		<td>
-				<div id="mainarea">
-					<table class="tabcont" width="100%" border="0" cellpadding="0" cellspacing="0">
-						<tr>
-     						<td class="tabcont" >
-									<textarea id="varnishlogs" rows="50" cols="87%">
-<?php 
-	$config_file = file_get_contents(BACULA_LOCALBASE."/etc/bacula/bacula-fd.conf");
-	echo $config_file;
-?>
-									</textarea>
-							</td>
-						</tr>
-					</table>
-				</div>
-			</td>
-		</tr>
+ 		<tr><td>
+			<div id="mainarea">
+				<table class="tabcont" width="100%" border="0" cellpadding="0" cellspacing="0">
+					<tr><td class="tabcont">
+						<textarea id="varnishlogs" rows="50" cols="87%">
+						<?php
+						$config_file = file_get_contents(BACULA_LOCALBASE."/etc/bacula/bacula-fd.conf");
+						echo $config_file;
+						?>
+						</textarea>
+					</td></tr>
+				</table>
+			</div>
+		</td></tr>
 	</table>
 </div>
 </form>
+
 <?php include("fend.inc"); ?>
 </body>
 </html>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1397,7 +1397,7 @@
 		<descr>Bacula is a set of Open Source computer programs that permit managings backups, recovery, and verification of computer data across a network of computers of different kinds.</descr>
 		<website>http://www.bacula.org/</website>
 		<category>Services</category>
-		<version>7.0.5 pkg v 1.0.7</version>
+		<version>1.0.8</version>
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/bacula-client/bacula-client.xml</config_file>


### PR DESCRIPTION
bacula-client.xml, bacula-client_fd.xml
- Fix copyright header and indentation
- Fix permissions
- Remove unused tags
- Sanitize version
- Improve some descriptions

bacula-client.inc
- Fix copyright header and indentation
- Fix pfSense version checks
- Code style and indentation fixes
- Remove unused global vars declaration
- Use stop_service() and restart_service()
- Make sure that at least one local Director is configured before trying to start the service, otherwise it fails (see e.g. https://forum.pfsense.org/index.php?topic=97934.0)

bacula-client_view_config.php
- Fix copyright header
- Fix pfSense version checks
- Nuke obsolete pfSense 1.2.x junk
- Code style and indentation
