### PR TITLE
zabbix-proxy-lts - code style cleanup

### DIFF
--- a/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
+++ b/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
@@ -1,110 +1,99 @@
 <?php
-/* $Id$ */
-/* ========================================================================== */
 /*
-    zabbix-proxy-lts.inc
-    part of the Zabbix package for pfSense
-    Copyright (C) 2013 Danilo G. Baio
-    Copyright (C) 2013 Marcello Coutinho
+	zabbix-proxy-lts.inc
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013 Danilo G. Baio
+	Copyright (C) 2013 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-    All rights reserved.            
-			                                                                  */
-/* ========================================================================== */
-/*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
 require_once("util.inc");
 require_once("functions.inc");
 require_once("pkg-utils.inc");
 require_once("globals.inc");
 
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
+$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
 if ($pf_version == "2.1" || $pf_version == "2.2") {
 	define('ZABBIX_PROXY_BASE', '/usr/pbi/zabbix22-proxy-' . php_uname("m"));
 } else {
 	define('ZABBIX_PROXY_BASE', '/usr/local');
 }
 
-function php_install_zabbix_proxy_lts(){
-	sync_package_zabbix_proxy_lts();	
-}
+function php_deinstall_zabbix_proxy_lts() {
+	conf_mount_rw();
 
-function php_deinstall_zabbix_proxy_lts(){
-   global $config, $g;
-
-   conf_mount_rw();
-
-   exec("/usr/bin/killall zabbix_proxy");
-   unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/rc.d/zabbix_proxy_lts.sh");
-   unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/zabbix22/zabbix_proxy_lts.conf");
-   unlink_if_exists("/var/log/zabbix-proxy-lts/zabbix_proxy_lts.log");
-   unlink_if_exists("/var/run/zabbix-proxy-lts/zabbix_proxy_lts.pid");
+	stop_service("zabbix_proxy_lts");
+	unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/rc.d/zabbix_proxy_lts.sh");
+	unlink_if_exists(ZABBIX_PROXY_BASE . "/etc/zabbix22/zabbix_proxy_lts.conf");
+	unlink_if_exists("/var/log/zabbix-proxy-lts/zabbix_proxy_lts.log");
+	unlink_if_exists("/var/run/zabbix-proxy-lts/zabbix_proxy_lts.pid");
 
 	if (is_dir("/var/log/zabbix-proxy-lts")) {
-		exec("/bin/rm -r /var/log/zabbix-proxy-lts/");
+		exec("/bin/rm -rf /var/log/zabbix-proxy-lts/");
 	}
 	if (is_dir("/var/run/zabbix-proxy-lts")) {
-		exec("/bin/rm -r /var/run/zabbix-proxy-lts/");
+		exec("/bin/rm -rf /var/run/zabbix-proxy-lts/");
 	}
-   if (is_dir("/var/db/zabbix-proxy-lts")) {
-		exec("/bin/rm -r /var/db/zabbix-proxy-lts/");
+	if (is_dir("/var/db/zabbix-proxy-lts")) {
+		exec("/bin/rm -rf /var/db/zabbix-proxy-lts/");
 	}
 
-   conf_mount_ro();
+	conf_mount_ro();
 }
 
-function validate_input_zabbix_proxy_lts($post, &$input_errors){
-	if  (isset($post['proxyenabled'])) {
+function validate_input_zabbix_proxy_lts($post, &$input_errors) {
+	if (isset($post['proxyenabled'])) {
 		if (!preg_match("/\w+/", $post['server'])) {
-			$input_errors[]='Server field is required.';
+			$input_errors[] = 'Server field is required.';
 		}
 
 		if (!is_numericint($post['serverport'])) {
-			$input_errors[]='Server Port is not numeric.'.$ServerPort;
+			$input_errors[] = 'Server Port is not numeric.'.$ServerPort;
 		}
 
 		if (!preg_match("/\w+/", $post['hostname'])) {
-			$input_errors[]='Hostname field is required.';
+			$input_errors[] = 'Hostname field is required.';
 		}
 
 		if (!is_numericint($post['configfrequency'])) {
-			$input_errors[]='Config Frequency is not numeric.';
+			$input_errors[] = 'Config Frequency is not numeric.';
 		}
 	}
 }
 
-function sync_package_zabbix_proxy_lts(){
+function sync_package_zabbix_proxy_lts() {
 	global $config, $g;
 
 	conf_mount_rw();
 
-	#check zabbix proxy config
-	if (is_array($config['installedpackages']['zabbixproxylts'])){
+	// Check zabbix proxy config
+	if (is_array($config['installedpackages']['zabbixproxylts'])) {
 		$zbproxy_config = $config['installedpackages']['zabbixproxylts']['config'][0];
-		if ($zbproxy_config['proxyenabled']=="on"){
-			$Mode=(is_numericint($zbproxy_config['proxymode'])?$zbproxy_config['proxymode'] : 0);
-			$AdvancedParams=base64_decode($zbproxy_config['advancedparams']);
-		
+		if ($zbproxy_config['proxyenabled'] == "on") {
+			$Mode = (is_numericint($zbproxy_config['proxymode']) ? $zbproxy_config['proxymode'] : 0);
+			$AdvancedParams = base64_decode($zbproxy_config['advancedparams']);
+
 			$zbproxy_conf_file = <<< EOF
 Server={$zbproxy_config['server']}
 ServerPort={$zbproxy_config['serverport']}
@@ -114,7 +103,8 @@ DBName=/var/db/zabbix-proxy-lts/proxy.db
 LogFile=/var/log/zabbix-proxy-lts/zabbix_proxy_lts.log
 ConfigFrequency={$zbproxy_config['configfrequency']}
 FpingLocation=/usr/local/sbin/fping
-#there's currently no fping6 (IPv6) dependency in the package, but if there was, the binary would likely also be in /usr/local/sbin
+# There's currently no fping6 (IPv6) dependency in the package,
+# but if there was, the binary would likely also be in /usr/local/sbin.
 Fping6Location=/usr/local/sbin/fping6
 ProxyMode={$Mode}
 {$AdvancedParams}
@@ -130,24 +120,25 @@ EOF;
 		'kern.ipc.semmsl' => '250'
 	);
 	$sysctls = array();
-	#check sysctl file values
+	// Check sysctl file values
 	$sc_file="";
 	if (file_exists("/etc/sysctl.conf")) {
 		$sc = file("/etc/sysctl.conf");
 		foreach ($sc as $line) {
 			list($sysk, $sysv) = explode("=", $line, 2);
-			if (preg_match("/\w/",$line) && !array_key_exists($sysk, $want_sysctls))
-				$sc_file.=$line;
+			if (preg_match("/\w/", $line) && !array_key_exists($sysk, $want_sysctls)) {
+				$sc_file .= $line;
 			}
+		}
 	}
-	foreach ($want_sysctls as $ws=> $wv) {
+	foreach ($want_sysctls as $ws => $wv) {
 		$sc_file .= "{$ws}={$wv}\n";
 		exec("/sbin/sysctl {$ws}={$wv}");
 	}
 	file_put_contents("/etc/sysctl.conf", $sc_file);
 
-	#check bootloader values
-	$lt_file="";
+	// Check bootloader values
+	$lt_file = "";
 	$want_tunables = array(
 		'kern.ipc.semopm' => '100',
 		'kern.ipc.semmni' => '128',
@@ -159,21 +150,23 @@ EOF;
 		$lt = file("/boot/loader.conf");
 		foreach ($lt as $line) {
 			list($tunable, $val) = explode("=", $line, 2);
-			if (preg_match("/\w/",$line) && !array_key_exists($tunable, $want_tunables))
-				$lt_file.=$line;
+			if (preg_match("/\w/", $line) && !array_key_exists($tunable, $want_tunables)) {
+				$lt_file .= $line;
+			}
 		}
 	}
 	foreach ($want_tunables as $wt => $wv) {
-		$lt_file.= "{$wt}={$wv}\n";
+		$lt_file .= "{$wt}={$wv}\n";
 	}
 	file_put_contents("/boot/loader.conf", $lt_file);
 
-	/*check startup script files*/
-	/* create a few directories and ensure the sample files are in place */
-	if (!is_dir(ZABBIX_PROXY_BASE . "/etc/zabbix22"))
+	// Check startup script files
+	// Create a few directories and ensure the sample files are in place
+	if (!is_dir(ZABBIX_PROXY_BASE . "/etc/zabbix22")) {
 		exec("/bin/mkdir -p " . ZABBIX_PROXY_BASE . "/etc/zabbix22");
+	}
 
-	$dir_checks  = <<< EOF
+	$dir_checks = <<< EOF
 
 	if [ ! -d /var/log/zabbix-proxy-lts ]; then
 		/bin/mkdir -p /var/log/zabbix-proxy-lts
@@ -195,7 +188,7 @@ EOF;
 
 EOF;
 
-	$pid_check  = <<< EOF
+	$pid_check = <<< EOF
 
 	/bin/pgrep -anx zabbix_proxy 2>/dev/null
 	if [ "\$?" -eq "0" ]; then
@@ -204,33 +197,33 @@ EOF;
 	fi
 
 EOF;
- 
-	$zproxy_rcfile="/usr/local/etc/rc.d/zabbix_proxy_lts.sh";
-	if (is_array($zbproxy_config) && $zbproxy_config['proxyenabled']=="on"){
-		$zproxy_start  = strtr($dir_checks, array("\r" => ""));
+
+	$zproxy_rcfile = "/usr/local/etc/rc.d/zabbix_proxy_lts.sh";
+	if (is_array($zbproxy_config) && $zbproxy_config['proxyenabled'] == "on") {
+		$zproxy_start = strtr($dir_checks, array("\r" => ""));
 		$zproxy_start .= "\techo \"Starting Zabbix Proxy LTS\"...\n";
 		$zproxy_start .= "\t" . ZABBIX_PROXY_BASE . "/sbin/zabbix_proxy\n";
-	
-		$zproxy_stop  = "echo \"Stopping Zabbix Proxy LTS\"\n";
+
+		$zproxy_stop = "echo \"Stopping Zabbix Proxy LTS\"\n";
 		$zproxy_stop .= "\t/usr/bin/killall zabbix_proxy\n";
 		$zproxy_stop .= "\t/bin/sleep 5\n";
 		$zproxy_stop .= strtr($pid_check, array("\r" => ""));
 
-		/* write out rc.d start/stop file */
+		// write out rc.d start/stop file
 		write_rcfile(array(
 			"file" => "zabbix_proxy_lts.sh",
 			"start" => $zproxy_start,
 			"stop" => $zproxy_stop
 			)
 		);
-		mwexec("{$zproxy_rcfile} restart");
-	}else{
-		if (file_exists($zproxy_rcfile)){
-		mwexec("{$zproxy_rcfile} stop");
-		unlink($zproxy_rcfile);
+		restart_service("zabbix_proxy_lts");
+	} else {
+		if (is_service_running("zabbix_proxy_lts")) {
+			stop_service("zabbix_proxy_lts");
 		}
+		unlink_if_exists($zproxy_rcfile);
 	}
-	
+
 	conf_mount_ro();
 }
 

--- a/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
+++ b/config/zabbix-proxy-lts/zabbix-proxy-lts.inc
@@ -50,13 +50,13 @@ function php_deinstall_zabbix_proxy_lts() {
 	unlink_if_exists("/var/run/zabbix-proxy-lts/zabbix_proxy_lts.pid");
 
 	if (is_dir("/var/log/zabbix-proxy-lts")) {
-		exec("/bin/rm -rf /var/log/zabbix-proxy-lts/");
+		mwexec("/bin/rm -rf /var/log/zabbix-proxy-lts/");
 	}
 	if (is_dir("/var/run/zabbix-proxy-lts")) {
-		exec("/bin/rm -rf /var/run/zabbix-proxy-lts/");
+		mwexec("/bin/rm -rf /var/run/zabbix-proxy-lts/");
 	}
 	if (is_dir("/var/db/zabbix-proxy-lts")) {
-		exec("/bin/rm -rf /var/db/zabbix-proxy-lts/");
+		mwexec("/bin/rm -rf /var/db/zabbix-proxy-lts/");
 	}
 
 	conf_mount_ro();
@@ -65,19 +65,21 @@ function php_deinstall_zabbix_proxy_lts() {
 function validate_input_zabbix_proxy_lts($post, &$input_errors) {
 	if (isset($post['proxyenabled'])) {
 		if (!preg_match("/\w+/", $post['server'])) {
-			$input_errors[] = 'Server field is required.';
+			$input_errors[] = "Server field is required.";
 		}
 
 		if (!is_numericint($post['serverport'])) {
-			$input_errors[] = 'Server Port is not numeric.'.$ServerPort;
+			$input_errors[] = "'Server Port' value is not numeric.";
+		} elseif ($post['serverport'] < 1 || $post['serverport'] > 65535) {
+			$input_errors[] = "You must enter a valid value for 'Server Port'.";
 		}
 
 		if (!preg_match("/\w+/", $post['hostname'])) {
-			$input_errors[] = 'Hostname field is required.';
+			$input_errors[] = "Hostname field is required.";
 		}
 
 		if (!is_numericint($post['configfrequency'])) {
-			$input_errors[] = 'Config Frequency is not numeric.';
+			$input_errors[] = "'Config Frequency' value is not numeric.";
 		}
 	}
 }
@@ -133,7 +135,7 @@ EOF;
 	}
 	foreach ($want_sysctls as $ws => $wv) {
 		$sc_file .= "{$ws}={$wv}\n";
-		exec("/sbin/sysctl {$ws}={$wv}");
+		mwexec("/sbin/sysctl {$ws}={$wv}");
 	}
 	file_put_contents("/etc/sysctl.conf", $sc_file);
 
@@ -163,7 +165,7 @@ EOF;
 	// Check startup script files
 	// Create a few directories and ensure the sample files are in place
 	if (!is_dir(ZABBIX_PROXY_BASE . "/etc/zabbix22")) {
-		exec("/bin/mkdir -p " . ZABBIX_PROXY_BASE . "/etc/zabbix22");
+		mwexec("/bin/mkdir -p " . ZABBIX_PROXY_BASE . "/etc/zabbix22");
 	}
 
 	$dir_checks = <<< EOF

--- a/config/zabbix-proxy-lts/zabbix-proxy-lts.xml
+++ b/config/zabbix-proxy-lts/zabbix-proxy-lts.xml
@@ -1,54 +1,57 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-<copyright>
+	<copyright>
 	<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    zabbix-proxy-lts.xml
-    part of the Zabbix package for pfSense
-    Copyright (C) 2013 Danilo G. Baio
-    Copyright (C) 2013 Marcello Coutinho
-
-    All rights reserved.            
-			                                                                  */
-/* ========================================================================== */
+	zabbix-proxy-lts.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013 Danilo G. Baio
+	Copyright (C) 2013 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
 	]]>
 	</copyright>
 	<name>zabbixproxylts</name>
 	<title>Services: Zabbix Proxy LTS</title>
 	<category>Monitoring</category>
-	<version>0.8.5</version>
+	<version>0.8.6</version>
 	<include_file>/usr/local/pkg/zabbix-proxy-lts.inc</include_file>
 	<addedit_string>Zabbix Proxy has been created/modified.</addedit_string>
 	<delete_string>Zabbix Proxy has been deleted.</delete_string>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/zabbix-proxy-lts/zabbix-proxy-lts.inc</item>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<menu>
 		<name>Zabbix Proxy LTS</name>
@@ -60,7 +63,7 @@
 		<name>zabbix_proxy_lts</name>
 		<rcfile>zabbix_proxy_lts.sh</rcfile>
 		<executable>zabbix_proxy</executable>
-		<description>Zabbix Proxy LTS collection daemon</description>
+		<description>Zabbix Proxy LTS Collection Daemon</description>
 	</service>
 	<tabs>
 		<tab>
@@ -69,6 +72,7 @@
 			<active />
 		</tab>
 	</tabs>
+	<advanced_options>enabled</advanced_options>
 	<fields>
 		<field>
 			<name>Zabbix Proxy LTS Settings</name>
@@ -77,31 +81,31 @@
 		<field>
 			<fielddescr>Enable</fielddescr>
 			<fieldname>proxyenabled</fieldname>
-			<description>Enable Zabbix Proxy LTS service</description>
+			<description>Enable Zabbix Proxy LTS service.</description>
 			<type>checkbox</type>
 		</field>
 		<field>
 			<fielddescr>Server</fielddescr>
 			<fieldname>server</fieldname>
-			<description>List of comma delimited IP addresses (or hostnames) of ZABBIX servers</description>
+			<description>List of comma delimited IP addresses (or hostnames) of ZABBIX servers.</description>
 			<default_value>127.0.0.1</default_value>
 			<type>input</type>
 			<size>60</size>
 			<required>true</required>
 		</field>
 		<field>
-         <fielddescr>Server Port</fielddescr>
-         <fieldname>serverport</fieldname>
-         <description>Port of Zabbix trapper on Zabbix server. default value 10051</description>
-         <default_value>10051</default_value>
-         <type>input</type>
-         <size>6</size>
-         <required>true</required>
+			<fielddescr>Server Port</fielddescr>
+			<fieldname>serverport</fieldname>
+			<description>Port of Zabbix trapper on Zabbix server. (Default: 10051)</description>
+			<default_value>10051</default_value>
+			<type>input</type>
+			<size>6</size>
+			<required>true</required>
 		</field>
 		<field>
 			<fielddescr>Hostname</fielddescr>
 			<fieldname>hostname</fieldname>
-			<description>Unique, case-sensitive proxy name. Make sure the proxy name is known to the server</description>
+			<description>Unique, case-sensitive proxy name. Make sure the proxy name is known to the server.</description>
 			<default_value>localhost</default_value>
 			<type>input</type>
 			<size>50</size>
@@ -110,7 +114,7 @@
 		<field>
 			<fielddescr>Proxy Mode</fielddescr>
 			<fieldname>proxymode</fieldname>
-			<description>Select Zabbix proxy mode (Active is default)</description>
+			<description>Select Zabbix proxy mode (Default: Active)</description>
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
@@ -135,15 +139,20 @@
 			<type>textarea</type>
 			<rows>5</rows>
 			<cols>50</cols>
-			<description>Advanced parameters. There are some rarely used parameters that sometimes need to be defined. Value has form, example: StartDiscoverers=10</description>
+			<description>Advanced parameters. There are some rarely used parameters that sometimes need to be defined. Example: StartDiscoverers=10</description>
+			<advancedfield/>
 		</field>
 	</fields>
-	<custom_php_install_command>sync_package_zabbix_proxy_lts();</custom_php_install_command>
-	<custom_php_command_before_form></custom_php_command_before_form>
-	<custom_php_after_head_command></custom_php_after_head_command>
-	<custom_php_after_form_command></custom_php_after_form_command>
-	<custom_php_validation_command>validate_input_zabbix_proxy_lts($_POST, $input_errors);</custom_php_validation_command>
-	<custom_add_php_command></custom_add_php_command>
-	<custom_php_resync_config_command>sync_package_zabbix_proxy_lts();</custom_php_resync_config_command>
-	<custom_php_deinstall_command>php_deinstall_zabbix_proxy_lts();</custom_php_deinstall_command>
+	<custom_php_install_command>
+		sync_package_zabbix_proxy_lts();
+	</custom_php_install_command>
+	<custom_php_validation_command>
+		validate_input_zabbix_proxy_lts($_POST, $input_errors);
+	</custom_php_validation_command>
+	<custom_php_resync_config_command>
+		sync_package_zabbix_proxy_lts();
+	</custom_php_resync_config_command>
+	<custom_php_deinstall_command>
+		php_deinstall_zabbix_proxy_lts();
+	</custom_php_deinstall_command>
 </packagegui>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1550,7 +1550,7 @@
 		<website>http://www.zabbix.com/product.php</website>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/zabbix-proxy-lts/zabbix-proxy-lts.xml</config_file>
-		<version>0.8.5</version>
+		<version>0.8.6</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<configurationfile>zabbix-proxy-lts.xml</configurationfile>


### PR DESCRIPTION
zabbix-proxy-lts.xml
- Fix copyright header
- Fix file permissions
- Nuke unused/useless tags
- Move advanced options to advancedfield

zabbix-proxy-lts.inc
- Fix copyright header
- Code style and allignment fixes
- Remove unused php_install_zabbix_proxy_lts() function
- Use stop_service()/restart_service()
