### PR TITLE
Snort 2.9.7.5 pkg v3.2.7

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -292,7 +292,8 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
                 if (empty($list))
                         return $list;
 		$localnet = $list['localnets'];
-		$wanip = $list['wanips'];
+//		$wanip = $list['wanips'];
+		$wanip = 'yes';
 		$wangw = $list['wangateips'];
 		$wandns = $list['wandnsips'];
 		$vips = $list['vips'];

--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -471,7 +471,7 @@ function snort_build_list($snortcfg, $listname = "", $whitelist = false, $extern
 		/* iterate all vips and add to whitelist */
 		if (is_array($config['virtualip']) && is_array($config['virtualip']['vip'])) {
 			foreach($config['virtualip']['vip'] as $vip) {
-				if ($vip['subnet'] && $vip['mode'] != 'proxyarp') {
+				if ($vip['subnet']) {
 					if (!in_array("{$vip['subnet']}/{$vip['subnet_bits']}", $home_net))
 						$home_net[] = "{$vip['subnet']}/{$vip['subnet_bits']}";
 				}

--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -45,11 +45,6 @@ ini_set("memory_limit", "384M");
 // Explicitly declare this as global so it works through function call includes 
 global $g, $config, $rebuild_rules;
 
-// Grab the Snort binary version programmatically, but if that fails use a safe default
-$snortver = array();
-$snortbindir = SNORT_PBI_BINDIR;
-exec("{$snortbindir}snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-26", $snortver);
-
 /* Rebuild Rules Flag -- if "true", rebuild enforcing rules and flowbit-rules files */
 $rebuild_rules = false;
 

--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -3455,7 +3455,7 @@ function snort_prepare_rule_files($snortcfg, $snortcfgdir) {
 
 	/* Build a new sid-msg.map file from the enabled */
 	/* rules and copy it to the interface directory. */
-	log_error(gettext("[Snort] Building new sig-msg.map file for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . "..."));
+	log_error(gettext("[Snort] Building new sid-msg.map file for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . "..."));
 	snort_build_sid_msg_map("{$snortcfgdir}/rules/", "{$snortcfgdir}/sid-msg.map");
 }
 

--- a/config/snort/snort.xml
+++ b/config/snort/snort.xml
@@ -45,7 +45,7 @@
 	</copyright>
 	<description>Snort IDS/IPS Package</description>
 	<name>Snort</name>
-	<version>3.2.6</version>
+	<version>3.2.7</version>
 	<title>Services: Snort IDS</title>
 	<include_file>/usr/local/pkg/snort/snort.inc</include_file>
 	<menu>

--- a/config/snort/snort_check_for_rule_updates.php
+++ b/config/snort/snort_check_for_rule_updates.php
@@ -64,19 +64,14 @@ $openappid_detectors = $config['installedpackages']['snortglobal']['openappid_de
 /* Working directory for downloaded rules tarballs and extraction */
 $tmpfname = "{$g['tmp_path']}/snort_rules_up";
 
-/* Grab the Snort binary version programmatically and use it to construct */
-/* the proper Snort VRT rules tarball and md5 filenames. Fallback to a    */
-/* default in the event we fail.                                          */
-$snortver = array();
-exec("{$snortbindir}snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-26", $snortver);
-// Save the version with decimal delimiters for use in extracting the rules
-$snort_version = $snortver[0];
-if (empty($snort_version))
-	$snort_version = SNORT_BIN_VERSION;
+/* Use the Snort binary version to construct the proper Snort VRT */
+/* rules tarball and md5 filenames. Save the version with decimal */
+/* delimiters for use in extracting the rules.                    */
+$snort_version = SNORT_BIN_VERSION;
 
 // Create a collapsed version string for use in the tarball filename
-$snortver[0] = str_replace(".", "", $snortver[0]);
-$snort_filename = "snortrules-snapshot-{$snortver[0]}.tar.gz";
+$snortver = str_replace(".", "", SNORT_BIN_VERSION);
+$snort_filename = "snortrules-snapshot-{$snortver}.tar.gz";
 $snort_filename_md5 = "{$snort_filename}.md5";
 $snort_rule_url = VRT_DNLD_URL;
 

--- a/config/snort/snort_defs.inc
+++ b/config/snort/snort_defs.inc
@@ -49,13 +49,12 @@ if (!defined("SNORTLOGDIR"))
 	define("SNORTLOGDIR", "{$g['varlog_path']}/snort");
 if (!defined("SNORT_BIN_VERSION")) {
 	// Grab the Snort binary version programmatically
-	$snortver = array();
 	$snortbindir = SNORT_PBI_BINDIR;
 	$snortver = exec_command("{$snortbindir}/snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-26");
 	if (!empty($snortver))
 		define("SNORT_BIN_VERSION", $snortver);
 	else
-		define("SNORT_BIN_VERSION", "");
+		define("SNORT_BIN_VERSION", "2.9.7.5");
 }
 if (!defined("SNORT_SID_MODS_PATH"))
 	define('SNORT_SID_MODS_PATH', "{$g['vardb_path']}/snort/sidmods/");

--- a/config/snort/snort_defs.inc
+++ b/config/snort/snort_defs.inc
@@ -51,11 +51,11 @@ if (!defined("SNORT_BIN_VERSION")) {
 	// Grab the Snort binary version programmatically
 	$snortver = array();
 	$snortbindir = SNORT_PBI_BINDIR;
-	mwexec("{$snortbindir}/snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-26", $snortver);
-	if (!empty($snortver[0]))
-		define("SNORT_BIN_VERSION", $snortver[0]);
+	$snortver = exec_command("{$snortbindir}/snort -V 2>&1 |/usr/bin/grep Version | /usr/bin/cut -c20-26");
+	if (!empty($snortver))
+		define("SNORT_BIN_VERSION", $snortver);
 	else
-		define("SNORT_BIN_VERSION", "2.9.7.3");
+		define("SNORT_BIN_VERSION", "");
 }
 if (!defined("SNORT_SID_MODS_PATH"))
 	define('SNORT_SID_MODS_PATH', "{$g['vardb_path']}/snort/sidmods/");

--- a/config/snort/snort_migrate_config.php
+++ b/config/snort/snort_migrate_config.php
@@ -541,10 +541,10 @@ unset($r);
 
 // Log a message if we changed anything
 if ($updated_cfg) {
-	$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.2.6";
 	log_error("[Snort] Settings successfully migrated to new configuration format...");
 }
-else
+else {
 	log_error("[Snort] Configuration version is current...");
+}
 
 ?>

--- a/config/snort/snort_passlist.php
+++ b/config/snort/snort_passlist.php
@@ -197,7 +197,8 @@ if ($savemsg) {
 	<p><?php echo gettext("1. Here you can create Pass List files for your Snort package rules.  Hosts on a Pass List are never blocked by Snort."); ?><br/>
 	<?php echo gettext("2. Add all the IP addresses or networks (in CIDR notation) you want to protect against Snort block decisions."); ?><br/>
 	<?php echo gettext("3. The default Pass List includes the WAN IP and gateway, defined DNS servers, VPNs and locally-attached networks."); ?><br/>
-	<?php echo gettext("4. Be careful, it is very easy to get locked out of your system by altering the default settings."); ?></p></span></td>
+	<?php echo gettext("4. Be careful, it is very easy to get locked out of your system by altering the default settings."); ?><br/>
+	<?php echo gettext("5. To use a custom Pass List on an interface, you must manually assign the list using the drop-down control on the Interface Settings tab."); ?></p></span></td>
 	</tr>
 	<tr>
 	<td width="100%"><span class="vexpl"><?php echo gettext("Remember you must restart Snort on the interface for changes to take effect!"); ?></span></td>

--- a/config/snort/snort_passlist_edit.php
+++ b/config/snort/snort_passlist_edit.php
@@ -3,7 +3,7 @@
  * snort_passlist_edit.php
  * Copyright (C) 2004 Scott Ullrich
  * Copyright (C) 2011-2012 Ermal Luci
- * Copyright (C) 2014 Bill Meeks
+ * Copyright (C) 2015 Bill Meeks
  * All rights reserved.
  *
  * originially part of m0n0wall (http://m0n0.ch/wall)
@@ -71,7 +71,7 @@ if (isset($id) && isset($a_passlist[$id])) {
 	$pconfig['address'] = $a_passlist[$id]['address'];
 	$pconfig['descr'] = html_entity_decode($a_passlist[$id]['descr']);
 	$pconfig['localnets'] = $a_passlist[$id]['localnets'];
-	$pconfig['wanips'] = $a_passlist[$id]['wanips'];
+//	$pconfig['wanips'] = $a_passlist[$id]['wanips'];
 	$pconfig['wangateips'] = $a_passlist[$id]['wangateips'];
 	$pconfig['wandnsips'] = $a_passlist[$id]['wandnsips'];
 	$pconfig['vips'] = $a_passlist[$id]['vips'];
@@ -87,7 +87,7 @@ if ($_GET['act'] == "import") {
 	$pconfig['address'] = htmlspecialchars($_GET['address']);
 	$pconfig['descr'] = htmlspecialchars($_GET['descr']);
 	$pconfig['localnets'] = htmlspecialchars($_GET['localnets'])? 'yes' : 'no';
-	$pconfig['wanips'] = htmlspecialchars($_GET['wanips'])? 'yes' : 'no';
+//	$pconfig['wanips'] = htmlspecialchars($_GET['wanips'])? 'yes' : 'no';
 	$pconfig['wangateips'] = htmlspecialchars($_GET['wangateips'])? 'yes' : 'no';
 	$pconfig['wandnsips'] = htmlspecialchars($_GET['wandnsips'])? 'yes' : 'no';
 	$pconfig['vips'] = htmlspecialchars($_GET['vips'])? 'yes' : 'no';
@@ -168,7 +168,7 @@ if ($_POST['save']) {
 		$p_list['name'] = $_POST['name'];
 		$p_list['uuid'] = $passlist_uuid;
 		$p_list['localnets'] = $_POST['localnets']? 'yes' : 'no';
-		$p_list['wanips'] = $_POST['wanips']? 'yes' : 'no';
+//		$p_list['wanips'] = $_POST['wanips']? 'yes' : 'no';
 		$p_list['wangateips'] = $_POST['wangateips']? 'yes' : 'no';
 		$p_list['wandnsips'] = $_POST['wandnsips']? 'yes' : 'no';
 		$p_list['vips'] = $_POST['vips']? 'yes' : 'no';
@@ -255,21 +255,12 @@ if ($savemsg)
 	<tr>
 		<td colspan="2" valign="top" class="listtopic"><?php echo gettext("Add auto-generated IP Addresses."); ?></td>
 	</tr>
-
 	<tr>
 		<td width="22%" valign="top" class="vncell"><?php echo gettext("Local Networks"); ?></td>
 		<td width="78%" class="vtable"><input name="localnets" type="checkbox"
 			id="localnets" size="40" value="yes"
 			<?php if($pconfig['localnets'] == 'yes'){ echo "checked";} if($pconfig['localnets'] == ''){ echo "checked";} ?> />
 		<span class="vexpl"> <?php echo gettext("Add firewall Local Networks to the list (excluding WAN)."); ?> </span></td>
-	</tr>
-
-	<tr>
-		<td width="22%" valign="top" class="vncell"><?php echo gettext("WAN IPs"); ?></td>
-		<td width="78%" class="vtable"><input name="wanips" type="checkbox"
-			id="wanips" size="40" value="yes"
-			<?php if($pconfig['wanips'] == 'yes'){ echo "checked";} if($pconfig['wanips'] == ''){ echo "checked";} ?> />
-		<span class="vexpl"> <?php echo gettext("Add WAN interface IPs to the list."); ?> </span></td>
 	</tr>
 	<tr>
 		<td width="22%" valign="top" class="vncell"><?php echo gettext("WAN Gateways"); ?></td>

--- a/config/snort/snort_post_install.php
+++ b/config/snort/snort_post_install.php
@@ -265,8 +265,8 @@ if (stristr($config['widgets']['sequence'], "snort_alerts-container") === FALSE)
 	$config['widgets']['sequence'] .= ",{$snort_widget_container}";
 
 /* Update Snort package version in configuration */
-$config['installedpackages']['snortglobal']['snort_config_ver'] = "3.2.6";
-write_config("Snort pkg v3.2.6: post-install configuration saved.");
+$config['installedpackages']['snortglobal']['snort_config_ver'] = $config['installedpackages']['package'][get_pkg_id("snort")]['version'];
+write_config("Snort pkg v{$config['installedpackages']['package'][get_pkg_id("snort")]['version']}: post-install configuration saved.");
 
 /* Done with post-install, so clear flag */
 unset($g['snort_postinstall']);

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -388,14 +388,14 @@
 		<category>Security</category>
 		<run_depends>bin/snort:security/snort</run_depends>
 		<port_category>security</port_category>
-		<depends_on_package_pbi>snort-2.9.7.3-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>snort-2.9.7.5-##ARCH##.pbi</depends_on_package_pbi>
 		<build_pbi>
 			<port>security/snort</port>
 			<ports_after>security/barnyard2</ports_after>
 		</build_pbi>
 		<build_options>barnyard2_UNSET_FORCE=ODBC PGSQL PRELUDE;barnyard2_SET_FORCE=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET_FORCE=BARNYARD PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;snort_UNSET_FORCE=PULLEDPORK FILEINSPECT HA</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>3.2.6</version>
+		<version>3.2.7</version>
 		<required_version>2.2</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>


### PR DESCRIPTION
Snort 2.9.7.5 pkg v3.2.7
==================
This updates the Snort binary to version 2.9.7.5 and the GUI package to version 3.2.7.  One new feature is introduced and three reported bugs are fixed in this release.

New Features
------------------
1.  The custom blocking Snort output plugin now includes code to monitor all of the firewall interfaces and automatically add the interface IP addresses to an internal Pass List so that firewall interface IPs themselves are never blocked.  This is most helpful for users with a frequently updating dynamic WAN IP address.  The blocking module will now be immediately notified of the updated WAN IP address and will add it to an internal automatic Pass List and remove the old IP from the same list.  This should prevent inadvertent blocking of the WAN IP following an update via DHCP or other means from the upstream ISP.  Similarly, other firewall interface IPs will be protected from inadvertent blocking.  When an IP change is detected by Snort, a message will logged to the firewall system log.

Bug Fixes
-------------
1.  Proxy ARP virtual IPs are not included in default HOME_NET variable and PASS LIST.

2.  Add reminder to PASS LIST screen to assign any custom-generated lists to an interface.

3.  Dynamic IPs on firewall interfaces sometimes blocked after being updated. (see new feature for further details).
