### PR TITLE
bandwidthd - code style and major improvements

### DIFF
--- a/config/bandwidthd/bandwidthd.inc
+++ b/config/bandwidthd/bandwidthd.inc
@@ -1,9 +1,11 @@
 <?php
-/* $Id$ */
 /*
 	bandwidthd.inc
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2006 Scott Ullrich
-	part of pfSense
+	Copyright (C) 2009 Bill Marquette
+	Copyright (C) 2012-2013 Phil Davis
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -27,181 +29,92 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
-// Check pfSense version
-$pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
+$pfs_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
 switch ($pfs_version) {
-  case "2.1":
-    define('PKG_BANDWIDTHD_BASE', '/usr/pbi/bandwidthd-' . php_uname("m") . '/bandwidthd');
-    define('PKG_BANDWIDTHD_RUNTIME_LIBRARY_ENV', '');
-    break;
-  case "2.2":
-    define('PKG_BANDWIDTHD_BASE', '/usr/pbi/bandwidthd-' . php_uname("m") . '/local/bandwidthd');
-    define('PKG_BANDWIDTHD_RUNTIME_LIBRARY_ENV', 'LD_LIBRARY_PATH=/usr/pbi/bandwidthd-' . php_uname("m") . '/local/lib');
-    break;
-  default:
-    define('PKG_BANDWIDTHD_BASE', '/usr/local/bandwidthd');
-    define('PKG_BANDWIDTHD_RUNTIME_LIBRARY_ENV', '');
- }
-// End: Check pfSense version
-
-function is_blank($value) {
-    return empty($value) && !is_numeric($value);
+	case "2.1":
+		define('PKG_BANDWIDTHD_BASE', '/usr/pbi/bandwidthd-' . php_uname("m") . '/bandwidthd');
+		define('PKG_BANDWIDTHD_RUNTIME_LIBRARY_ENV', '');
+		break;
+	case "2.2":
+		define('PKG_BANDWIDTHD_BASE', '/usr/pbi/bandwidthd-' . php_uname("m") . '/local/bandwidthd');
+		define('PKG_BANDWIDTHD_RUNTIME_LIBRARY_ENV', 'LD_LIBRARY_PATH=/usr/pbi/bandwidthd-' . php_uname("m") . '/local/lib');
+		break;
+	default:
+		define('PKG_BANDWIDTHD_BASE', '/usr/local/bandwidthd');
+		define('PKG_BANDWIDTHD_RUNTIME_LIBRARY_ENV', '');
 }
 
 function bandwidthd_install_deinstall() {
 	conf_mount_rw();
-	exec("rm -f /usr/local/etc/rc.d/bandwidthd*");
-	exec("rm -rf " . PKG_BANDWIDTHD_BASE . "/htdocs");
-	exec("rm -f /usr/local/www/bandwidthd");
+	stop_service("bandwidthd");
+	mwexec("/bin/rm -rf " . PKG_BANDWIDTHD_BASE . "/htdocs");
+	mwexec("/bin/rm -f /usr/local/www/bandwidthd");
 	// Remove the cron job, if it is there
 	install_cron_job("/bin/kill -HUP `cat /var/run/bandwidthd.pid`", false);
 	conf_mount_ro();
 }
 
 function bandwidthd_install_config() {
-	global $config, $g;
+	global $config, $g, $bandwidthd_config;
+	conf_mount_rw();
 
 	/* bandwidthd doesn't have a way to pass a custom config path, unfortunately */
-	/* the conf file must be ./etc/bandwidthd.conf relative to the current dir */
+	/* So, the .conf file must be ./etc/bandwidthd.conf relative to the current dir */
 	$bandwidthd_base_dir = PKG_BANDWIDTHD_BASE;
 	$bandwidthd_config_dir = PKG_BANDWIDTHD_BASE . "/etc";
 	$bandwidthd_runtime_library_env = PKG_BANDWIDTHD_RUNTIME_LIBRARY_ENV;
 
-	conf_mount_rw();
-
-	/* user defined values */
+	/* General Options */
 	$bandwidthd_config = $config['installedpackages']['bandwidthd']['config'][0];
-	$meta_refresh = $bandwidthd_config['meta_refresh'];
-	if (is_numeric($meta_refresh))
-		$meta_refresh = "meta_refresh $meta_refresh\n";
-	else
-		$meta_refresh = "";
-
-	$graph = $bandwidthd_config['drawgraphs'];
-	if ($graph)
-		$graph = "graph true\n";
-	else
-		$graph = "graph false\n";
-
-	$filter_text = $bandwidthd_config['filter'];
-	if (!is_blank($filter_text))
-		$filter_text = "filter $filter_text\n";
-	else
-		$filter_text = "";
-
-	$recover_cdf = $bandwidthd_config['recovercdf'];
-	if ($recover_cdf)
-		$recover_cdf = "recover_cdf true\n";
-	else
-		$recover_cdf = "";
-
-	$output_cdf = $bandwidthd_config['outputcdf'];
-	if ($output_cdf)
-		$output_cdf_string = "output_cdf true\n";
-	else
-		$output_cdf_string = "";
-
-	$output_postgresql = $bandwidthd_config['outputpostgresql'];
-	$postgresql_host = $bandwidthd_config['postgresqlhost'];
-	$postgresql_database = $bandwidthd_config['postgresqldatabase'];
-	$postgresql_username = $bandwidthd_config['postgresqlusername'];
-	$postgresql_password = $bandwidthd_config['postgresqlpassword'];
-	$postgresql_string = "";
-	if ($output_postgresql) {
-		if (!is_blank($postgresql_host) && !is_blank($postgresql_username) && !is_blank($postgresql_database) && !is_blank($postgresql_password))
-			$postgresql_string = "pgsql_connect_string \"user = $postgresql_username dbname = $postgresql_database password = $postgresql_password host = $postgresql_host\"\n";
-		else
-			log_error("bandwidthd: You have to specify the postgreSQL Host, Database, Username and Password. postgreSQL details have been ignored.");
-	}
-
-	$sensor_id = $bandwidthd_config['sensorid'];
-
-	if (!is_blank($sensor_id))
-		$sensor_id_string = "sensor_id \"$sensor_id\"";
-	else
-		$sensor_id_string = "";
-
-	$promiscuous = $bandwidthd_config['promiscuous'];
-	if ($promiscuous)
-		$promiscuous = "promiscuous true\n";
-	else
-		$promiscuous = "promiscuous false\n";
-
-	$graph_cutoff = $bandwidthd_config['graphcutoff'];
-	if (!is_blank($graph_cutoff))
-		$graph_cutoff = "graph_cutoff $graph_cutoff\n";
-	else
-		$graph_cutoff = "";
-
-	$skip_intervals = $bandwidthd_config['skipintervals'];
-	if ($skip_intervals) {
-		$skip_intervals = "skip_intervals $skip_intervals\n";
-	} else {
-		/* Includes the case where 0 is explicitly specified, which is the default anyway. */
-		$skip_intervals = "";
-	}
-
-	if (!is_blank($bandwidthd_config['active_interface'])){
-		$ifdescrs = array($bandwidthd_config['active_interface']);
-	} else {
-		log_error("You should specify an interface for bandwidthd to listen on. Exiting.");
-	}
-
-	$subnets_custom = explode(';',str_replace(' ','',$bandwidthd_config['subnets_custom']));
-
-	/* initialize to "" */
-	$subnets = "";
-	//$ifdescrs = array("lan", "wan");
-	//for ($j = 1; isset($config['interfaces']['opt' . $j]); $j++) {
-		//$ifdescrs['opt' . $j] = "opt" . $j;
-	//}
-	if (is_array($ifdescrs)) {
-		foreach ($ifdescrs as $int) {
-			/* calculate interface subnet information */
-			$ifcfg = $config['interfaces'][$int];
-			$subnet = gen_subnet($ifcfg['ipaddr'], $ifcfg['subnet']);
-			$subnetmask = gen_subnet_mask($ifcfg['subnet']);
-			$subnet_with_mask = "";
-			if ($subnet == "pppoe") {
-				$subnet = find_interface_ip("ng0");
-				if ($subnet) {
-					$subnet_with_mask = $subnet . "/32";
-				}
-			} else {
-				if ($subnet) {
-					$subnet_with_mask = $subnet . "/" . $ifcfg['subnet'];
-				}
-			}
-			if (!empty($subnet_with_mask)) {
-				/* Only add the subnet if the user has not specified it in the custom subnets. */
-				/* This avoids generating an unnecessary syntax error message from the config. */
-				if (!in_array($subnet_with_mask, $subnets_custom))
-					$subnets .= "subnet {$subnet_with_mask}\n";
-			}
-		}
-	}
-
-	if (is_array($subnets_custom)) {
-		foreach ($subnets_custom as $sub) {
-			if (!empty($sub) && is_subnet($sub))
-				$subnets .= "subnet {$sub}\n";
-		}
-	}
-
-	/* initialize to "" */
+	/* Configure bandwidthd web interface */
 	$dev = "";
-	if (is_array($ifdescrs)) {
-		foreach ($ifdescrs as $ifdescr) {
-			$descr = convert_friendly_interface_to_real_interface_name($ifdescr);
-			$dev .= "dev \"$descr\"\n";
+	$ifdescrs = array($bandwidthd_config['active_interface']);
+	foreach ($ifdescrs as $ifdescr) {
+		$descr = convert_friendly_interface_to_real_interface_name($ifdescr);
+		$dev .= "dev \"{$descr}\"\n";
+	}
+	/* Configure stats interface(s) */
+	$subnets = "";
+	$stats_interfaces = $bandwidthd_config['interface_array'] ?: 'lan';
+	foreach ($stats_interfaces as $iface) {
+		if (is_ipaddr(get_interface_ip($iface))) {
+			$subnets .= "subnet " . gen_subnet(get_interface_ip($iface),get_interface_subnet($iface)) . "/" . get_interface_subnet($iface) . "\n";
 		}
 	}
+	$promiscuous_val = ($bandwidthd_config['promiscuous'] != "" ? "promiscuous true" : "promiscuous false");
+	$sensor_id_string_val = ($bandwidthd_config['sensorid'] != "" ? "sensor_id \"{$bandwidthd_config['sensorid']}\"" : "");
 
+	/* Graphs Options */
+	$graph_val = ($bandwidthd_config['drawgraphs'] != "" ? "graph true" : "graph false");
+	$meta_refresh_val = ($bandwidthd_config['meta_refresh'] != "" ? "meta_refresh {$bandwidthd_config['meta_refresh']}" : "");
+	$skip_intervals_val = ($bandwidthd_config['skipintervals'] != "" ? "skip_intervals {$bandwidthd_config['skipintervals']}" : "");
+	$graph_cutoff_val = ($bandwidthd_config['graphcutoff'] != "" ? "graph_cutoff {$bandwidthd_config['graphcutoff']}" : "");
+	$output_cdf_val = ($bandwidthd_config['outputcdf'] != "" ? "output_cdf true" : "");
+	$recover_cdf_val = ($bandwidthd_config['recovercdf'] != "" ? "recover_cdf true" : "");
+
+	/* PostgreSQL Options */
+	if ($bandwidthd_config['outputpostgresql']) {
+		$postgresql_host = $bandwidthd_config['postgresqlhost'];
+		$postgresql_database = $bandwidthd_config['postgresqldatabase'];
+		$postgresql_username = $bandwidthd_config['postgresqlusername'];
+		$postgresql_password = base64_decode($bandwidthd_config['postgresqlpasswordenc']);
+		$postgresql_string_val = "pgsql_connect_string \"user = $postgresql_username dbname = $postgresql_database password = $postgresql_password host = $postgresql_host\"\n";
+	} else {
+		$postgresql_string_val = "";
+	}
+
+	/* Advanced Filter */
+	if ($bandwidthd_config['advfilter']) {
+		$filter_text_val = "filter " . escapeshellarg(base64_decode($bandwidthd_config['advfilter']));
+	} else {
+		$filter_text_val = "";
+	}
+
+	/* Write out the config file */
 	$config_file = <<<EOF
 #
 # This file was automatically generated by the pfSense
-# package management system.  Changing this file
+# package management system. Changing this file
 # will lead to it being overwritten again when
 # the package manager resyncs.
 #
@@ -211,62 +124,62 @@ function bandwidthd_install_config() {
 # Commented out options are here to provide
 # documentation and represent defaults
 
-# Subnets to collect statistics on.  Traffic that
+# Subnets to collect statistics on. Traffic that
 # matches none of these subnets will be ignored.
 # Syntax is either IP Subnet Mask or CIDR
-$subnets
+{$subnets}
 
 # Device to listen on
 # Bandwidthd listens on the first device it detects
-# by default.  Run "bandwidthd -l" for a list of
+# by default. Run "bandwidthd -l" for a list of
 # devices.
-$dev
+{$dev}
 
 ###################################################
 # Options that don't usually get changed
 
 # An interval is 2.5 minutes, this is how many
 # intervals to skip before doing a graphing run
-$skip_intervals
+{$skip_intervals_val}
 
 # Graph cutoff is how many k must be transferred by an
 # ip before we bother to graph it
-$graph_cutoff
+{$graph_cutoff_val}
 
 #Put interface in promiscuous mode to score to traffic
 #that may not be routing through the host machine.
-$promiscuous
+{$promiscuous_val}
 
 #Log data to cdf file htdocs/log.cdf
-$output_cdf_string
+{$output_cdf_val}
 
 #Read back the cdf file on startup
-$recover_cdf
+{$recover_cdf_val}
 
 # Standard postgres connect string, just like php, see postgres docs for
 # details
-$postgresql_string
+{$postgresql_string_val}
 
 # Arbitrary sensor name, I recommend the sensors fully qualified domain
 # name
-$sensor_id_string
+{$sensor_id_string_val}
 
 #Libpcap format filter string used to control what bandwidthd sees
 #Please always include "ip" in the string to avoid strange problems
-$filter_text
+{$filter_text_val}
 
 #Draw Graphs - This defaults to true to graph the traffic bandwidthd is recording
 #Usually set this to false if you only want cdf output or
-#you are using the database output option.  Bandwidthd will use very little
+#you are using the database output option. Bandwidthd will use very little
 #ram and cpu if this is set to false.
-$graph
+{$graph_val}
 
 #Set META REFRESH seconds (default 150, use 0 to disable).
-$meta_refresh
+{$meta_refresh_val}
 
 EOF;
 
-	$fd = fopen("{$bandwidthd_config_dir}/bandwidthd.conf","w");
+	$fd = fopen("{$bandwidthd_config_dir}/bandwidthd.conf", "w");
 	if (!$fd) {
 		log_error("could not open {$bandwidthd_config_dir}/bandwidthd.conf for writing");
 		exit;
@@ -274,13 +187,12 @@ EOF;
 	fwrite($fd, $config_file);
 	fclose($fd);
 
+	/* nanobsd hacks */
 	if ($g['platform'] == 'nanobsd') {
 		$bandwidthd_nano_dir = "/var/bandwidthd";
 		$bandwidthd_htdocs_dir = $bandwidthd_nano_dir . "/htdocs";
 		if (!is_dir($bandwidthd_nano_dir)) {
-			if (file_exists($bandwidthd_nano_dir)) {
-				unlink($bandwidthd_nano_dir);
-			}
+			unlink_if_exists($bandwidthd_nano_dir);
 			mkdir($bandwidthd_nano_dir);
 		}
 	} else {
@@ -289,24 +201,19 @@ EOF;
 
 	$rc = array();
 	$rc['file'] = 'bandwidthd.sh';
-	$rc['stop'] = <<<EOD
-/usr/bin/killall bandwidthd
-EOD;
+	$rc['stop'] = '/usr/bin/killall bandwidthd';
 
-	// If this is an old config before the enable checkbox was added, then enable by default
-	$bandwidthd_enable = (!isset($bandwidthd_config['enable']) || ($bandwidthd_config['enable']));
-	if ($bandwidthd_enable) {
+	if ($bandwidthd_config['enable']) {
 		if ($g['platform'] == 'nanobsd') {
-			// On nanobsd, /var/bandwidthd is created.
-			// In that is a real /var/bandwidth/htdocs, where the graph data is written
-			// A soft link to the real bandwidth program is made - /var/bandwidthd/bandwidthd
-			// A soft link to the etc folder with the conf file is made - /var/bandwidthd/etc
-			// bandwidthd is started from /var/bandwidthd with the current dir /var/bandwidth
-			// This way, it:
-			//   looks in ./etc for the conf file
-			//   writes graph files in ./htdocs
-			//   writes cdf log files (if selected in the config) to ./
-			// All of this is on the /var filesystem, which is a read-write memory disk on nanobsd
+		/* On nanobsd:
+		* first, /var/bandwidthd is created, with real /var/bandwidth/htdocs inside, where the graph data is written;
+		* soft link to the real bandwidth program is made - /var/bandwidthd/bandwidthd;
+		* soft link to the etc folder with the conf file is made - /var/bandwidthd/etc;
+		* bandwidthd is started from /var/bandwidthd with the current dir /var/bandwidth.
+		* This way, it looks in ./etc for the conf file, writes graph files in ./htdocs
+		* writes cdf log files (if selected in the config) to ./
+		* All of these are on the /var filesystem, which is a read-write memory disk on nanobsd	*/
+
 			$rc['start'] = <<<EOD
 if [ ! -d "{$bandwidthd_nano_dir}" ] ; then
 	if [ -e "{$bandwidthd_nano_dir}" ] ; then
@@ -355,21 +262,17 @@ EOD;
 		$rc['start'] = "return";
 	}
 
-	/* write out rc.d start/stop file */
+	/* Write out rc.d file */
 	write_rcfile($rc);
 
 	if (!is_dir($bandwidthd_htdocs_dir)) {
-		if (file_exists($bandwidthd_htdocs_dir)) {
-			unlink($bandwidthd_htdocs_dir);
-		}
-		mkdir($bandwidthd_htdocs_dir);
+		unlink_if_exists($bandwidthd_htdocs_dir);
+		safe_mkdir($bandwidthd_htdocs_dir);
 	}
+
 	$bandwidthd_www_link = $g["www_path"] . "/bandwidthd";
 	if (!is_link($bandwidthd_www_link)) {
-		if (file_exists($bandwidthd_www_link)) {
-			// It is a file and not a link - clean it up.
-			unlink($bandwidthd_www_link);
-		}
+		unlink_if_exists($bandwidthd_www_link);
 		symlink($bandwidthd_htdocs_dir, $bandwidthd_www_link);
 	}
 
@@ -378,19 +281,136 @@ EOD;
 		exec("echo \"Please start bandwidthd to populate this directory.\" > " . $bandwidthd_index_file);
 	}
 
-	if (($bandwidthd_enable) && ($output_cdf)) {
+	/* Cron job for graphs */
+	if (($bandwidthd_config['enable']) && ($output_cdf)) {
 		// Use cron job to rotate logs every day at 00:01
 		install_cron_job("/bin/kill -HUP `cat /var/run/bandwidthd.pid`", true, "1", "0");
-	}
-	else
-	{
-		// Remove the cron job, if it is there
+	} else {
+		// Remove the cron job if it is there
 		install_cron_job("/bin/kill -HUP `cat /var/run/bandwidthd.pid`", false);
 	}
+
 	conf_mount_ro();
-	stop_service("bandwidthd");
-	if ($bandwidthd_enable) {
-		start_service("bandwidthd");
+	
+	/* Restart the service if enabled; otherwise stop it */
+	if ($bandwidthd_config['enable']) {
+		restart_service("bandwidthd");
+	} else {
+		stop_service("bandwidthd");
+	}
+}
+
+function bandwidthd_upgrade_config() {
+	global $config, $changes;
+	// The 'Advanced Filter' options and 'Database Password' are now base64-encoded
+	// in order to now break config.xml if they contain some special chars.
+	// If this is an old config, pick up the original unencoded values and upgrade
+	$changes = 0;
+	$bandwidthd_config = $config['installedpackages']['bandwidthd']['config'][0];
+	if (isset($bandwidthd_config['filter'])) {
+		$config['installedpackages']['bandwidthd']['config'][0]['advfilter'] = base64_encode($bandwidthd_config['filter']);
+		unset($config['installedpackages']['bandwidthd']['config'][0]['filter']);
+		$changes++;
+	}
+	if (isset($bandwidthd_config['postgresqlpassword'])) {
+		$config['installedpackages']['bandwidthd']['config'][0]['postgresqlpasswordenc'] = base64_encode($bandwidthd_config['postgresqlpassword']);
+		unset($config['installedpackages']['bandwidthd']['config'][0]['postgresqlpassword']);
+		$changes++;
+	}
+	// Subnet(s) for Statistics Collection - convert old subnets_custom to interface_array here as well.
+	if (isset($bandwidthd_config['subnets_custom'])) {
+		$i = 0;
+		$subnets_custom = explode(';', $bandwidthd_config['subnets_custom']);
+		// For each configured interface on this box...
+		$iflist = get_configured_interface_list_by_realif();
+		foreach ($iflist as $if) {
+			// first, gets its subnet...
+			$sn = gen_subnet(get_interface_ip($if), get_interface_subnet($if));
+			foreach ($subnets_custom as $subnet_custom) {
+				// next, strip the subnet mask from the old settings value...
+				$subnet_custom = substr($subnet_custom, 0, strpos($subnet_custom, '/'));
+				// next, try to match the originally configured subnet against configured interfaces...
+				if ($subnet_custom != "" && $subnet_custom == $sn) {
+					// skip PPPoE interfaces if any...
+					$realif = get_real_interface($if);
+					if (!preg_match("/pppoe[0-9]+/i", $realif)) {
+						// and finally, set the new config value for config.xml
+						echo $if;
+						$config['installedpackages']['bandwidthd']['config'][0]['interface_array'][$i] = $if;
+						$i++;
+					}
+				}
+			}
+		}
+		// Remove the old settings value now that we are done with config upgrade
+		unset($config['installedpackages']['bandwidthd']['config'][0]['subnets_custom']);
+	}
+	// Write the upgraded config.xml if something changed
+	write_config("[bandwidthd] Upgraded old package configuration.");
+}
+
+function bandwidthd_validate_input($post, &$input_errors) {
+	if ($post['active_interface']) {
+		$realif = get_real_interface($post['active_interface']);
+		$ip = find_interface_ip($realif);
+		if (!is_ipaddrv4($ip)) {
+			// IPv6-only interfaces are not supported
+			$errif = convert_friendly_interface_to_friendly_descr($post['active_interface']);
+			$input_errors[] = gettext("The \"{$errif}\" interface selected under 'BandwidthD Web Interface' has no IPv4 configured. Configured IPv4 is required.");
+		}
+	} else {
+		$input_errors[] = "You must select the 'BandwidthD Web Interface'.";
+	}
+	// bandwidthd does not work with PPPoE; IPv6 is also not supported
+	if ($post['interface_array']) {
+		foreach ($post['interface_array'] as $ifname) {
+			$realif = get_real_interface($ifname);
+			$ip = find_interface_ip($realif);
+			$errif = convert_friendly_interface_to_friendly_descr($ifname);
+			if (preg_match("/pppoe[0-9]+/i", $realif)) {
+				$input_errors[] = gettext("Sorry, BandwidthD does not support PPPoE interfaces. Remove \"{$errif}\" from 'Subnet(s) for Statistics Collection'.");
+			}
+			if (!is_ipaddrv4($ip)) {
+				$input_errors[] = gettext("The \"{$errif}\" interface selected under 'Subnet(s) for Statistics Collection' has no IPv4 configured. Configured IPv4 is required.");
+			}
+		}
+	} else {
+		$input_errors[] = "You must select at least on interface under 'Subnet(s) for Statistics Collection'.";
+	}
+	// Only support sane characters in Sensor ID
+	if ($post['sensorid']) {
+		if ((!is_hostname($post['sensorid'])) && !preg_match("/^[a-zA-Z0-9\-\=\(\):. ]*$/", $post['sensorid'])) {
+			$input_errors[] .= gettext('Sensor ID must be either a hostname or a string which may only contain characters matching ^[a-zA-Z0-9\-\(\):. ]*$ regexp.');
+		}
+	}
+	if (($post['meta_refresh']) && (!is_numericint($post['meta_refresh']))) {
+		$input_errors[] = gettext("The value for 'Meta Refresh' must be a positive integer.");
+	}
+	if (($post['skipintervals']) && (!is_numericint($post['skipintervals']))) {
+		$input_errors[] = gettext("The value for 'Skip Intervals' must be a positive integer.");
+	}
+	if (($post['graphcutoff']) && (!is_numericint($post['graphcutoff']))) {
+		$input_errors[] = gettext("The value for 'Graph Cutoff' must be a positive integer.");
+	}
+	if ($post['outputpostgresql']) {
+		if (!$post['postgresqlhost']) {
+		$input_errors[] = gettext("The value for 'Database Host' must not be empty when 'Output to PostgreSQL' is enabled.");
+		}
+		if (!$post['postgresqldatabase']) {
+		$input_errors[] = gettext("The value for 'Database Name' must not be empty when 'Output to PostgreSQL' is enabled.");
+		}
+		if (!$post['postgresqlusername']) {
+		$input_errors[] = gettext("The value for 'Database User' must not be empty when 'Output to PostgreSQL' is enabled.");
+		}
+		if (!$post['postgresqlpasswordenc']) {
+		$input_errors[] = gettext("The value for 'Database Password' must not be empty when 'Output to PostgreSQL' is enabled.");
+		}
+	}
+	if (($post['postgresqlhost']) && (!is_hostname($post['postgresqlhost']))) {
+		$input_errors[] = gettext("The value for 'Database Host' must be a valid hostname or IPv4.");
+	}
+	if (($post['advfilter']) && !preg_match("/^[a-zA-Z0-9\+\-\=\(\):. ]*$/", $post['advfilter'])) {
+		$input_errors[] = gettext('Advanced traffic filtering options may only contain characters matching ^[a-zA-Z0-9\+\-\=\(\):. ]*$ regexp.');
 	}
 }
 

--- a/config/bandwidthd/bandwidthd.inc
+++ b/config/bandwidthd/bandwidthd.inc
@@ -335,9 +335,9 @@ function bandwidthd_upgrade_config() {
 					$realif = get_real_interface($if);
 					if (!preg_match("/pppoe[0-9]+/i", $realif)) {
 						// and finally, set the new config value for config.xml
-						echo $if;
 						$config['installedpackages']['bandwidthd']['config'][0]['interface_array'][$i] = $if;
 						$i++;
+						$changes++;
 					}
 				}
 			}
@@ -346,7 +346,9 @@ function bandwidthd_upgrade_config() {
 		unset($config['installedpackages']['bandwidthd']['config'][0]['subnets_custom']);
 	}
 	// Write the upgraded config.xml if something changed
-	write_config("[bandwidthd] Upgraded old package configuration.");
+	if ($changes > 0 ) {
+		write_config("[bandwidthd] Upgraded old package configuration.");
+	}
 }
 
 function bandwidthd_validate_input($post, &$input_errors) {

--- a/config/bandwidthd/bandwidthd.xml
+++ b/config/bandwidthd/bandwidthd.xml
@@ -3,57 +3,61 @@
 <?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-	<![CDATA[
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    bandwidthd.xml
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2007 to whom it may belong
-    All rights reserved.
-
-    Based on m0n0wall (http://m0n0.ch/wall)
-    Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
+	bandwidthd.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2006 Scott Ullrich
+	Copyright (C) 2009 Bill Marquette
+	Copyright (C) 2012-2013 Phil Davis
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
 	]]>
 	</copyright>
-	<description>Describe your package here</description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>bandwidthd</name>
-	<version>2.0.1_5 pkg v.0.4</version>
-	<title>Bandwidthd</title>
+	<version>0.6</version>
+	<title>Diagnostics: Bandwidthd</title>
 	<aftersaveredirect>/pkg_edit.php?xml=bandwidthd.xml&amp;id=0</aftersaveredirect>
 	<include_file>/usr/local/pkg/bandwidthd.inc</include_file>
 	<menu>
 		<name>BandwidthD</name>
 		<tooltiptext></tooltiptext>
-		<section>Services</section>
+		<section>Diagnostics</section>
+		<url>/bandwidthd/index.html</url>
+	</menu>
+	<menu>
+		<name>BandwidthD Settings</name>
+		<tooltiptext></tooltiptext>
+		<section>Diagnostics</section>
 		<url>/pkg_edit.php?xml=bandwidthd.xml&amp;id=0</url>
 	</menu>
 	<service>
@@ -64,152 +68,232 @@
 	</service>
 	<tabs>
 		<tab>
-			<text>BandwidthD</text>
+			<text>Settings</text>
 			<url>/pkg_edit.php?xml=bandwidthd.xml&amp;id=0</url>
 			<active/>
 		</tab>
 		<tab>
 			<text>Access BandwidthD</text>
-			<url>/bandwidthd/index.html" target="_blank</url>
+			<url>/bandwidthd/index.html</url>
 		</tab>
 	</tabs>
+	<advanced_options>enabled</advanced_options>
 	<configpath>installedpackages->package->bandwidthd</configpath>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0677</chmod>
 		<item>https://packages.pfsense.org/packages/config/bandwidthd/bandwidthd.inc</item>
 	</additional_files_needed>
 	<fields>
 		<field>
-			<fielddescr>Enable bandwidthd</fielddescr>
+			<name>General Options</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Enable BandwidthD</fielddescr>
 			<fieldname>enable</fieldname>
 			<type>checkbox</type>
 			<description></description>
 		</field>
 		<field>
-			<fielddescr>Interface</fielddescr>
+			<fielddescr>BandwidthD Web Interface</fielddescr>
 			<fieldname>active_interface</fieldname>
-			<description>The interface that bandwidthd will bind to.</description>
+			<description>Bind the BandwidthD web interface to IP address of the specified interface.</description>
 			<type>interfaces_selection</type>
+			<hideinterfaceregex>(loopback|wan)</hideinterfaceregex>
 			<required/>
 			<default_value>lan</default_value>
 		</field>
 		<field>
-			<fielddescr>Subnet</fielddescr>
-			<fieldname>subnets_custom</fieldname>
-			<description>The subnet(s) on which bandwidthd will report. (separate with ';' for multiple subnets, e.g. 192.168.1.0/24;10.0.0.0/24) The ordinary subnet for the selected interface/s is automatically put in the config, do not specify it here.</description>
-			<type>input</type>
-		</field>
-		<field>
-			<fielddescr>Skip intervals</fielddescr>
-			<fieldname>skipintervals</fieldname>
-			<description>Number of intervals to skip between graphing. Default 0. Each interval is 200 seconds = 3 min 20 sec.</description>
-			<type>input</type>
-		</field>
-		<field>
-			<fielddescr>Graph cutoff</fielddescr>
-			<fieldname>graphcutoff</fieldname>
-			<description>Graph cutoff is how many KB must be transferred by an IP before it is graphed. Default 1024.</description>
-			<type>input</type>
+			<fielddescr>Subnet(s) for Statistics Collection</fielddescr>
+			<fieldname>interface_array</fieldname>
+			<description>
+				<![CDATA[
+				The subnet(s) on which BandwidthD will collect statistics. Traffic that matches none of these subnets will be ignored.<br />
+				<strong>Note: PPPoE interfaces are NOT supported!</strong>
+				]]>
+			</description>
+			<type>interfaces_selection</type>
+			<hideinterfaceregex>loopback</hideinterfaceregex>
+			<size>3</size>
+			<multiple>true</multiple>
+			<required/>
 		</field>
 		<field>
 			<fielddescr>Promiscuous</fielddescr>
 			<fieldname>promiscuous</fieldname>
-			<description>Put interface in promiscuous mode to see traffic that may not be routing through the host machine.&lt;br&gt;
-			Note: If the interface is connected to a switch then the interface will only see the traffic on its port.</description>
+			<description>
+				<![CDATA[
+				Put interface in promiscuous mode to see traffic that may not be routing through the host machine.<br />
+				Note: If the interface is connected to a switch then the interface will only see the traffic on its port.
+				]]>
+			</description>
 			<type>checkbox</type>
 		</field>
 		<field>
-			<fielddescr>output_cdf</fielddescr>
-			<fieldname>outputcdf</fieldname>
-			<description>Log data to cdf files log*.cdf</description>
-			<type>checkbox</type>
-		</field>
-		<field>
-			<fielddescr>recover_cdf</fielddescr>
-			<fieldname>recovercdf</fieldname>
-			<description>Read back the cdf files on startup</description>
-			<type>checkbox</type>
-		</field>
-		<field>
-			<fielddescr>output PostgreSQL</fielddescr>
-			<fieldname>outputpostgresql</fieldname>
-			<description>Log data to a PostgreSQL database.&lt;br&gt;
-			Get the postgreSQL schema and PHP files to display the results from: &lt;a target="_new" href="https://github.com/individual-it/bandwidthd-pSQL-frontend"&gt;https://github.com/individual-it/bandwidthd-pSQL-frontend&lt;/a&gt;</description>
-			<type>checkbox</type>
-		</field>
-		<field>
-			<fielddescr>Database host</fielddescr>
-			<fieldname>postgresqlhost</fieldname>
-			<description>Hostname of the postgreSQL database server.</description>
-			<type>input</type>
-		</field>
-		<field>
-			<fielddescr>Database name</fielddescr>
-			<fieldname>postgresqldatabase</fieldname>
-			<description>Database on the postgreSQL database server.</description>
-			<type>input</type>
-		</field>
-		<field>
-			<fielddescr>Database Username</fielddescr>
-			<fieldname>postgresqlusername</fieldname>
-			<description>Username of the postgreSQL database server.</description>
-			<type>input</type>
-		</field>
-		<field>
-			<fielddescr>Database Password</fielddescr>
-			<fieldname>postgresqlpassword</fieldname>
-			<description>Password of the postgreSQL database server.</description>
-			<type>password</type>
-		</field>
-		<field>
-			<fielddescr>sensor_id</fielddescr>
+			<fielddescr>Sensor ID</fielddescr>
 			<fieldname>sensorid</fieldname>
-			<description>Arbitrary sensor name, I recommend the sensors fully qualified domain name.</description>
+			<description>
+				<![CDATA[
+				Arbitrary sensor name.<br />
+				(Using the sensor's fully qualified domain name is recommended.)
+				]]>
+			</description>
 			<type>input</type>
 		</field>
 		<field>
-			<fielddescr>Filter</fielddescr>
-			<fieldname>filter</fieldname>
-			<description>Libpcap format filter string used to control what bandwidthd sees.  Please always include "ip" in the string to avoid strange problems.</description>
-			<type>input</type>
+			<name>Graph Options</name>
+			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Draw Graphs</fielddescr>
 			<fieldname>drawgraphs</fieldname>
-			<description>This defaults to true to graph the traffic bandwidthd is recording. Set this to false if you only want cdf output or you are using the database output option. Bandwidthd will use very little RAM and CPU if this is set to false.</description>
+			<description>
+				<![CDATA[
+				Enabled by default in order to graph the traffic that BandwidthD is recording. Uncheck this if you only want CDF output or you are using the database output option.<br />
+				BandwidthD will use very little RAM and CPU if this option is disabled.
+				]]>
+			</description>
 			<type>checkbox</type>
 			<default_value>on</default_value>
 		</field>
 		<field>
 			<fielddescr>Meta Refresh</fielddescr>
 			<fieldname>meta_refresh</fieldname>
-			<description>Sets the interval (seconds) at which the browser graph display refreshes (default 150, use 0 to disable).</description>
+			<description>
+				<![CDATA[
+				Sets the interval (seconds) at which the browser graph display refreshes<br />
+				Default 150, use 0 to disable.
+				]]>
+			</description>
 			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>Skip Intervals</fielddescr>
+			<fieldname>skipintervals</fieldname>
+			<description>
+				<![CDATA[
+				Number of intervals to skip between graphing.<br />
+				Default 0. (Each interval is 200 seconds = 3 min 20 sec.)
+				]]>
+			</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>Graph Cutoff</fielddescr>
+			<fieldname>graphcutoff</fieldname>
+			<description>
+				<![CDATA[
+				Graph cutoff means how many KB must be transferred by an IP before it is graphed.<br />
+				Default 1024.
+				]]>
+			</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>Output to CDF</fielddescr>
+			<fieldname>outputcdf</fieldname>
+			<description>Log data to CDF files log*.cdf</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Recover CDF</fielddescr>
+			<fieldname>recovercdf</fieldname>
+			<description>Read back the CDF files on startup.</description>
+			<type>checkbox</type>
 		</field>
 		<field>
 			<fielddescr>Graph and Log Info</fielddescr>
 			<fieldname>graph_log_info</fieldname>
-			<description>If draw graphs is on, then the daily report and graph html data is regenerated every (skip intervals + 1) * 200 seconds. The data volumes in the report are for the same period as the span of the graph.&lt;br&gt;
-			If output_cdf is on, then a cron job is added to rotate the log files at 00:01 each day. 6 log files are kept for each log frequency (daily, weekly, monthly, yearly). At the respective rotation intervals, the oldest log is deleted, the others are shuffled back and a new log is created.&lt;br&gt;
-			&lt;table cellpadding=1 cellspacing=0 style=&quot;text-align: left;&quot;&gt; &lt;tbody&gt;
-			&lt;tr&gt;&lt;th&gt;  &lt;/th&gt;&lt;th&gt; Data Interval &lt;/th&gt;&lt;th&gt; Graph Span &lt;/th&gt;&lt;th&gt; Log Rotation &lt;/th&gt;&lt;th&gt; Log File Name &lt;/th&gt;&lt;/tr&gt;
-			&lt;tr&gt;&lt;th&gt; Daily &lt;/th&gt;&lt;td&gt; 200 seconds &lt;/td&gt;&lt;td&gt; 2 days &lt;/td&gt;&lt;td&gt; 1 day &lt;/td&gt;&lt;td&gt; log.1.[0-5].cdf &lt;/td&gt;&lt;/tr&gt;
-			&lt;tr&gt;&lt;th&gt; Weekly &lt;/th&gt;&lt;td&gt; 10 minutes &lt;/td&gt;&lt;td&gt; 7 days &lt;/td&gt;&lt;td&gt; 7 days &lt;/td&gt;&lt;td&gt; log.2.[0-5].cdf &lt;/td&gt;&lt;/tr&gt;
-			&lt;tr&gt;&lt;th&gt; Monthly &lt;/th&gt;&lt;td&gt; 1 hour &lt;/td&gt;&lt;td&gt; 35 days &lt;/td&gt;&lt;td&gt; 35 days &lt;/td&gt;&lt;td&gt; log.3.[0-5].cdf &lt;/td&gt;&lt;/tr&gt;
-			&lt;tr&gt;&lt;th&gt; Yearly &lt;/th&gt;&lt;td&gt; 12 hours &lt;/td&gt;&lt;td&gt; 412.5 days &lt;/td&gt;&lt;td&gt; 412.5 days &lt;/td&gt;&lt;td&gt; log.4.[0-5].cdf &lt;/td&gt;&lt;/tr&gt;
-			&lt;/tbody&gt; &lt;/table&gt;
+			<description>
+			<![CDATA[
+				If "Draw Graphs" is on, then the daily report and graph html data is regenerated every (skip intervals + 1) * 200 seconds.&nbsp;
+				The data volumes in the report are for the same period as the span of the graph.<br />
+				If "Output to CDF" is on, then a cron job is added to rotate the log files at 00:01 each day. 6 log files are kept for each log frequency (daily, weekly, monthly, yearly).&nbsp;
+				At the respective rotation intervals, the oldest log is deleted, the others are shuffled back and a new log is created.<br /><br />
+				<table cellpadding="1" cellspacing="0" style="text-align: left"><tbody>
+				<tr><th></th><th>Data Interval</th><th>Graph Span</th><th>Log Rotation</th><th>Log File Name</th></tr>
+				<tr><th>Daily</th><td>200 seconds</td><td>2 days</td><td>1 day</td><td>log.1.[0-5].cdf</td></tr>
+				<tr><th>Weekly</th><td>10 minutes</td><td>7 days</td><td>7 days</td><td>log.2.[0-5].cdf</td></tr>
+				<tr><th>Monthly</th><td>1 hour</td><td>35 days</td><td>35 days</td><td>log.3.[0-5].cdf</td></tr>
+				<tr><th>Yearly</th><td>12 hours</td><td>412.5 days</td><td>412.5 days </td><td>log.4.[0-5].cdf</td></tr>
+				</tbody></table>
+				]]>
 			</description>
 			<type>info</type>
+		</field>
+		<field>
+			<name>PostgreSQL Options</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Output to PostgreSQL</fielddescr>
+			<fieldname>outputpostgresql</fieldname>
+			<description>
+				<![CDATA[
+				Log data to a PostgreSQL database.<br />
+				Get the PostgreSQL schema and PHP files to display the results from <a href="https://github.com/individual-it/bandwidthd-pSQL-frontend">https://github.com/individual-it/bandwidthd-pSQL-frontend</a>
+				]]>
+			</description>
+			<enablefields>postgresqlhost,postgresqldatabase,postgresqlusername,postgresqlpasswordenc</enablefields>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Database Host</fielddescr>
+			<fieldname>postgresqlhost</fieldname>
+			<description>Hostname of the PostgreSQL database server.</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>Database Name</fielddescr>
+			<fieldname>postgresqldatabase</fieldname>
+			<description>Database on the PostgreSQL database server.</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>Database Username</fielddescr>
+			<fieldname>postgresqlusername</fieldname>
+			<description>Username of the PostgreSQL database server.</description>
+			<type>input</type>
+		</field>
+		<field>
+			<fielddescr>Database Password</fielddescr>
+			<fieldname>postgresqlpasswordenc</fieldname>
+			<description>Password of the PostgreSQL database server.</description>
+			<type>password</type>
+			<encoding>base64</encoding>
+		</field>
+		<field>
+			<fielddescr>Advanced Filter</fielddescr>
+			<fieldname>advfilter</fieldname>
+			<description>
+				<![CDATA[
+				Libpcap format filter string used to control what traffic is counted.&nbsp;
+				Please, refer to <a href="https://www.freebsd.org/cgi/man.cgi?query=pcap-filter&amp;sektion=7&amp;apropos=0&amp;manpath=FreeBSD+10.1-RELEASE+and+Ports">pcap-filter(7)</a> for documentation.
+				<br />
+				NOTE: You should always specify "ip" in the filter to avoid strange results.<br /><br />
+				Example: We only want to account for a certain IP.<br />
+				Filter expression: <em>ip and host 192.0.2.1</em><br /><br />
+				<strong>WARNING: You are completely on your own with this! If misconfigured, BandwidthD will malfunction or even not start at all.</strong>
+				]]>
+			</description>
+			<type>textarea</type>
+			<encoding>base64</encoding>
+			<cols>65</cols>
+			<rows>1</rows>
+			<advancedfield/>
 		</field>
 	</fields>
 	<custom_php_resync_config_command>
 		bandwidthd_install_config();
 	</custom_php_resync_config_command>
 	<custom_php_install_command>
+		bandwidthd_upgrade_config();
 		bandwidthd_install_config();
 	</custom_php_install_command>
 	<custom_php_deinstall_command>
 		bandwidthd_install_deinstall();
 	</custom_php_deinstall_command>
+	<custom_php_validation_command>
+		bandwidthd_validate_input($_POST, $input_errors);
+	</custom_php_validation_command>
 </packagegui>

--- a/config/bandwidthd/bandwidthd.xml
+++ b/config/bandwidthd/bandwidthd.xml
@@ -61,10 +61,10 @@
 		<url>/pkg_edit.php?xml=bandwidthd.xml&amp;id=0</url>
 	</menu>
 	<service>
-			<name>bandwidthd</name>
-			<rcfile>bandwidthd.sh</rcfile>
-			<executable>bandwidthd</executable>
-			<description>BandwidthD bandwidth monitoring daemon</description>
+		<name>bandwidthd</name>
+		<rcfile>bandwidthd.sh</rcfile>
+		<executable>bandwidthd</executable>
+		<description>BandwidthD bandwidth monitoring daemon</description>
 	</service>
 	<tabs>
 		<tab>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -929,7 +929,7 @@
 		<website>http://bandwidthd.sourceforge.net/</website>
 		<descr>BandwidthD tracks usage of TCP/IP network subnets and builds html files with graphs to display utilization. Charts are built by individual IPs, and by default display utilization over 2 day, 8 day, 40 day, and 400 day periods. Furthermore, each ip address's utilization can be logged out at intervals of 3.3 minutes, 10 minutes, 1 hour or 12 hours in cdf format, or to a backend database server. HTTP, TCP, UDP, ICMP, VPN, and P2P traffic are color coded.</descr>
 		<category>System</category>
-		<version>0.5</version>
+		<version>0.6</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<depends_on_package_pbi>bandwidthd-2.0.1_6-##ARCH##.pbi</depends_on_package_pbi>


### PR DESCRIPTION
bandwidthd.xml
- Fix copyright header and indentation
- Reorder the GUI and split into logical sections
- Improve descriptions
- Move the menu entry to Diagnostics section, to match other similar packages (ntop, ntopng, darkstat etc.)
- Add another menu entry to access bandwidthd graphs directly from menu
- Add input validation

bandwidthd.inc
- Update copyright headers
- Fix code style and indentation
- Provide input validation for most of the configuration options

-- Check for IPv4 configured on selected interfaces
-- Check for PPPoE type interfaces
-- Require relevant options to be filled in when PostgreSQL is enabled (also check that the hostname is valid)
-- Require sane numeric input for graphs options
-- Limit Sensor ID to sane chars

- PostgreSQL DB password is now base64-encoded to deal with special chars and not break config.xml
- The filtering moved to advanced options, also base64-encoded
- The stats interface(s) are now a multiselect instead of asking users to type subnets directly
- Upgrade function provided to preserve the old settings
- Use {start,stop,restart}_service() functions instead of calling the rc script directly
- Probably other small things...