### PR TITLE
Altered OpenVPN Client Export

### DIFF
--- a/config/openvpn-client-export/openvpn-client-export.inc
+++ b/config/openvpn-client-export/openvpn-client-export.inc
@@ -138,7 +138,15 @@ function openvpn_client_export_validate_config($srvid, $usrid, $crtid) {
 	if (!$server_cert) {
 		$input_errors[] = "Could not locate server certificate.";
 	} else {
+<<<<<<< Updated upstream
 		$server_ca = lookup_ca($server_cert['caref']);
+=======
+		/*
+			Replaced lookup_ca($server_cert['caref']) with ca_chain($server_cert). Note that ca_chain returns a string of Base64 encoded certificates, not an array. 
+			Thus, all references to base64_decode($server_ca['crt']) have been replaced with simply $server_ca
+		*/
+		$server_ca = ca_chain($server_cert); 
+>>>>>>> Stashed changes
 		if (!$server_ca) {
 			$input_errors[] = "Could not locate the CA reference for the server certificate.";
 		}

--- a/config/openvpn-client-export/openvpn-client-export.inc
+++ b/config/openvpn-client-export/openvpn-client-export.inc
@@ -138,11 +138,7 @@ function openvpn_client_export_validate_config($srvid, $usrid, $crtid) {
 	if (!$server_cert) {
 		$input_errors[] = "Could not locate server certificate.";
 	} else {
-		/*
-			Replaced lookup_ca() with ca_chain(). Note that ca_chain returns a string of Base64 encoded certificates, not an array. 
-			Thus, all references to base64_decode($server_ca['crt']) have been replaced with simply $server_ca
-		*/
-		$server_ca = lookup_ca($server_cert['caref']); 
+		$server_ca = lookup_ca($server_cert['caref']);
 		if (!$server_ca) {
 			$input_errors[] = "Could not locate the CA reference for the server certificate.";
 		}
@@ -395,7 +391,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 			file_put_contents("{$tempdir}/{$prefix}.ovpn", $conf);
 
 			$cafile = "{$tempdir}/{$cafile}";
-			file_put_contents("{$cafile}", $server_ca);
+			file_put_contents("{$cafile}", base64_decode($server_ca['crt']));
 			if ($settings['tls']) {
 				$tlsfile = "{$tempdir}/{$prefix}-tls.key";
 				file_put_contents($tlsfile, base64_decode($settings['tls']));
@@ -429,7 +425,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 		case "inlinedroid":
 		case "inlineios":
 			// Inline CA
-			$conf .= "<ca>{$nl}" . trim($server_ca) . "{$nl}</ca>{$nl}";
+			$conf .= "<ca>{$nl}" . trim(base64_decode($server_ca['crt'])) . "{$nl}</ca>{$nl}";
 			if ($settings['mode'] != "server_user") {
 				// Inline Cert
 				$conf .= "<cert>{$nl}" . trim(base64_decode($cert['crt'])) . "{$nl}</cert>{$nl}";
@@ -457,7 +453,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 			file_put_contents("{$tempdir}/vpn.cnf", $conf);
 
 			$cafile = "{$keydir}/ca.crt";
-			file_put_contents("{$cafile}", $server_ca);
+			file_put_contents("{$cafile}", base64_decode($server_ca['crt']));
 			if ($settings['tls']) {
 				$tlsfile = "{$keydir}/ta.key";
 				file_put_contents($tlsfile, base64_decode($settings['tls']));
@@ -483,7 +479,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 			file_put_contents("{$tempdir}/vpn.cnf", $conf);
 
 			$cafile = "{$tempdir}/ca.crt";
-			file_put_contents("{$cafile}", $server_ca);
+			file_put_contents("{$cafile}", base64_decode($server_ca['crt']));
 			if ($settings['tls']) {
 				$tlsfile = "{$tempdir}/ta.key";
 				file_put_contents($tlsfile, base64_decode($settings['tls']));
@@ -576,7 +572,7 @@ function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $veri
 	file_put_contents($cfgfile, $conf);
 
 	$cafile = "{$tempdir}/config/{$prefix}-ca.crt";
-	file_put_contents($cafile, $server_ca);
+	file_put_contents($cafile, base64_decode($server_ca['crt']));
 	if ($settings['tls']) {
 		$tlsfile = "{$tempdir}/config/{$prefix}-tls.key";
 		file_put_contents($tlsfile, base64_decode($settings['tls']));
@@ -712,7 +708,7 @@ EOF;
 
 	// write ca
 	$cafile = "{$tempdir}/ca.crt";
-	file_put_contents($cafile, $server_ca);
+	file_put_contents($cafile, base64_decode($server_ca['crt']));
 
 	if ($settings['mode'] != "server_user") {
 

--- a/config/openvpn-client-export/openvpn-client-export.inc
+++ b/config/openvpn-client-export/openvpn-client-export.inc
@@ -138,7 +138,11 @@ function openvpn_client_export_validate_config($srvid, $usrid, $crtid) {
 	if (!$server_cert) {
 		$input_errors[] = "Could not locate server certificate.";
 	} else {
-		$server_ca = lookup_ca($server_cert['caref']);
+		/*
+			Replaced lookup_ca() with ca_chain(). Note that ca_chain returns a string of Base64 encoded certificates, not an array. 
+			Thus, all references to base64_decode($server_ca['crt']) have been replaced with simply $server_ca
+		*/
+		$server_ca = lookup_ca($server_cert['caref']); 
 		if (!$server_ca) {
 			$input_errors[] = "Could not locate the CA reference for the server certificate.";
 		}
@@ -391,7 +395,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 			file_put_contents("{$tempdir}/{$prefix}.ovpn", $conf);
 
 			$cafile = "{$tempdir}/{$cafile}";
-			file_put_contents("{$cafile}", base64_decode($server_ca['crt']));
+			file_put_contents("{$cafile}", $server_ca);
 			if ($settings['tls']) {
 				$tlsfile = "{$tempdir}/{$prefix}-tls.key";
 				file_put_contents($tlsfile, base64_decode($settings['tls']));
@@ -425,7 +429,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 		case "inlinedroid":
 		case "inlineios":
 			// Inline CA
-			$conf .= "<ca>{$nl}" . trim(base64_decode($server_ca['crt'])) . "{$nl}</ca>{$nl}";
+			$conf .= "<ca>{$nl}" . trim($server_ca) . "{$nl}</ca>{$nl}";
 			if ($settings['mode'] != "server_user") {
 				// Inline Cert
 				$conf .= "<cert>{$nl}" . trim(base64_decode($cert['crt'])) . "{$nl}</cert>{$nl}";
@@ -453,7 +457,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 			file_put_contents("{$tempdir}/vpn.cnf", $conf);
 
 			$cafile = "{$keydir}/ca.crt";
-			file_put_contents("{$cafile}", base64_decode($server_ca['crt']));
+			file_put_contents("{$cafile}", $server_ca);
 			if ($settings['tls']) {
 				$tlsfile = "{$keydir}/ta.key";
 				file_put_contents($tlsfile, base64_decode($settings['tls']));
@@ -479,7 +483,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 			file_put_contents("{$tempdir}/vpn.cnf", $conf);
 
 			$cafile = "{$tempdir}/ca.crt";
-			file_put_contents("{$cafile}", base64_decode($server_ca['crt']));
+			file_put_contents("{$cafile}", $server_ca);
 			if ($settings['tls']) {
 				$tlsfile = "{$tempdir}/ta.key";
 				file_put_contents($tlsfile, base64_decode($settings['tls']));
@@ -572,7 +576,7 @@ function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $veri
 	file_put_contents($cfgfile, $conf);
 
 	$cafile = "{$tempdir}/config/{$prefix}-ca.crt";
-	file_put_contents($cafile, base64_decode($server_ca['crt']));
+	file_put_contents($cafile, $server_ca);
 	if ($settings['tls']) {
 		$tlsfile = "{$tempdir}/config/{$prefix}-tls.key";
 		file_put_contents($tlsfile, base64_decode($settings['tls']));
@@ -708,7 +712,7 @@ EOF;
 
 	// write ca
 	$cafile = "{$tempdir}/ca.crt";
-	file_put_contents($cafile, base64_decode($server_ca['crt']));
+	file_put_contents($cafile, $server_ca);
 
 	if ($settings['mode'] != "server_user") {
 

--- a/config/openvpn-client-export/openvpn-client-export.xml
+++ b/config/openvpn-client-export/openvpn-client-export.xml
@@ -44,7 +44,7 @@
 	]]>
 	</copyright>
 	<name>OpenVPN Client Export</name>
-	<version>1.2.19</version>
+	<version>1.2.20</version>
 	<title>OpenVPN Client Export</title>
 	<include_file>/usr/local/pkg/openvpn-client-export.inc</include_file>
 	<tabs>


### PR DESCRIPTION
I altered OpenVPN Client Export to include entire CA chain when exporting, rather than just the server certificate's immediate CA. This corrects issues were exported configurations fail due to the server's cert being issued by an intermediate CA. (See: https://redmine.pfsense.org/issues/4934)

This change works as expected for my use case (where the server's certificate is the child of an intermediate certificate) but has not been tested when the server's certificate is the direct child of a CA, or when the server's certificate is itself a CA.