### PR TITLE
ipguard - make it work on 2.2.x plus code style cleanup

### DIFF
--- a/config/ipguard/ipguard.inc
+++ b/config/ipguard/ipguard.inc
@@ -1,88 +1,81 @@
 <?php
-
-/* ========================================================================== */
 /*
-    ipguard.inc
-    part of the ipguard package for pfSense (http://www.pfSense.com)
-    Copyright (C) 2012 Marcello Coutinho
-    All rights reserved.
+	ipguard.inc
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-    Based on m0n0wall (http://m0n0.ch/wall)
-    Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
-/*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
- require_once("config.inc");
- require_once("util.inc");
- 
-function ipguard_custom_php_deinstall_command(){
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+require_once("config.inc");
+require_once("util.inc");
+
+function ipguard_custom_php_deinstall_command() {
+	conf_mount_rw();
+	stop_service('ipguard');
+	unlink_if_exists("/usr/local/etc/rc.d/ipguard.sh");
+	$files = glob("/usr/local/etc/ipguard_*.conf");
+	foreach ($files as $file) {
+		unlink_if_exists($file);
+	}
+	conf_mount_ro();
+}
+
+function ipguard_custom_php_write_config() {
 	global $g, $config;
 
-	conf_mount_rw();
-	
-	stop_service('ipguard');
-	$ipguard_sh_file = "/usr/local/etc/rc.d/ipguard.sh";
-	if (is_file($ipguard_sh_file))
-		chmod($ipguard_sh_file,0444);
-
-	conf_mount_ro();
+	/* Detect boot process and do nothing */
+	if (platform_booting()) {
+		return;
 	}
 
-function ipguard_custom_php_write_config(){
-	global $g, $config;
-	
-	# detect boot process
-	if (is_array($_POST)){
-		if (!preg_match("/\w+/",$_POST['__csrf_magic']))
-			return;
-		}
-
-		
-	if (is_array($config['installedpackages']['ipguard']['config'])){
+	if (is_array($config['installedpackages']['ipguard']['config'])) {
 		// Read config
 		$new_config=array();
-		foreach ($config['installedpackages']['ipguard']['config'] as $ipguard){
-			if ($ipguard['enable'] && $ipguard['interface'] && $ipguard['mac'] && $ipguard['ip']){
-				$new_config[$ipguard['interface']].= "{$ipguard['mac']} {$ipguard['ip']} {$ipguard['description']}\n";
+		foreach ($config['installedpackages']['ipguard']['config'] as $ipguard) {
+			if ($ipguard['enable'] && $ipguard['interface'] && $ipguard['mac'] && $ipguard['ip']) {
+				$new_config[$ipguard['interface']] .= "{$ipguard['mac']} {$ipguard['ip']} {$ipguard['description']}\n";
 			}
 		}
 	}
 
-	//Save /etc/ssh/ipguard_extra
-	$script="/usr/local/etc/rc.d/ipguard.sh";
 	$start="";
 	$stop="pkill -anx ipguard";
 	conf_mount_rw();
-	if (count ($new_config) > 0 && $ipguard['enable']){
-			foreach ($new_config as $key => $value){
-				$conf_file="/usr/local/etc/ipguard_{$key}.conf";
-				file_put_contents($conf_file,$value,LOCK_EX);
-				$config_file=file_put_contents($conf_file,$new_config[$key],LOCK_EX);
-				$iface=convert_friendly_interface_to_real_interface_name($key);
-				$start.="/usr/local/sbin/ipguard -l /var/log/ipguard_{$key}.log -p /var/run/ipguard_{$key}.pid -f {$conf_file} -u 300 -z {$iface}\n\t";
+	/* Create rc script and restart service if ipguard is enabled */
+	if (count($new_config) > 0 && $ipguard['enable']) {
+			foreach ($new_config as $key => $value) {
+				$conf_file = "/usr/local/etc/ipguard_{$key}.conf";
+				file_put_contents($conf_file, $value, LOCK_EX);
+				$config_file = file_put_contents($conf_file, $new_config[$key], LOCK_EX);
+				/* Hack around PBI stupidity; ipguard does not find its own conf files otherwise */
+				$pfs_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+				if ($pfs_version == "2.2") {
+					$conf_file_link = "/usr/pbi/ipguard-" . php_uname("m") . "/local/etc/ipguard_{$key}.conf";
+					@symlink($conf_file, $conf_file_link);
+				}
+				$iface = convert_friendly_interface_to_real_interface_name($key);
+				$start .= "/usr/local/sbin/ipguard -l /var/log/ipguard_{$key}.log -p /var/run/ipguard_{$key}.pid -f {$conf_file} -u 300 -z {$iface}\n\t";
 			}
 			write_rcfile(array(
 					'file' => 'ipguard.sh',
@@ -90,38 +83,36 @@ function ipguard_custom_php_write_config(){
 					'stop' => $stop
 					));
 			restart_service('ipguard');
-			
-		}
-	else{
-		#remove config files
+
+	} else {
+		/* Otherwise, stop the service and remove rc script */
 		stop_service('ipguard');
-		$ipguard_sh_file = "/usr/local/etc/rc.d/ipguard.sh";
-		if (is_file($ipguard_sh_file))
-			chmod($ipguard_sh_file,0444);
+		unlink_if_exists("/usr/local/etc/rc.d/ipguard.sh");
+
 	}
-	// Mount Read-only
 	conf_mount_ro();
-	
-	//sync config with other pfsense servers
+
+	/* Sync config with other pfSense servers */
 	ipguard_sync_on_changes();
-	}
+}
 
 /* Uses XMLRPC to synchronize the changes to a remote node */
 function ipguard_sync_on_changes() {
 	global $config, $g;
-	
+
 	if (is_array($config['installedpackages']['ipguardsync'])) {
-		if ($config['installedpackages']['ipguardsync']['config'][0]['synconchanges'])	{
-			log_error("[ipguard] xmlrpc sync is starting.");
-			foreach ($config['installedpackages']['ipguardsync']['config'] as $rs ){
-				foreach($rs['row'] as $sh){
+		if ($config['installedpackages']['ipguardsync']['config'][0]['synconchanges']) {
+			log_error("[ipguard] XMLRPC sync is starting.");
+			foreach ($config['installedpackages']['ipguardsync']['config'] as $rs ) {
+				foreach ($rs['row'] as $sh) {
 					$sync_to_ip = $sh['ipaddress'];
 					$password = $sh['password'];
-					if($password && $sync_to_ip)
+					if ($password && $sync_to_ip) {
 						ipguard_do_xmlrpc_sync($sync_to_ip, $password);
+					}
 				}
 			}
-			log_error("[ipguard] xmlrpc sync is ending.");
+			log_error("[ipguard] XMLRPC sync is ending.");
 		}
 	}
 }
@@ -130,53 +121,57 @@ function ipguard_sync_on_changes() {
 function ipguard_do_xmlrpc_sync($sync_to_ip, $password) {
 	global $config, $g;
 
-	if(!$password)
+	if (!$password) {
 		return;
+	}
 
-	if(!$sync_to_ip)
+	if (!$sync_to_ip) {
 		return;
+	}
 
-	$username='admin';
+	$username = 'admin';
 	$xmlrpc_sync_neighbor = $sync_to_ip;
-    if($config['system']['webgui']['protocol'] != "") {
+	if ($config['system']['webgui']['protocol'] != "") {
 		$synchronizetoip = $config['system']['webgui']['protocol'];
 		$synchronizetoip .= "://";
-    }
-    $port = $config['system']['webgui']['port'];
-    /* if port is empty lets rely on the protocol selection */
-    if($port == "") {
-		if($config['system']['webgui']['protocol'] == "http") 
+	}
+	$port = $config['system']['webgui']['port'];
+	/* If port is empty, let's rely on the protocol selection */
+	if ($port == "") {
+		if ($config['system']['webgui']['protocol'] == "http") {
 			$port = "80";
-		else 
+		} else {
 			$port = "443";
-    }
+		}
+	}
 	$synchronizetoip .= $sync_to_ip;
 
 	/* xml will hold the sections to sync */
 	$xml = array();
 	$xml['ipguard'] = $config['installedpackages']['ipguard'];
-	/* assemble xmlrpc payload */
+	/* Assemble XMLRPC payload */
 	$params = array(
 		XML_RPC_encode($password),
 		XML_RPC_encode($xml)
 	);
 
-	/* set a few variables needed for sync code borrowed from filter.inc */
+	/* Set a few variables needed for sync code; borrowed from filter.inc */
 	$url = $synchronizetoip;
 	log_error("Beginning ipguard XMLRPC sync to {$url}:{$port}.");
 	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
-	if($g['debug'])
+	if ($g['debug']) {
 		$cli->setDebug(1);
+	}
 	/* send our XMLRPC message and timeout after 250 seconds */
 	$resp = $cli->send($msg, "250");
-	if(!$resp) {
+	if (!$resp) {
 		$error = "A communications error occurred while attempting ipguard XMLRPC sync with {$url}:{$port}.";
 		log_error($error);
 		file_notice("sync_settings", $error, "ipguard Settings Sync", "");
-	} elseif($resp->faultCode()) {
+	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, "250");
 		$error = "An error code was received while attempting ipguard XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
@@ -185,27 +180,27 @@ function ipguard_do_xmlrpc_sync($sync_to_ip, $password) {
 	} else {
 		log_error("ipguard XMLRPC sync successfully completed with {$url}:{$port}.");
 	}
-	
+
 	/* tell ipguard to reload our settings on the destination sync host. */
 	$method = 'pfsense.exec_php';
-	$execcmd  = "require_once('/usr/local/pkg/ipguard.inc');\n";
+	$execcmd = "require_once('/usr/local/pkg/ipguard.inc');\n";
 	$execcmd .= "ipguard_custom_php_write_config();";
 	/* assemble xmlrpc payload */
 	$params = array(
 		XML_RPC_encode($password),
 		XML_RPC_encode($execcmd)
 	);
-	
+
 	log_error("ipguard XMLRPC reload data {$url}:{$port}.");
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
 	$resp = $cli->send($msg, "250");
-	if(!$resp) {
+	if (!$resp) {
 		$error = "A communications error occurred while attempting ipguard XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
 		log_error($error);
 		file_notice("sync_settings", $error, "ipguard Settings Sync", "");
-	} elseif($resp->faultCode()) {
+	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, "250");
 		$error = "An error code was received while attempting ipguard XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
@@ -215,4 +210,5 @@ function ipguard_do_xmlrpc_sync($sync_to_ip, $password) {
 		log_error("ipguard XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
 	}
 }
-	?>
+
+?>

--- a/config/ipguard/ipguard.inc
+++ b/config/ipguard/ipguard.inc
@@ -31,12 +31,10 @@ require_once("config.inc");
 require_once("util.inc");
 
 function ipguard_custom_php_deinstall_command() {
-	conf_mount_rw();
 	stop_service('ipguard');
 	unlink_if_exists("/usr/local/etc/rc.d/ipguard.sh");
 	$files = glob("/usr/local/etc/ipguard_*.conf");
 	unlink_if_exists($files);
-	conf_mount_ro();
 }
 
 function ipguard_custom_php_write_config() {

--- a/config/ipguard/ipguard.inc
+++ b/config/ipguard/ipguard.inc
@@ -72,7 +72,11 @@ function ipguard_custom_php_write_config() {
 				$pfs_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
 				if ($pfs_version == "2.2") {
 					$conf_file_link = "/usr/pbi/ipguard-" . php_uname("m") . "/local/etc/ipguard_{$key}.conf";
-					@symlink($conf_file, $conf_file_link);
+					/* Better recreate this every time just in case users shuffle interfaces assignment somehow */
+					if (is_link($conf_file_link)) {
+						unlink($conf_file_link);
+					}
+					symlink($conf_file, $conf_file_link);
 				}
 				$iface = convert_friendly_interface_to_real_interface_name($key);
 				$start .= "/usr/local/sbin/ipguard -l /var/log/ipguard_{$key}.log -p /var/run/ipguard_{$key}.pid -f {$conf_file} -u 300 -z {$iface}\n\t";

--- a/config/ipguard/ipguard.inc
+++ b/config/ipguard/ipguard.inc
@@ -35,9 +35,7 @@ function ipguard_custom_php_deinstall_command() {
 	stop_service('ipguard');
 	unlink_if_exists("/usr/local/etc/rc.d/ipguard.sh");
 	$files = glob("/usr/local/etc/ipguard_*.conf");
-	foreach ($files as $file) {
-		unlink_if_exists($file);
-	}
+	unlink_if_exists($files);
 	conf_mount_ro();
 }
 

--- a/config/ipguard/ipguard.xml
+++ b/config/ipguard/ipguard.xml
@@ -1,55 +1,55 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-<copyright>
-        <![CDATA[
+	<copyright>
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    ipguard.xml
-    part of the ipguard package for pfSense (http://www.pfSense.com)
-    Copyright (C) 2012 Marcello Coutinho
-    All rights reserved.
-
-    Based on m0n0wall (http://m0n0.ch/wall)
-    Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
+	ipguard.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
-        </copyright>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>ipguard</name>
-	<version>1.0</version>
-	<title>Ipguard</title>
-	<description>Ipguard macs/ip</description>
+	<version>0.1.1</version>
+	<title>Firewall: IPguard</title>
+	<description>IPguard MACs/IP</description>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/ipguard.inc</include_file>
 	<menu>
-		<name>Ipguard</name>
-		<tooltiptext>Tool designed to protect LAN IP address space by ARP spoofing</tooltiptext>
+		<name>IPguard</name>
+		<tooltiptext>Tool designed to protect LAN IP address space by ARP spoofing.</tooltiptext>
 		<section>Firewall</section>
 		<url>/pkg.php?xml=ipguard.xml</url>
 	</menu>
@@ -57,17 +57,15 @@
 		<name>ipguard</name>
 		<rcfile>ipguard.sh</rcfile>
 		<executable>ipguard</executable>
-		<description>Tool designed to protect LAN IP address space by ARP spoofing.</description>
+		<description>IPguard ARP Spoofing Daemon</description>
 	</service>
 	<configpath>installedpackages->package->ipguard</configpath>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>755</chmod>
 		<item>https://packages.pfsense.org/packages/config/ipguard/ipguard.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>755</chmod>
 		<item>https://packages.pfsense.org/packages/config/ipguard/ipguard_sync.xml</item>
 	</additional_files_needed>
 	<tabs>
@@ -92,11 +90,11 @@
 			<fieldname>interface</fieldname>
 		</columnitem>
 		<columnitem>
-			<fielddescr>Mac Address</fielddescr>
+			<fielddescr>MAC Address</fielddescr>
 			<fieldname>mac</fieldname>
 		</columnitem>
 		<columnitem>
-			<fielddescr>Ip Address(es)</fielddescr>
+			<fielddescr>IP Address(es)</fielddescr>
 			<fieldname>ip</fieldname>
 		</columnitem>
 		<columnitem>
@@ -104,43 +102,53 @@
 			<fieldname>description</fieldname>
 		</columnitem>
 		<movable>on</movable>
-		<description><![CDATA[If firewall receives traffic with MAC/IP pair not listed here, it will send ARP reply with configured fake address.<br>This will prevent not permitted host from working properly in the specified ethernet segment.]]></description>
+		<description>
+			<![CDATA[
+			If firewall receives traffic with MAC/IP pair not listed here, it will send ARP reply with configured fake address.<br />
+			This will prevent not permitted host from working properly in the specified ethernet segment.
+			]]>
+		</description>
 	</adddeleteeditpagefields>
 	<fields>
 		<field>
 			<type>listtopic</type>
-			<name>Ipguard Options</name>
+			<name>IPguard Options</name>
 			<fieldname>temp</fieldname>
 		</field>
 		<field>
-		<fielddescr>sortable</fielddescr>
-		<fieldname>sortable</fieldname>
-		<display_maximum_rows>20</display_maximum_rows>
-		<type>sorting</type>
-		<include_filtering_inputbox/>
-		<sortablefields>
-			<item>
-				<name>Mac Address</name>
-				<fieldname>mac</fieldname>
-				<regex>/%FILTERTEXT%/i</regex>
-			</item>
-			<item>
-				<name>Ip Address</name>
-				<fieldname>ip</fieldname>
-				<regex>/%FILTERTEXT%/i</regex>
-			</item>
-		</sortablefields>
+			<fielddescr>sortable</fielddescr>
+			<fieldname>sortable</fieldname>
+			<display_maximum_rows>20</display_maximum_rows>
+			<type>sorting</type>
+			<include_filtering_inputbox/>
+			<sortablefields>
+				<item>
+					<name>MAC Address</name>
+					<fieldname>mac</fieldname>
+					<regex>/%FILTERTEXT%/i</regex>
+				</item>
+				<item>
+					<name>IP Address</name>
+					<fieldname>ip</fieldname>
+					<regex>/%FILTERTEXT%/i</regex>
+				</item>
+			</sortablefields>
 		</field>
 		<field>
-		<fielddescr>Enable</fielddescr>
+			<fielddescr>Enable</fielddescr>
 			<fieldname>enable</fieldname>
 			<type>checkbox</type>
-		<description><![CDATA[Enable this mac rule.<br><strong>Important Note:</strong> Always create rules for pfsense mac and ip address to avoid denying access to pfsense gui.]]></description>
+			<description>
+				<![CDATA[
+				Enable this MAC rule.<br />
+				<strong>Important Note:</strong> Always create rules for pfSense MAC and IP address to avoid denying access to pfFense GUI!
+				]]>
+			</description>
 		</field>
 		<field>
 			<fielddescr>Interface</fielddescr>
 			<fieldname>interface</fieldname>
-			<description>The interface on which ipguard server will check this mac</description>
+			<description>The interface on which IPguard server will check this MAC.</description>
 			<type>interfaces_selection</type>
 			<required/>
 			<default_value>lan</default_value>
@@ -148,39 +156,44 @@
 		<field>
 			<fielddescr>Description</fielddescr>
 			<fieldname>description</fieldname>
-			<description>Describe this mac rule.</description>
+			<description>Describe this MAC rule.</description>
 			<type>input</type>
 			<size>50</size>
 			<required/>
 		</field>
 		<field>
-			<fielddescr>Mac address</fielddescr>
+			<fielddescr>MAC Address</fielddescr>
 			<fieldname>mac</fieldname>
-			<description><![CDATA[Insert mac address you want to filter.<br>
-				<strong>To include a permit rule, use mac=00:00:00:00:00:00</strong>]]></description>
+			<description>
+				<![CDATA[
+				Insert MAC address you want to filter.<br />
+				<strong>To include a permit rule, use MAC 00:00:00:00:00:00</strong>
+				]]>
+			</description>
 			<type>input</type>
 			<size>25</size>
 			<required/>
 		</field>
 		<field>
-			<fielddescr>Ip address</fielddescr>
+			<fielddescr>IP Address</fielddescr>
 			<fieldname>ip</fieldname>
-			<description><![CDATA[Insert ip address, hostname or network cidr you want to apply on this ipguard rule.<br>
-				<strong>To include a permit rule, use your lan cidr or 0.0.0.0</strong>]]></description>
+			<description>
+				<![CDATA[
+				Insert IP address, hostname or network CIDR you want to apply on this IPguard rule.<br>
+				<strong>To include a permit rule, use your LAN CIDR or 0.0.0.0</strong>
+				]]>
+			</description>
 			<type>input</type>
 			<size>40</size>
 			<required/>
 		</field>
 	</fields>
-
 	<custom_delete_php_command>
 		ipguard_custom_php_write_config();
 	</custom_delete_php_command>
 	<custom_add_php_command>
 		ipguard_custom_php_write_config();
 	</custom_add_php_command>
-	<custom_php_install_command>
-	</custom_php_install_command>
 	<custom_php_deinstall_command>
 		ipguard_custom_php_deinstall_command();
 	</custom_php_deinstall_command>
@@ -190,5 +203,4 @@
 	<custom_php_command_before_form>
 		unset($_POST['temp']);
 	</custom_php_command_before_form>
-
 </packagegui>

--- a/config/ipguard/ipguard_sync.xml
+++ b/config/ipguard/ipguard_sync.xml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-	<![CDATA[
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    ipguard_sync.xml
-    part of the ipguard package for pfSense (http://www.pfSense.com)
-    Copyright (C) 2012 Marcello Coutinho
-    All rights reserved.            
-                                                                  */
-/* ========================================================================== */
+	ipguard_sync.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
 	]]>
 	</copyright>
-	<description>Describe your package here</description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>ipguardsync</name>
-	<version>1.0</version>
-	<title>Ipguard - Sync</title>
+	<version>0.1.1</version>
+	<title>IPguard - Sync</title>
 	<include_file>/usr/local/pkg/ipguard.inc</include_file>
 	<tabs>
 		<tab>
@@ -89,8 +89,6 @@
 			</rowhelper>
 		</field>
 	</fields>
-	<custom_php_validation_command>
-	</custom_php_validation_command>
 	<custom_php_resync_config_command>
 		ipguard_custom_php_write_config();
 	</custom_php_resync_config_command>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -633,7 +633,7 @@
 		<config_file>https://packages.pfsense.org/packages/config/ipguard/ipguard.xml</config_file>
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,49917.msg263664.html#msg263664</pkginfolink>
 		<depends_on_package_pbi>ipguard-1.04_2-##ARCH##.pbi</depends_on_package_pbi>
-		<version>0.1</version>
+		<version>0.1.1</version>
 		<status>beta</status>
 		<required_version>2.2</required_version>
 		<configurationfile>ipguard.xml</configurationfile>


### PR DESCRIPTION
ipguard.xml
- Fix copyright header, indentation
- Fix file permissions
- Remove unused tags
- Improve descriptions

ipguard_sync.xml
- Fix copyright header
- Remove unused tag
- Fix version

ipguard.inc
- Fix copyright header
- Code style and indentation fixes
- Hack to make this work on 2.2.x by symlinking the .conf files to PBI's /etc dir; another piece of PBI stupidity.
- Fix bogus boot check
- Clean up after itself a bit better on uninstall.