### PR TITLE
zabbix-agent-lts - code style cleanup

### DIFF
--- a/config/zabbix-agent-lts/zabbix-agent-lts.inc
+++ b/config/zabbix-agent-lts/zabbix-agent-lts.inc
@@ -79,7 +79,7 @@ function validate_input_zabbix_agent_lts($post, &$input_errors) {
 		if ($post['listenport'] != '') {
 			if (!is_numericint($post['listenport'])) {
 				$input_errors[] = "'Listen Port' value is not numeric.";
-			} elseif ($post['buffersize'] < 1 || $post['buffersize'] > 65535) {
+			} elseif ($post['listenport'] < 1 || $post['listenport'] > 65535) {
 				$input_errors[] = "You must enter a valid value for 'Listen Port'.";
 			}
 		}

--- a/config/zabbix-agent-lts/zabbix-agent-lts.inc
+++ b/config/zabbix-agent-lts/zabbix-agent-lts.inc
@@ -1,159 +1,149 @@
 <?php
-/* $Id$ */
-/* ========================================================================== */
 /*
-    zabbix-agent-lts.inc
-    part of the Zabbix package for pfSense
-    Copyright (C) 2013 Danilo G. Baio
-    Copyright (C) 2013 Marcello Coutinho
+	zabbix-agent-lts.inc
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013 Danilo G. Baio
+	Copyright (C) 2013 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-    All rights reserved.            
-			                                                                  */
-/* ========================================================================== */
-/*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
 require_once("util.inc");
 require_once("functions.inc");
 require_once("pkg-utils.inc");
 require_once("globals.inc");
 
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
+$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
 if ($pf_version == "2.1" || $pf_version == "2.2") {
 	define('ZABBIX_AGENT_BASE', '/usr/pbi/zabbix22-agent-' . php_uname("m"));
 } else {
 	define('ZABBIX_AGENT_BASE', '/usr/local');
 }
 
-function php_install_zabbix_agent_lts(){
-	sync_package_zabbix_agent_lts();	
-}
+function php_deinstall_zabbix_agent_lts() {
+	conf_mount_rw();
 
-function php_deinstall_zabbix_agent_lts(){
-   global $config, $g;
-
-   conf_mount_rw();
-
-   exec("/usr/bin/killall zabbix_agentd");
-   unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/rc.d/zabbix_agentd_lts.sh");
-   unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/zabbix22/zabbix_agentd.conf");
-   unlink_if_exists("/var/log/zabbix-agent-lts/zabbix_agentd_lts.log");
-   unlink_if_exists("/var/run/zabbix-agent-lts/zabbix_agentd_lts.pid");
+	stop_service("zabbix_agentd_lts");
+	unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/rc.d/zabbix_agentd_lts.sh");
+	unlink_if_exists(ZABBIX_AGENT_BASE . "/etc/zabbix22/zabbix_agentd.conf");
+	unlink_if_exists("/var/log/zabbix-agent-lts/zabbix_agentd_lts.log");
+	unlink_if_exists("/var/run/zabbix-agent-lts/zabbix_agentd_lts.pid");
 
 	if (is_dir("/var/log/zabbix-agent-lts")) {
-		exec("/bin/rm -r /var/log/zabbix-agent-lts/");
+		mwexec("/bin/rm -rf /var/log/zabbix-agent-lts/");
 	}
-
 	if (is_dir("/var/run/zabbix-agent-lts")) {
-		exec("/bin/rm -r /var/run/zabbix-agent-lts/");
+		mwexec("/bin/rm -rf /var/run/zabbix-agent-lts/");
 	}
 
-   conf_mount_ro();
+	conf_mount_ro();
 }
 
-function validate_input_zabbix_agent_lts($post, &$input_errors){
+function validate_input_zabbix_agent_lts($post, &$input_errors) {
 
 	if (isset($post['agentenabled'])) {
 		if (!preg_match("/\w+/", $post['server'])) {
-			$input_errors[]='Server field is required.';
+			$input_errors[] = "Server field is required.";
 		}
-		
+
 		if (!preg_match("/\w+/", $post['hostname'])) {
-			$input_errors[]='Hostname field is required.';
+			$input_errors[] = "Hostname field is required.";
 		}
-	
+
 		if ($post['listenip'] != '') {
-			if (!is_ipaddr_configured($post['listenip']) && !preg_match("/(127.0.0.1|0.0.0.0)/",$post['listenip'])) {
-				$input_errors[]='Listen IP is not a configured IP address.';
+			if (!is_ipaddr_configured($post['listenip']) && !preg_match("/(127.0.0.1|0.0.0.0)/", $post['listenip'])) {
+				$input_errors[] = "'Listen IP' is not a configured IP address.";
 			}
 		}
 
 		if ($post['listenport'] != '') {
-			if (!preg_match("/^\d+$/", $post['listenport'])) {
-				$input_errors[]='Listen Port is not numeric.';
-			}	
+			if (!is_numericint($post['listenport'])) {
+				$input_errors[] = "'Listen Port' value is not numeric.";
+			} elseif ($post['buffersize'] < 1 || $post['buffersize'] > 65535) {
+				$input_errors[] = "You must enter a valid value for 'Listen Port'.";
+			}
 		}
 
 		if ($post['refreshactchecks'] != '') {
-			if (!preg_match("/^\d+$/", $post['refreshactchecks'])) {
-				$input_errors[]='Refresh Active Checks is not numeric.';
-			} elseif ( $post['refreshactchecks'] < 60 || $post['refreshactchecks'] > 3600 ) {
-				$input_errors[]='You must enter a valid value for \'Refresh Active Checks\'';
+			if (!is_numericint($post['refreshactchecks'])) {
+				$input_errors[] = "'Refresh Active Checks' value is not numeric.";
+			} elseif ($post['refreshactchecks'] < 60 || $post['refreshactchecks'] > 3600) {
+				$input_errors[] = "You must enter a valid value for 'Refresh Active Checks'.";
 			}
 		}
 
 		if ($post['timeout'] != '') {
 			if (!is_numericint($post['timeout'])) {
-				$input_errors[]='Timeout is not numeric.';
-			} elseif ( $post['timeout'] < 1 || $post['timeout'] > 30 ) {
-				$input_errors[]='You must enter a valid value for \'Timeout\'';
+				$input_errors[] = "Timeout value is not numeric.";
+			} elseif ($post['timeout'] < 1 || $post['timeout'] > 30) {
+				$input_errors[] = "You must enter a valid value for 'Timeout'.";
 			}
 		}
-	
+
 		if ($post['buffersend'] != '') {
 			if (!is_numericint($post['buffersend'])) {
-				$input_errors[]='Buffer Send is not numeric.';
-			} elseif ( $post['buffersend'] < 1 || $post['buffersend'] > 3600 ) {
-				$input_errors[]='You must enter a valid value for \'Buffer Send\'';
+				$input_errors[] = "'Buffer Send' value is not numeric.";
+			} elseif ($post['buffersend'] < 1 || $post['buffersend'] > 3600) {
+				$input_errors[] = "You must enter a valid value for 'Buffer Send'.";
 			}
 		}
-		
+
 		if ($post['buffersize'] != '') {
 			if (!is_numericint($post['buffersize'])) {
-				$input_errors[]='Bufer Size is not numeric.';
-			} elseif ( $post['buffersize'] < 2 || $post['buffersize'] > 65535 ) {
-				$input_errors[]='You must enter a valid value for \'Buffer Size\'';
+				$input_errors[] = "'Buffer Size' value is not numeric.";
+			} elseif ($post['buffersize'] < 2 || $post['buffersize'] > 65535) {
+				$input_errors[] = "You must enter a valid value for 'Buffer Size'.";
 			}
 		}
-		
+
 		if ($post['startagents'] != '') {
 			if (!is_numericint($post['startagents'])) {
-				$input_errors[]='Start Agents is not numeric.';
-			} elseif ( $post['startagents'] < 0 || $post['startagents'] > 100 ) {
-				$input_errors[]='You must enter a valid value for \'Start Agents\'';
+				$input_errors[] = "'Start Agents' value is not numeric.";
+			} elseif ($post['startagents'] < 0 || $post['startagents'] > 100) {
+				$input_errors[] = "You must enter a valid value for 'Start Agents'.";
 			}
 		}
-	}	
+	}
 }
 
-function sync_package_zabbix_agent_lts(){
+function sync_package_zabbix_agent_lts() {
 	global $config, $g;
 
 	conf_mount_rw();
 
-	/* check zabbix agent settings*/
-	if (is_array($config['installedpackages']['zabbixagentlts'])){
+	// Check Zabbix Agent settings
+	if (is_array($config['installedpackages']['zabbixagentlts'])) {
 		$zbagent_config = $config['installedpackages']['zabbixagentlts']['config'][0];
-		if ($zbagent_config['agentenabled']=="on"){
-			$RefreshActChecks=(preg_match("/(\d+)/",$zbagent_config['refreshactchecks'],$matches)? $matches[1] : "120");
-			$BufferSend=(preg_match("/(\d+)/",$zbagent_config['buffersend'],$matches)? $matches[1]  : "5"  );
-			$BufferSize=(preg_match("/(\d+)/",$zbagent_config['buffersize'],$matches)? $matches[1]  : "100");
-			$StartAgents=(preg_match("/(\d+)/",$zbagent_config['startagents'],$matches)? $matches[1] :"3" );
-			$UserParams=base64_decode($zbagent_config['userparams']);
-			$ListenIp=($zbagent_config['listenip'] != ''? $zbagent_config['listenip'] : "0.0.0.0");
-			$ListenPort=($zbagent_config['listenport'] != ''? $zbagent_config['listenport'] : "10050");
-			$TimeOut=($zbagent_config['timeout'] != ''? $zbagent_config['timeout'] : "3");
-	
+		if ($zbagent_config['agentenabled'] == "on") {
+			$RefreshActChecks = (preg_match("/(\d+)/", $zbagent_config['refreshactchecks'], $matches)? $matches[1] : "120");
+			$BufferSend = (preg_match("/(\d+)/", $zbagent_config['buffersend'], $matches) ? $matches[1] : "5");
+			$BufferSize = (preg_match("/(\d+)/", $zbagent_config['buffersize'], $matches) ? $matches[1] : "100");
+			$StartAgents = (preg_match("/(\d+)/", $zbagent_config['startagents'], $matches) ? $matches[1] : "3");
+			$UserParams = base64_decode($zbagent_config['userparams']);
+			$ListenIp = $zbagent_config['listenip'] ?: "0.0.0.0";
+			$ListenPort = $zbagent_config['listenport'] ?: "10050";
+			$TimeOut = $zbagent_config['timeout'] ?: "3";
+
 			$zbagent_conf_file = <<< EOF
 Server={$zbagent_config['server']}
 ServerActive={$zbagent_config['serveractive']}
@@ -172,33 +162,35 @@ StartAgents={$StartAgents}
 {$UserParams}
 
 EOF;
-		file_put_contents(ZABBIX_AGENT_BASE . "/etc/zabbix22/zabbix_agentd.conf",  strtr($zbagent_conf_file, array("\r" => "")));
+			file_put_contents(ZABBIX_AGENT_BASE . "/etc/zabbix22/zabbix_agentd.conf", strtr($zbagent_conf_file, array("\r" => "")));
 		}
 	}
+
 	$want_sysctls = array(
 		'kern.ipc.shmall' => '2097152',
 		'kern.ipc.shmmax' => '2147483648',
 		'kern.ipc.semmsl' => '250'
 	);
 	$sysctls = array();
-	#check sysctl file values
+	// Check sysctl file values
 	$sc_file="";
 	if (file_exists("/etc/sysctl.conf")) {
 		$sc = file("/etc/sysctl.conf");
 		foreach ($sc as $line) {
 			list($sysk, $sysv) = explode("=", $line, 2);
-			if (preg_match("/\w/",$line) && !array_key_exists($sysk, $want_sysctls))
-				$sc_file.=$line;
+			if (preg_match("/\w/", $line) && !array_key_exists($sysk, $want_sysctls)) {
+				$sc_file .= $line;
 			}
+		}
 	}
-	foreach ($want_sysctls as $ws=> $wv) {
+	foreach ($want_sysctls as $ws => $wv) {
 		$sc_file .= "{$ws}={$wv}\n";
-		exec("/sbin/sysctl {$ws}={$wv}");
+		mwexec("/sbin/sysctl {$ws}={$wv}");
 	}
 	file_put_contents("/etc/sysctl.conf", $sc_file);
 
-	#check bootloader values
-	$lt_file="";
+	// Check bootloader values
+	$lt_file = "";
 	$want_tunables = array(
 		'kern.ipc.semopm' => '100',
 		'kern.ipc.semmni' => '128',
@@ -210,61 +202,62 @@ EOF;
 		$lt = file("/boot/loader.conf");
 		foreach ($lt as $line) {
 			list($tunable, $val) = explode("=", $line, 2);
-			if (preg_match("/\w/",$line) && !array_key_exists($tunable, $want_tunables))
-				$lt_file.=$line;
+			if (preg_match("/\w/", $line) && !array_key_exists($tunable, $want_tunables)) {
+				$lt_file .= $line;
+			}
 		}
 	}
 	foreach ($want_tunables as $wt => $wv) {
-		$lt_file.= "{$wt}={$wv}\n";
+		$lt_file .= "{$wt}={$wv}\n";
 	}
 	file_put_contents("/boot/loader.conf", $lt_file);
 
-	/*check startup script files*/
-	/* create a few directories and ensure the sample files are in place */
-	if (!is_dir(ZABBIX_AGENT_BASE . "/etc/zabbix22"))
-		exec("/bin/mkdir -p " . ZABBIX_AGENT_BASE . "/etc/zabbix22");
+	// Check startup script files
+	// Create a few directories and ensure the sample files are in place
+	if (!is_dir(ZABBIX_AGENT_BASE . "/etc/zabbix22")) {
+		mwexec("/bin/mkdir -p " . ZABBIX_AGENT_BASE . "/etc/zabbix22");
+	}
 
-	$dir_checks  = <<< EOF
-if [ ! -d /var/log/zabbix-agent-lts ]
- then
- /bin/mkdir -p /var/log/zabbix-agent-lts
- /usr/sbin/chmod 755 /var/log/zabbix-agent-lts
- fi
-/usr/sbin/chown -R zabbix:zabbix /var/log/zabbix-agent-lts
+	$dir_checks = <<< EOF
 
-if [ ! -d /var/run/zabbix-agent-lts ]
- then
- /bin/mkdir -p /var/run/zabbix-agent-lts
- /usr/sbin/chmod 755 /var/run/zabbix-agent-lts
- fi
-/usr/sbin/chown -R zabbix:zabbix /var/run/zabbix-agent-lts
+	if [ ! -d /var/log/zabbix-agent-lts ]; then
+		/bin/mkdir -p /var/log/zabbix-agent-lts
+		/usr/sbin/chmod 755 /var/log/zabbix-agent-lts
+	fi
+	/usr/sbin/chown -R zabbix:zabbix /var/log/zabbix-agent-lts
+
+	if [ ! -d /var/run/zabbix-agent-lts ]; then
+		/bin/mkdir -p /var/run/zabbix-agent-lts
+		/usr/sbin/chmod 755 /var/run/zabbix-agent-lts
+	fi
+	/usr/sbin/chown -R zabbix:zabbix /var/run/zabbix-agent-lts
 
 EOF;
- 
-	$zagent_rcfile="/usr/local/etc/rc.d/zabbix_agentd_lts.sh";
-	if (is_array($zbagent_config) && $zbagent_config['agentenabled']=="on"){
+
+	$zagent_rcfile = "/usr/local/etc/rc.d/zabbix_agentd_lts.sh";
+	if (is_array($zbagent_config) && $zbagent_config['agentenabled'] == "on") {
 		$zagent_start .= strtr($dir_checks, array("\r" => "")). "\necho \"Starting Zabbix Agent LTS...\"\n";
 		$zagent_start .= ZABBIX_AGENT_BASE . "/sbin/zabbix_agentd\n";
-	
-		$zagent_stop  = "echo \"Stopping Zabbix Agent LTS...\"\n";
+
+		$zagent_stop = "echo \"Stopping Zabbix Agent LTS...\"\n";
 		$zagent_stop .= "/usr/bin/killall zabbix_agentd\n";
 		$zagent_stop .= "/bin/sleep 5\n";
-	
-		/* write out rc.d start/stop file */
+
+		// write out rc.d start/stop file
 		write_rcfile(array(
-						"file" => "zabbix_agentd_lts.sh",
-						"start" => "$zagent_start",
-						"stop" => "$zagent_stop"
-				)
+			"file" => "zabbix_agentd_lts.sh",
+			"start" => "$zagent_start",
+			"stop" => "$zagent_stop"
+			)
 		);
-		mwexec("{$zagent_rcfile} restart");	
-	}else{
-		if (file_exists($zagent_rcfile)){
-		mwexec("{$zagent_rcfile} stop");
-		unlink($zagent_rcfile);
+		restart_service("zabbix_agentd_lts");
+	} else {
+		if (is_service_running("zabbix_agentd_lts")) {
+			stop_service("zabbix_agentd_lts");
 		}
+		unlink_if_exists($zagent_rcfile);
 	}
-		
+
 	conf_mount_ro();
 }
 

--- a/config/zabbix-agent-lts/zabbix-agent-lts.xml
+++ b/config/zabbix-agent-lts/zabbix-agent-lts.xml
@@ -1,54 +1,57 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-<copyright>
+	<copyright>
 	<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    zabbix-agent-lts.xml
-    part of the Zabbix package for pfSense
-    Copyright (C) 2013 Danilo G. Baio
-    Copyright (C) 2013 Marcello Coutinho
-	
-    All rights reserved.            
-			                                                                  */
-/* ========================================================================== */
+	zabbix-agent-lts.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013 Danilo G. Baio
+	Copyright (C) 2013 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
 	]]>
 	</copyright>
 	<name>zabbixagentlts</name>
 	<title>Services: Zabbix Agent LTS</title>
 	<category>Monitoring</category>
-	<version>0.8.5</version>
+	<version>0.8.6</version>
 	<include_file>/usr/local/pkg/zabbix-agent-lts.inc</include_file>
 	<addedit_string>Zabbix Agent LTS has been created/modified.</addedit_string>
 	<delete_string>Zabbix Agent LTS has been deleted.</delete_string>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/zabbix-agent-lts/zabbix-agent-lts.inc</item>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<menu>
 		<name>Zabbix Agent LTS</name>
@@ -60,7 +63,7 @@
 		<name>zabbix_agentd_lts</name>
 		<rcfile>zabbix_agentd_lts.sh</rcfile>
 		<executable>zabbix_agentd</executable>
-		<description>Zabbix Agent LTS host monitor daemon</description>
+		<description>Zabbix Agent LTS Host Monitor Daemon</description>
 	</service>
 	<tabs>
 		<tab>
@@ -69,6 +72,7 @@
 			<active />
 		</tab>
 	</tabs>
+	<advanced_options>enabled</advanced_options>
 	<fields>
 		<field>
 			<name>Zabbix Agent LTS Settings</name>
@@ -77,27 +81,27 @@
 		<field>
 			<fielddescr>Enable</fielddescr>
 			<fieldname>agentenabled</fieldname>
-			<description>Enable Zabbix Agent LTS service</description>
+			<description>Enable Zabbix Agent LTS service.</description>
 			<type>checkbox</type>
 		</field>
 		<field>
 			<fielddescr>Server</fielddescr>
 			<fieldname>server</fieldname>
-			<description>List of comma delimited IP addresses (or hostnames) of ZABBIX servers</description>
+			<description>List of comma delimited IP addresses (or hostnames) of ZABBIX servers.</description>
 			<type>input</type>
 			<size>60</size>
 		</field>
 		<field>
 			<fielddescr>Server Active</fielddescr>
 			<fieldname>serveractive</fieldname>
-			<description>List of comma delimited IP:port (or hostname:port) pairs of Zabbix servers for active checks</description>
+			<description>List of comma delimited IP:port (or hostname:port) pairs of Zabbix servers for active checks.</description>
 			<type>input</type>
 			<size>60</size>
 		</field>
 		<field>
 			<fielddescr>Hostname</fielddescr>
 			<fieldname>hostname</fieldname>
-			<description>Unique hostname. Required for active checks and must match hostname as configured on the Zabbix server (case sensitive).</description>
+			<description>Unique, case sensitive hostname. Required for active checks and must match hostname as configured on the Zabbix server.</description>
 			<type>input</type>
 			<size>60</size>
 		</field>
@@ -107,7 +111,7 @@
 			<default_value>0.0.0.0</default_value>
 			<type>input</type>
 			<size>60</size>
-			<description>Listen IP for connections from the server (default 0.0.0.0 for all interfaces)</description>
+			<description>Listen IP for connections from the server. (Default: 0.0.0.0 - all interfaces)</description>
 		</field>
 		<field>
 			<fielddescr>Listen Port</fielddescr>
@@ -115,7 +119,7 @@
 			<default_value>10050</default_value>
 			<type>input</type>
 			<size>5</size>
-			<description>Listen port for connections from the server (default 10050)</description>
+			<description>Listen port for connections from the server. (Default: 10050)</description>
 		</field>
 		<field>
 			<fielddescr>Refresh Active Checks</fielddescr>
@@ -123,7 +127,7 @@
 			<default_value>120</default_value>
 			<type>input</type>
 			<size>5</size>
-			<description>The agent will refresh list of active checks once per 120 (default) seconds.</description>
+			<description>The agent will refresh list of active checks once per this number of seconds. (Default: 120)</description>
 		</field>
 		<field>
 			<fielddescr>Timeout</fielddescr>
@@ -131,7 +135,13 @@
 			<default_value>3</default_value>
 			<type>input</type>
 			<size>5</size>
-			<description>Timeout (default 3). Do not spend more that Timeout seconds on getting requested value (1-30). The agent does not kill timeouted User Parameters processes!</description>
+			<description>
+				<![CDATA[
+				Do not spend more that N seconds on getting requested value.<br />
+				Note: The agent does not kill timeouted User Parameters processes!<br />
+				(Default: 3. Valid range: 1-30)
+				]]>
+			</description>
 		</field>
 		<field>
 			<fielddescr>Buffer Send</fielddescr>
@@ -139,7 +149,12 @@
 			<default_value>5</default_value>
 			<type>input</type>
 			<size>5</size>
-			<description>Buffer Send (default 5). Do not keep data longer than N seconds in buffer (1-3600).</description>
+			<description>
+				<![CDATA[
+				Do not keep data longer than N seconds in buffer.<br />
+				(Default: 5. Valid range: 1-3600)
+				]]>
+			</description>
 		</field>
 		<field>
 			<fielddescr>Buffer Size</fielddescr>
@@ -147,7 +162,12 @@
 			<default_value>100</default_value>
 			<type>input</type>
 			<size>5</size>
-			<description>Buffer Size (default 100). Maximum number of values in a memory buffer (2-65535). The agent will send all collected data to Zabbix server or proxy if the buffer is full.</description>
+			<description>
+				<![CDATA[
+				Maximum number of values in the memory buffer. The agent will send all collected data to Zabbix server or proxy if the buffer is full.<br />
+				(Default: 100. Valid range: 2-65535)
+				]]>
+			</description>
 		</field>
 		<field>
 			<fielddescr>Start Agents</fielddescr>
@@ -155,7 +175,13 @@
 			<default_value>3</default_value>
 			<type>input</type>
 			<size>5</size>
-			<description>Start Agents (default 3). Number of pre-forked instances of zabbix_agentd that process passive checks (0-100).If set to 0, disables passive checks and the agent will not listen on any TCP port.</description>
+			<description>
+				<![CDATA[
+				Number of pre-forked instances of zabbix_agentd that process passive checks.<br />
+				Note: Setting to 0 disables passive checks and the agent will not listen on any TCP port.<br />
+				(Default: 3. Valid range: 0-100)
+				]]>
+			</description>
 		</field>
 		<field>
 			<fielddescr>User Parameters</fielddescr>
@@ -164,15 +190,25 @@
 			<type>textarea</type>
 			<rows>5</rows>
 			<cols>50</cols>
-			<description>User-defined parameter to monitor. There can be several user-defined parameters. Value has form, example: UserParameter=users,who|wc -l</description>
+			<description>
+				<![CDATA[
+				User-defined parameter(s) to monitor. There can be multiple user-defined parameters.<br />
+				Example: <em>UserParameter=users,who|wc -l</em>
+				]]>
+			</description>
+			<advancedfield/>
 		</field>
 	</fields>
-	<custom_php_install_command>sync_package_zabbix_agent_lts();</custom_php_install_command>
-	<custom_php_command_before_form></custom_php_command_before_form>
-	<custom_php_after_head_command></custom_php_after_head_command>
-	<custom_php_after_form_command></custom_php_after_form_command>
-	<custom_php_validation_command>validate_input_zabbix_agent_lts($_POST, $input_errors);</custom_php_validation_command>
-	<custom_add_php_command></custom_add_php_command>
-	<custom_php_resync_config_command>sync_package_zabbix_agent_lts();</custom_php_resync_config_command>
-	<custom_php_deinstall_command>php_deinstall_zabbix_agent_lts();</custom_php_deinstall_command>
+	<custom_php_install_command>
+		sync_package_zabbix_agent_lts();
+	</custom_php_install_command>
+	<custom_php_validation_command>
+		validate_input_zabbix_agent_lts($_POST, $input_errors);
+	</custom_php_validation_command>
+	<custom_php_resync_config_command>
+		sync_package_zabbix_agent_lts();
+	</custom_php_resync_config_command>
+	<custom_php_deinstall_command>
+		php_deinstall_zabbix_agent_lts();
+	</custom_php_deinstall_command>
 </packagegui>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1523,7 +1523,7 @@
 		<website>http://www.zabbix.com/product.php</website>
 		<category>Services</category>
 		<config_file>https://packages.pfsense.org/packages/config/zabbix-agent-lts/zabbix-agent-lts.xml</config_file>
-		<version>0.8.5</version>
+		<version>0.8.6</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<configurationfile>zabbix-agent-lts.xml</configurationfile>


### PR DESCRIPTION
zabbix-agent-lts.xml
- Fix copyright header
- Fix file permissions
- Nuke unused/useless tags
- Improve some descriptions.
- Move User Parameters to advancedfield

zabbix-agent-lts.inc
- Fix copyright header
- Code style and allignment fixes
- Remove unused php_install_zabbix_agent_lts() function
- Use stop_service()/restart_service()
- Use mwexec() instead of exec()
- Improve some input validations