### PR TITLE
Remove useless log spam

### DIFF
--- a/config/nut/nut.inc
+++ b/config/nut/nut.inc
@@ -518,9 +518,6 @@ EOD;
 
 			log_error("[nut] INFO: Starting service");
 			start_service("nut");
-			if (!is_process_running('upsmon')) {
-				log_error("[nut] ERROR: Service failed to start: check configuration.");
-			}
 		} elseif (!$return && file_exists(NUT_RCFILE)) {
 			/* no parameters user does not want nut running */
 			/* lets stop the service and remove the rc file */

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -814,7 +814,7 @@
 		<descr>Network UPS Tools.</descr>
 		<website>http://www.networkupstools.org/</website>
 		<category>Network Management</category>
-		<version>2.0.7</version>
+		<version>2.0.8</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<maintainer>rswagoner@gmail.com</maintainer>


### PR DESCRIPTION
NUT takes quite some time to launch (notably with networked UPS); this creates misleading log entries confusing users.