### PR TITLE
autoconfigbackup - code style fixes

### DIFF
--- a/config/autoconfigbackup/autoconfigbackup.inc
+++ b/config/autoconfigbackup/autoconfigbackup.inc
@@ -74,9 +74,11 @@ function acb_custom_php_validation_command($post, &$input_errors) {
 }
 
 function acb_custom_php_resync_config_command() {
-	conf_mount_rw();
-	unlink_if_exists("/cf/conf/lastpfSbackup.txt");
-	conf_mount_ro();
+	if (is_file("/cf/conf/lastpfSbackup.txt") {
+		conf_mount_rw();
+		unlink("/cf/conf/lastpfSbackup.txt");
+		conf_mount_ro();
+	}
 	if (!function_exists("filter_configure")) {
 		require_once("filter.inc");
 	}

--- a/config/autoconfigbackup/autoconfigbackup.inc
+++ b/config/autoconfigbackup/autoconfigbackup.inc
@@ -287,4 +287,3 @@ function upload_config($reasonm = "") {
 	}
 }
 
-?>

--- a/config/autoconfigbackup/autoconfigbackup.inc
+++ b/config/autoconfigbackup/autoconfigbackup.inc
@@ -74,7 +74,7 @@ function acb_custom_php_validation_command($post, &$input_errors) {
 }
 
 function acb_custom_php_resync_config_command() {
-	if (is_file("/cf/conf/lastpfSbackup.txt") {
+	if (is_file("/cf/conf/lastpfSbackup.txt")) {
 		conf_mount_rw();
 		unlink("/cf/conf/lastpfSbackup.txt");
 		conf_mount_ro();
@@ -109,7 +109,11 @@ function test_connection($post) {
 	global $savemsg, $config, $g;
 
 	// Do nothing when booting
-	if (platform_booting()) {
+	if (function_exists("platform_booting")) {
+		if (platform_booting()) {
+			return;
+		}
+	} elseif ($g['booting']) {
 		return;
 	}
 

--- a/config/autoconfigbackup/autoconfigbackup.inc
+++ b/config/autoconfigbackup/autoconfigbackup.inc
@@ -163,7 +163,11 @@ function upload_config($reasonm = "") {
 	global $config, $g, $input_errors;
 
 	// Do nothing when booting
-	if (platform_booting()) {
+	if (function_exists("platform_booting")) {
+		if (platform_booting()) {
+			return;
+		}
+	} elseif ($g['booting']) {
 		return;
 	}
 

--- a/config/autoconfigbackup/autoconfigbackup.inc
+++ b/config/autoconfigbackup/autoconfigbackup.inc
@@ -39,7 +39,7 @@ unlink_if_exists("/usr/local/pkg/parse_config/parse_config_upload.inc");
 unlink_if_exists("/usr/local/pkg/parse_config/parse_config_upload.php");
 
 // Ensures patches match
-function custom_php_validation_command($post, &$input_errors) {
+function acb_custom_php_validation_command($post, &$input_errors) {
 	global $_POST, $savemsg, $config;
 
 	if (!$post['username']) {
@@ -71,6 +71,20 @@ function custom_php_validation_command($post, &$input_errors) {
 
 	// We do not need to store this value.
 	unset($_POST['testconnection']);
+}
+
+function acb_custom_php_resync_config_command() {
+	conf_mount_rw();
+	unlink_if_exists("/cf/conf/lastpfSbackup.txt");
+	conf_mount_ro();
+	if (!function_exists("filter_configure")) {
+		require_once("filter.inc");
+	}
+	filter_configure();
+	if ($savemsg) {
+		$savemsg .= "<br/>";
+	}
+	$savemsg .= "A configuration backup has been queued.";
 }
 
 function configure_proxy() {

--- a/config/autoconfigbackup/autoconfigbackup.inc
+++ b/config/autoconfigbackup/autoconfigbackup.inc
@@ -1,69 +1,74 @@
 <?php
-/* $Id$ */
 /*
-    autoconfigbackup.inc
-    Copyright (C) 2008-2014 Electric Sheep Fencing LP  
+	autoconfigbackup.inc
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2008-2015 Electric Sheep Fencing LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require_once("filter.inc");
 require_once("notices.inc");
 
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version < 2.0)
+$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+if ($pf_version < 2.0) {
 	require_once("crypt_acb.php");
+}
 
 // Plugin moved to save only
-if(file_exists("/usr/local/pkg/parse_config/parse_config_upload.inc"))
-	unlink("/usr/local/pkg/parse_config/parse_config_upload.inc");
-if(file_exists("/usr/local/pkg/parse_config/parse_config_upload.php"))
-	unlink("/usr/local/pkg/parse_config/parse_config_upload.php");
+unlink_if_exists("/usr/local/pkg/parse_config/parse_config_upload.inc");
+unlink_if_exists("/usr/local/pkg/parse_config/parse_config_upload.php");
 
-/* ensures patches match */
+// Ensures patches match
 function custom_php_validation_command($post, &$input_errors) {
 	global $_POST, $savemsg, $config;
 
-	if(!$post['username'])
+	if (!$post['username']) {
 		$input_errors[] = "Username is required.";
-
-	if(!$post['password'] or !$post['passwordagain'])
-		$input_errors[] = "The subscription password is required.";
-
-	if(!$post['crypto_password'] or !$post['crypto_password2'])
-		$input_errors[] = "The encryption password is required.";
-
-	if($post['password'] <> $post['passwordagain']) 
-		$input_errors[] = "Sorry, the entered portal.pfsense.org passwords do not match.";
-
-	if($post['crypto_password'] <> $post['crypto_password2']) 
-		$input_errors[] = "Sorry, the entered encryption passwords do not match.";
-
-	if($post['testconnection']) {
-		$status = test_connection($post);
-		if($status) 
-			$savemsg = "Connection to portal.pfsense.org was tested with no errors.";
 	}
-	
+
+	if (!$post['password'] or !$post['passwordagain']) {
+		$input_errors[] = "The subscription password is required.";
+	}
+
+	if (!$post['crypto_password'] or !$post['crypto_password2']) {
+		$input_errors[] = "The encryption password is required.";
+	}
+
+	if ($post['password'] <> $post['passwordagain']) {
+		$input_errors[] = "Sorry, the entered portal.pfsense.org passwords do not match.";
+	}
+
+	if ($post['crypto_password'] <> $post['crypto_password2']) {
+		$input_errors[] = "Sorry, the entered encryption passwords do not match.";
+	}
+
+	if ($post['testconnection']) {
+		$status = test_connection($post);
+		if ($status) {
+			$savemsg = "Connection to portal.pfsense.org was tested with no errors.";
+		}
+	}
+
 	// We do not need to store this value.
 	unset($_POST['testconnection']);
 }
@@ -73,8 +78,9 @@ function configure_proxy() {
 	$ret = array();
 	if (!empty($config['system']['proxyurl'])) {
 		$ret[CURLOPT_PROXY] = $config['system']['proxyurl'];
-		if (!empty($config['system']['proxyport']))
+		if (!empty($config['system']['proxyport'])) {
 			$ret[CURLOPT_PROXYPORT] = $config['system']['proxyport'];
+		}
 		if (!empty($config['system']['proxyuser']) && !empty($config['system']['proxypass'])) {
 			$ret[CURLOPT_PROXYAUTH] = CURLAUTH_ANY | CURLAUTH_ANYSAFE;
 			$ret[CURLOPT_PROXYUSERPWD] = "{$config['system']['proxyuser']}:{$config['system']['proxypass']}";
@@ -86,27 +92,28 @@ function configure_proxy() {
 function test_connection($post) {
 	global $savemsg, $config, $g;
 
-	/* do nothing when booting */
-	if($g['booting']) 
+	// Do nothing when booting
+	if (platform_booting()) {
 		return;
+	}
 
 	// Seperator used during client / server communications
-	$oper_sep			= "\|\|";
+	$oper_sep = "\|\|";
 
 	// Encryption password
-	$decrypt_password 	= $post['crypto_password'];
+	$decrypt_password = $post['crypto_password'];
 
 	// Defined username
-	$username			= $post['username'];
+	$username = $post['username'];
 
 	// Defined password
-	$password			= $post['password'];
+	$password = $post['password'];
 
 	// Set hostname
-	$hostname			= $config['system']['hostname'] . "." . $config['system']['domain'];
+	$hostname = $config['system']['hostname'] . "." . $config['system']['domain'];
 
 	// URL to restore.php
-	$get_url			= "https://portal.pfsense.org/pfSconfigbackups/restore.php";
+	$get_url = "https://portal.pfsense.org/pfSconfigbackups/restore.php";
 
 	// Populate available backups
 	$curl_session = curl_init();
@@ -124,29 +131,30 @@ function test_connection($post) {
 	curl_setopt($curl_session, CURLOPT_POSTFIELDS, "action=showbackups&hostname={$hostname}");
 	$data = curl_exec($curl_session);
 
-	if (curl_errno($curl_session)) 
+	if (curl_errno($curl_session)) {
 		return("An error occurred " . curl_error($curl_session));
-	else 
+	} else {
 		curl_close($curl_session);
-
+	}
 	return;
 }
 
 function upload_config($reasonm = "") {
 	global $config, $g, $input_errors;
 
-	/* do nothing when booting */
-	if($g['booting']) 
+	// Do nothing when booting
+	if (platform_booting()) {
 		return;
+	}
 
 	/*
-	 *   pfSense upload config to pfSense.org script
-	 *   This file plugs into config.inc (/usr/local/pkg/parse_config)
-	 *   and runs every time the running firewall filter changes.
-	 * 
+	 * pfSense upload config to pfSense.org script
+	 * This file plugs into config.inc (/usr/local/pkg/parse_config)
+	 * and runs every time the running firewall filter changes.
+	 *
 	 */
-	
-	if(file_exists("/tmp/acb_nooverwrite")) {
+
+	if (file_exists("/tmp/acb_nooverwrite")) {
 		unlink("/tmp/acb_nooverwrite");
 		$nooverwrite = "true";
 	} else {
@@ -154,28 +162,30 @@ function upload_config($reasonm = "") {
 	}
 
 	// Define some needed variables
-	if(file_exists("/cf/conf/lastpfSbackup.txt"))
+	if (file_exists("/cf/conf/lastpfSbackup.txt")) {
 		$last_backup_date = str_replace("\n", "", file_get_contents("/cf/conf/lastpfSbackup.txt"));
-	else
+	} else {
 		$last_backup_date = "";
+	}
 
 	$last_config_change = $config['revision']['time'];
-	$hostname  			= $config['system']['hostname'] . "." . $config['system']['domain'];
-	if($reasonm)
+	$hostname = $config['system']['hostname'] . "." . $config['system']['domain'];
+	if ($reasonm) {
 		$reason = $reasonm;
-	else 
-		$reason	   			= $config['revision']['description'];
-	$username 			= $config['installedpackages']['autoconfigbackup']['config'][0]['username'];
-	$password  			= $config['installedpackages']['autoconfigbackup']['config'][0]['password'];
-	$encryptpw 			= $config['installedpackages']['autoconfigbackup']['config'][0]['crypto_password'];
+	} else {
+		$reason	= $config['revision']['description'];
+	}
+	$username = $config['installedpackages']['autoconfigbackup']['config'][0]['username'];
+	$password = $config['installedpackages']['autoconfigbackup']['config'][0]['password'];
+	$encryptpw = $config['installedpackages']['autoconfigbackup']['config'][0]['crypto_password'];
 
 	// Define upload_url, must be present after other variable definitions due to username, password
 	$upload_url = "https://portal.pfsense.org/pfSconfigbackups/backup.php";
 
-	if(!$username or !$password or !$encryptpw) {
-		if(!file_exists("/cf/conf/autoconfigback.notice")) {
-			$notice_text =  "Either the username, password or encryption password is not set for Automatic Configuration Backup.  ";
-			$notice_text .= "Please correct this in Diagnostics -> AutoConfigBackup -> Settings.";
+	if (!$username or !$password or !$encryptpw) {
+		if (!file_exists("/cf/conf/autoconfigback.notice")) {
+			$notice_text = "Either the username, password or encryption password is not set for Automatic Configuration Backup.";
+			$notice_text .= " Please correct this in Diagnostics -> AutoConfigBackup -> Settings.";
 			//log_error($notice_text);
 			//file_notice("AutoConfigBackup", $notice_text, $notice_text, "");
 			conf_mount_rw();
@@ -184,81 +194,83 @@ function upload_config($reasonm = "") {
 		}
 	} else {
 		/* If configuration has changed, upload to pfS */
-		if($last_backup_date <> $last_config_change) {
+		if ($last_backup_date <> $last_config_change) {
 
-				// Mount RW (if needed)
-				conf_mount_rw();
+			// Mount RW (if needed)
+			conf_mount_rw();
 
-				$notice_text = "Beginning https://portal.pfsense.org configuration backup.";
+			$notice_text = "Beginning https://portal.pfsense.org configuration backup.";
+			log_error($notice_text);
+			update_filter_reload_status($notice_text);
+
+			// Encrypt config.xml
+			$data = file_get_contents("/cf/conf/config.xml");
+			$raw_config_sha256_hash = trim(shell_exec("/sbin/sha256 /cf/conf/config.xml | /usr/bin/awk '{ print $4 }'"));
+			$data = encrypt_data($data, $encryptpw);
+			tagfile_reformat($data, $data, "config.xml");
+
+			$post_fields = array(
+				'reason' => urlencode((string)$reason),
+				'hostname' => urlencode($hostname),
+				'configxml' => urlencode($data),
+				'nooverwrite' => urlencode($nooverwrite),
+				'raw_config_sha256_hash' => urlencode($raw_config_sha256_hash)
+			);
+
+			// URL-ify the data for the POST
+			foreach ($post_fields as $key=>$value) {
+				$fields_string .= $key . '=' . $value . '&';
+			}
+			rtrim($fields_string,'&');
+
+			// Check configuration into the ESF repo
+			$curl_session = curl_init();
+			curl_setopt($curl_session, CURLOPT_URL, $upload_url);
+			curl_setopt($curl_session, CURLOPT_HTTPHEADER, array("Authorization: Basic " . base64_encode("{$username}:{$password}")));
+			curl_setopt($curl_session, CURLOPT_POST, count($post_fields));
+			curl_setopt($curl_session, CURLOPT_POSTFIELDS, $fields_string);
+			curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);
+			curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);
+			curl_setopt($curl_session, CURLOPT_CONNECTTIMEOUT, 55);
+			curl_setopt($curl_session, CURLOPT_TIMEOUT, 30);
+			curl_setopt($curl_session, CURLOPT_USERAGENT, $g['product_name'] . '/' . rtrim(file_get_contents("/etc/version")));
+			// Proxy
+			curl_setopt_array($curl_session, configure_proxy());
+
+			$data = curl_exec($curl_session);
+			if (curl_errno($curl_session)) {
+				$fd = fopen("/tmp/backupdebug.txt", "w");
+				fwrite($fd, $upload_url . "" . $fields_string . "\n\n");
+				fwrite($fd, $data);
+				fwrite($fd, curl_error($curl_session));
+				fclose($fd);
+			} else {
+				curl_close($curl_session);
+			}
+
+			if (!strstr($data, "500")) {
+				$notice_text = "An error occurred while uploading your pfSense configuration to portal.pfsense.org";
+				log_error($notice_text . " - " . $data);
+				file_notice("autoconfigurationbackup", $notice_text, $data, "");
+				update_filter_reload_status($notice_text . " - " . $data);
+			} else {
+				// Update last pfS backup time
+				$fd = fopen("/cf/conf/lastpfSbackup.txt", "w");
+				fwrite($fd, $config['revision']['time']);
+				fclose($fd);
+				$notice_text = "End of portal.pfsense.org configuration backup (success).";
 				log_error($notice_text);
 				update_filter_reload_status($notice_text);
+			}
 
-				// Encrypt config.xml
-				$data = file_get_contents("/cf/conf/config.xml");
-				$raw_config_sha256_hash = trim(`/sbin/sha256 /cf/conf/config.xml | awk '{ print $4 }'`);
-				$data = encrypt_data($data, $encryptpw);
-				tagfile_reformat($data, $data, "config.xml");
-
-				$post_fields = array(
-					'reason'					=> urlencode((string)$reason),  
-					'hostname'					=> urlencode($hostname),  
-					'configxml'					=> urlencode($data),
-					'nooverwrite'				=> urlencode($nooverwrite),
-					'raw_config_sha256_hash' 	=> urlencode($raw_config_sha256_hash)
-				);
-
-				//url-ify the data for the POST  
-				foreach($post_fields as $key=>$value) 
-					$fields_string .= $key.'='.$value.'&'; 
-				rtrim($fields_string,'&');
-
-				// Check configuration into the ESF repo
-				$curl_session = curl_init();
-				curl_setopt($curl_session, CURLOPT_URL, $upload_url);  
-				curl_setopt($curl_session, CURLOPT_HTTPHEADER, array("Authorization: Basic " . base64_encode("{$username}:{$password}")));
-				curl_setopt($curl_session, CURLOPT_POST, count($post_fields));  
-				curl_setopt($curl_session, CURLOPT_POSTFIELDS, $fields_string);
-				curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);		
-				curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);
-				curl_setopt($curl_session, CURLOPT_CONNECTTIMEOUT, 55);
-				curl_setopt($curl_session, CURLOPT_TIMEOUT, 30);
-				curl_setopt($curl_session, CURLOPT_USERAGENT, $g['product_name'] . '/' . rtrim(file_get_contents("/etc/version")));
-				// Proxy
-				curl_setopt_array($curl_session, configure_proxy());
-				
-				$data = curl_exec($curl_session);
-				if (curl_errno($curl_session)) {
-					$fd = fopen("/tmp/backupdebug.txt", "w");
-					fwrite($fd, $upload_url . "" . $fields_string . "\n\n");
-					fwrite($fd, $data);
-					fwrite($fd, curl_error($curl_session));
-					fclose($fd);
-				} else {
-				    curl_close($curl_session);
-				}
-
-				if(!strstr($data, "500")) {
-					$notice_text = "An error occurred while uploading your pfSense configuration to portal.pfsense.org";
-					log_error($notice_text . " - " . $data);
-					file_notice("autoconfigurationbackup", $notice_text, $data, "");			
-					update_filter_reload_status($notice_text . " - " . $data);	
-				} else {
-					// Update last pfS backup time
-					$fd = fopen("/cf/conf/lastpfSbackup.txt", "w");
-					fwrite($fd, $config['revision']['time']);
-					fclose($fd);				
-					$notice_text = "End of portal.pfsense.org configuration backup (success).";
-					log_error($notice_text);
-					update_filter_reload_status($notice_text);	
-				}
-
-				// Mount image RO (if needed)
-				conf_mount_ro();
+			// Mount image RO (if needed)
+			conf_mount_ro();
 
 		} else {
-			// debugging
+			// Debugging
 			//log_error("No https://portal.pfsense.org backup required.");
 		}
-	}	
+	}
 }
 
+?>

--- a/config/autoconfigbackup/autoconfigbackup.php
+++ b/config/autoconfigbackup/autoconfigbackup.php
@@ -1,81 +1,86 @@
 <?php
-/* $Id$ */
 /*
-    autoconfigbackup.php
-    Copyright (C) 2008 Scott Ullrich
-    All rights reserved.
+	autoconfigbackup.php
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2008 Scott Ullrich
+	Copyright (C) 2008-2015 Electric Sheep Fencing LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require("guiconfig.inc");
 require("autoconfigbackup.inc");
 
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version < 2.0)
+global $pf_version;
+$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+if ($pf_version < 2.0) {
 	require("crypt_acb.php");
+}
 
 // Seperator used during client / server communications
-$oper_sep			= "\|\|";
+$oper_sep = "\|\|";
 
-// Encryption password 
-$decrypt_password 	= $config['installedpackages']['autoconfigbackup']['config'][0]['crypto_password'];
+// Encryption password
+$decrypt_password = $config['installedpackages']['autoconfigbackup']['config'][0]['crypto_password'];
 
 // Defined username
-$username			= $config['installedpackages']['autoconfigbackup']['config'][0]['username'];
+$username = $config['installedpackages']['autoconfigbackup']['config'][0]['username'];
 
 // Defined password
-$password			= $config['installedpackages']['autoconfigbackup']['config'][0]['password'];
+$password = $config['installedpackages']['autoconfigbackup']['config'][0]['password'];
 
 // URL to restore.php
-$get_url			= "https://portal.pfsense.org/pfSconfigbackups/restore.php";
+$get_url = "https://portal.pfsense.org/pfSconfigbackups/restore.php";
 
 // URL to stats
-$stats_url			= "https://portal.pfsense.org/pfSconfigbackups/showstats.php";
+$stats_url = "https://portal.pfsense.org/pfSconfigbackups/showstats.php";
 
 // URL to delete.php
-$del_url			= "https://portal.pfsense.org/pfSconfigbackups/delete.php";
+$del_url = "https://portal.pfsense.org/pfSconfigbackups/delete.php";
 
 // Set hostname
-if($_REQUEST['hostname'])
-	$hostname		= $_REQUEST['hostname'];
-else
-	$hostname		= $config['system']['hostname'] . "." . $config['system']['domain'];
+if ($_REQUEST['hostname']) {
+	$hostname = $_REQUEST['hostname'];
+} else {
+	$hostname = $config['system']['hostname'] . "." . $config['system']['domain'];
+}
 
 // Hostname of local machine
-$myhostname		= $config['system']['hostname'] . "." . $config['system']['domain'];
+$myhostname = $config['system']['hostname'] . "." . $config['system']['domain'];
 
-if(!$username) {
+if (!$username) {
 	Header("Location: /pkg_edit.php?xml=autoconfigbackup.xml&id=0&savemsg=Please+setup+Auto+Config+Backup");
 	exit;
 }
 
-if($_REQUEST['savemsg']) 
+if ($_REQUEST['savemsg']) {
 	$savemsg = htmlentities($_REQUEST['savemsg']);
+}
 
-if($_REQUEST['download']) 
+if ($_REQUEST['download']) {
 	$pgtitle = "Diagnostics: Auto Configuration Backup revision information";
-else
+} else {
 	$pgtitle = "Diagnostics: Auto Configuration Backup";
+}
 
 include("head.inc");
 
@@ -83,16 +88,16 @@ function get_hostnames() {
 	global $stats_url, $username, $password, $oper_sep, $config, $g;
 	// Populate available backups
 	$curl_session = curl_init();
-	curl_setopt($curl_session, CURLOPT_URL, $stats_url);  
+	curl_setopt($curl_session, CURLOPT_URL, $stats_url);
 	curl_setopt($curl_session, CURLOPT_HTTPHEADER, array("Authorization: Basic " . base64_encode("{$username}:{$password}")));
-	curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);	
+	curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);
 	curl_setopt($curl_session, CURLOPT_POST, 1);
 	curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);
 	curl_setopt($curl_session, CURLOPT_POSTFIELDS, "action=showstats");
 	curl_setopt($curl_session, CURLOPT_USERAGENT, $g['product_name'] . '/' . rtrim(file_get_contents("/etc/version")));
 	// Proxy
 	curl_setopt_array($curl_session, configure_proxy());
-	
+
 	$data = curl_exec($curl_session);
 	if (curl_errno($curl_session)) {
 		$fd = fopen("/tmp/acb_statsdebug.txt", "w");
@@ -101,15 +106,16 @@ function get_hostnames() {
 		fwrite($fd, curl_error($curl_session));
 		fclose($fd);
 	} else {
-	    curl_close($curl_session);
+		curl_close($curl_session);
 	}
 	// Loop through and create new confvers
-	$data_split = split("\n", $data);
+	$data_split = explode("\n", $data);
 	$statvers = array();
-	foreach($data_split as $ds) {
+	foreach ($data_split as $ds) {
 		$ds_split = split($oper_sep, $ds);
-		if($ds_split[0])
-			$statvers[] = $ds_split[0];;
+		if ($ds_split[0]) {
+			$statvers[] = $ds_split[0];
+		}
 	}
 	return $statvers;
 }
@@ -119,99 +125,99 @@ function get_hostnames() {
 <div id='maincontent'>
 <script src="/javascript/scriptaculous/prototype.js" type="text/javascript"></script>
 <?php
-	include("fbegin.inc"); 
-	if ($pf_version < 2.0)
+	include("fbegin.inc");
+	if ($pf_version < 2.0) {
 		echo "<p class=\"pgtitle\">{$pgtitle}</p>";
-	if($savemsg) {
+	}
+	if ($savemsg) {
 		echo "<div id='savemsg'>";
 		print_info_box($savemsg);
-		echo "</div>";	
-	}	
-	if ($input_errors)
+		echo "</div>";
+	}
+	if ($input_errors) {
 		print_input_errors($input_errors);
-	if($hostname <> $myhostname) 
-			print_info_box("Warning! You are currently viewing an alternate host's backup history ($hostname)");
+	}
+	if ($hostname <> $myhostname) {
+		print_info_box("Warning! You are currently viewing an alternate host's backup history ($hostname)");
+	}
 ?>
-<table width="100%" border="0" cellpadding="0" cellspacing="0">  <tr><td>
+<table width="100%" border="0" cellpadding="0" cellspacing="0">
+<tr><td>
 <div id="loading">
-	<img src="/themes/metallic/images/misc/loader.gif"> Loading, please wait...
-	<p/>&nbsp;
+	<img src="/themes/metallic/images/misc/loader.gif" alt="" /> Loading, please wait...
+	<div>&nbsp;</div>
 </div>
 <div id='feedbackdiv'></div>
 	<?php
 		$tab_array = array();
 		$tab_array[0] = array("Settings", false, "/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0");
-		if($_REQUEST['download']) 
+		if ($_REQUEST['download']) {
 			$active = false;
-		else 
+		} else {
 			$active = true;
+		}
 		$tab_array[1] = array("Restore", $active, "/autoconfigbackup.php");
-		if($_REQUEST['download'])
+		if ($_REQUEST['download']) {
 			$tab_array[] = array("Revision", true, "/autoconfigbackup.php?download={$_REQUEST['download']}");
+		}
 		$tab_array[] = array("Backup now", false, "/autoconfigbackup_backup.php");
 		$tab_array[] = array("Stats", false, "/autoconfigbackup_stats.php");
 		display_top_tabs($tab_array);
 		$hostnames = get_hostnames();
-	?>			
-  </td></tr>
-  <tr>
-    <td>
+	?>
+</td></tr>
+<tr><td>
 	<table id="backuptable" class="tabcont" align="center" width="100%" border="0" cellpadding="6" cellspacing="0">
 	<tr>
 		<td colspan="2" align="left">
 			<?php
-				if($_REQUEST['rmver'] != "") {
+				if ($_REQUEST['rmver'] != "") {
 					$curl_session = curl_init();
 					curl_setopt($curl_session, CURLOPT_URL, $del_url);
 					curl_setopt($curl_session, CURLOPT_HTTPHEADER, array("Authorization: Basic " . base64_encode("{$username}:{$password}")));
-					curl_setopt($curl_session, CURLOPT_POST, 3);				
-					curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);	
-					curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);	
-					curl_setopt($curl_session, CURLOPT_POSTFIELDS, "action=delete" . 
-						"&hostname=" . urlencode($hostname) . 
-						"&revision=" . urlencode($_REQUEST['rmver']));
+					curl_setopt($curl_session, CURLOPT_POST, 3);
+					curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);
+					curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);
+					curl_setopt($curl_session, CURLOPT_POSTFIELDS, "action=delete" . "&hostname=" . urlencode($hostname) . "&revision=" . urlencode($_REQUEST['rmver']));
 					curl_setopt($curl_session, CURLOPT_USERAGENT, $g['product_name'] . '/' . rtrim(file_get_contents("/etc/version")));
 					// Proxy
 					curl_setopt_array($curl_session, configure_proxy());
-					
+
 					$data = curl_exec($curl_session);
 					if (curl_errno($curl_session)) {
 						$fd = fopen("/tmp/acb_deletedebug.txt", "w");
-						fwrite($fd, $get_url . "" . "action=delete&hostname=" . 
-							urlencode($hostname) . "&revision=" . 
-							urlencode($_REQUEST['rmver']) . "\n\n");
+						fwrite($fd, $get_url . "" . "action=delete&hostname=" . urlencode($hostname) . "&revision=" . urlencode($_REQUEST['rmver']) . "\n\n");
 						fwrite($fd, $data);
 						fwrite($fd, curl_error($curl_session));
 						fclose($fd);
 						$savemsg = "An error occurred while trying to remove the item from portal.pfsense.org.";
 					} else {
-					    curl_close($curl_session);
+						curl_close($curl_session);
 						$savemsg = "Backup revision {$_REQUEST['rmver']} has been removed.";
 					}
 					print_info_box($savemsg);
-				}			
-				if($_REQUEST['newver'] != "") {
+				}
+				if ($_REQUEST['newver'] != "") {
 					// Phone home and obtain backups
 					$curl_session = curl_init();
 					curl_setopt($curl_session, CURLOPT_URL, $get_url);
 					curl_setopt($curl_session, CURLOPT_HTTPHEADER, array("Authorization: Basic " . base64_encode("{$username}:{$password}")));
-					curl_setopt($curl_session, CURLOPT_POST, 3);				
-					curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);	
-					curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);	
-					curl_setopt($curl_session, CURLOPT_POSTFIELDS, "action=restore" . 
-						"&hostname=" . urlencode($hostname) . 	
-						"&revision=" . urlencode($_REQUEST['newver']));
+					curl_setopt($curl_session, CURLOPT_POST, 3);
+					curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);
+					curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);
+					curl_setopt($curl_session, CURLOPT_POSTFIELDS, "action=restore" . "&hostname=" . urlencode($hostname) . "&revision=" . urlencode($_REQUEST['newver']));
 					curl_setopt($curl_session, CURLOPT_USERAGENT, $g['product_name'] . '/' . rtrim(file_get_contents("/etc/version")));
 					// Proxy
 					curl_setopt_array($curl_session, configure_proxy());
 					$data = curl_exec($curl_session);
 					$data_split = split("\+\+\+\+", $data);
-					$sha256 = trim($data_split[0]);	// sha256
+					$sha256 = trim($data_split[0]);
 					$data = $data_split[1];
-					if (!tagfile_deformat($data, $data, "config.xml")) 
+					if (!tagfile_deformat($data, $data, "config.xml")) {
 						$input_errors[] = "The downloaded file does not appear to contain an encrypted pfSense configuration.";
+					}
 					$out = decrypt_data($data, $decrypt_password);
-					
+
 					$pos = stripos($out, "</pfsense>");
 					$data = substr($out, 0, $pos);
 					$data = $data . "</pfsense>\n";
@@ -219,12 +225,16 @@ function get_hostnames() {
 					$fd = fopen("/tmp/config_restore.xml", "w");
 					fwrite($fd, $data);
 					fclose($fd);
-					if(strlen($data) < 50) 
-						$input_errors[] = "The decrypted config.xml is under 50 characters, something went wrong.  Aborting.";
-					$ondisksha256 = trim(`/sbin/sha256 /tmp/config_restore.xml | awk '{ print $4 }'`);
-					if($sha256 != "0" && $sha256 != "")  // we might not have a sha256 on file for older backups
-						if($ondisksha256 <> $sha256)
+					if (strlen($data) < 50) {
+						$input_errors[] = "The decrypted config.xml is under 50 characters, something went wrong. Aborting.";
+					}
+					$ondisksha256 = trim(shell_exec("/sbin/sha256 /tmp/config_restore.xml | /usr/bin/awk '{ print $4 }'"));
+					// We might not have a sha256 on file for older backups
+					if ($sha256 != "0" && $sha256 != "") {
+						if ($ondisksha256 <> $sha256) {
 							$input_errors[] = "SHA256 values do not match, cannot restore. $ondisksha256 <> $sha256";
+						}
+					}
 					if (curl_errno($curl_session)) {
 						/* If an error occured, log the error in /tmp/ */
 						$fd = fopen("/tmp/acb_restoredebug.txt", "w");
@@ -233,18 +243,18 @@ function get_hostnames() {
 						fwrite($fd, curl_error($curl_session));
 						fclose($fd);
 					} else {
-					    curl_close($curl_session);
+						curl_close($curl_session);
 					}
-					if(!$input_errors && $data) {
+					if (!$input_errors && $data) {
 						conf_mount_rw();
-						if(config_restore("/tmp/config_restore.xml") == 0) {
+						if (config_restore("/tmp/config_restore.xml") == 0) {
 							$savemsg = "Successfully reverted the pfSense configuration to revision " . urldecode($_REQUEST['newver']) . ".";
 							$savemsg .= <<<EOF
-							<p/>
-						  <form action="reboot.php" method="post">
-							Would you like to reboot? 
-						  <input name="Submit" type="submit" class="formbtn" value=" Yes ">
-						  <input name="Submit" type="submit" class="formbtn" value=" No ">
+							<br />
+						<form action="reboot.php" method="post">
+							Would you like to reboot?
+							<input name="Submit" type="submit" class="formbtn" value=" Yes " />
+							<input name="Submit" type="submit" class="formbtn" value=" No " />
 						</form>
 EOF;
 						} else {
@@ -256,42 +266,43 @@ EOF;
 					}
 					unlink_if_exists("/tmp/config_restore.xml");
 					conf_mount_ro();
-				} 			
-				if($_REQUEST['download']) {
+				}
+				if ($_REQUEST['download']) {
 					// Phone home and obtain backups
 					$curl_session = curl_init();
 					curl_setopt($curl_session, CURLOPT_URL, $get_url);
 					curl_setopt($curl_session, CURLOPT_HTTPHEADER, array("Authorization: Basic " . base64_encode("{$username}:{$password}")));
-					curl_setopt($curl_session, CURLOPT_POST, 3);				
-					curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);	
-					curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);	
-					curl_setopt($curl_session, CURLOPT_POSTFIELDS, "action=restore" . 
-						"&hostname=" . urlencode($hostname) . 
-						"&revision=" . urlencode($_REQUEST['download']));
+					curl_setopt($curl_session, CURLOPT_POST, 3);
+					curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);
+					curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);
+					curl_setopt($curl_session, CURLOPT_POSTFIELDS, "action=restore" . "&hostname=" . urlencode($hostname) . "&revision=" . urlencode($_REQUEST['download']));
 					curl_setopt($curl_session, CURLOPT_USERAGENT, $g['product_name'] . '/' . rtrim(file_get_contents("/etc/version")));
 					// Proxy
 					curl_setopt_array($curl_session, configure_proxy());
 					$data = curl_exec($curl_session);
-					if (!tagfile_deformat($data, $data1, "config.xml")) 
+					if (!tagfile_deformat($data, $data1, "config.xml")) {
 						$input_errors[] = "The downloaded file does not appear to contain an encrypted pfSense configuration.";
+					}
 					if ($input_errors) {
 						print_input_errors($input_errors);
 					} else {
 						$ds = split("\+\+\+\+", $data);
 						$revision = $_REQUEST['download'];
 						$sha256sum = $ds[0];
-						if($sha256sum == "0")
+						if ($sha256sum == "0") {
 							$sha256sum = "None on file.";
+						}
 						$data = $ds[1];
 						$configtype = "Encrypted";
-						if (!tagfile_deformat($data, $data, "config.xml")) 
+						if (!tagfile_deformat($data, $data, "config.xml")) {
 							$input_errors[] = "The downloaded file does not appear to contain an encrypted pfSense configuration.";
+						}
 						$data = htmlentities(decrypt_data($data, $decrypt_password));
-						if(!strstr($data, "pfsense")) {
-							$data = "Could not decrypt.  Different encryption key?";
+						if (!strstr($data, "pfsense")) {
+							$data = "Could not decrypt. Different encryption key?";
 							$input_errors[] = "Could not decrypt config.xml";
 						}
-						echo "<h2>Hostname</h2>";						
+						echo "<h2>Hostname</h2>";
 						echo "<textarea rows='1' cols='70'>{$hostname}</textarea>";
 						echo "<h2>Revision date/time</h2>";
 						echo "<textarea name='download' rows='1' cols='70'>{$_REQUEST['download']}</textarea>";
@@ -304,20 +315,21 @@ EOF;
 						echo "<h2>Decrypted config.xml</h2>";
 						echo "<textarea name='dec_config_xml' rows='40' cols='70'>{$data}</textarea>";
 					}
-					if(!$input_errors)
-						echo "<p/><input type=\"button\" value=\"Install this revision\" onClick=\"document.location='autoconfigbackup.php?newver=" . urlencode($_REQUEST['download']) . "';\">";
+					if (!$input_errors) {
+						echo "<br /><input type=\"button\" value=\"Install this revision\" onclick=\"document.location='autoconfigbackup.php?newver=" . urlencode($_REQUEST['download']) . "';\">";
+					}
 					echo "<script type=\"text/javascript\">";
 					echo "$('loading').innerHTML = '';";
 					echo "</script>";
 					echo "</td></tr></table></div></td></td></tr></tr></table></form>";
 					require("fend.inc");
-					exit;	
+					exit;
 				}
 				// Populate available backups
 				$curl_session = curl_init();
-				curl_setopt($curl_session, CURLOPT_URL, $get_url);  
+				curl_setopt($curl_session, CURLOPT_URL, $get_url);
 				curl_setopt($curl_session, CURLOPT_HTTPHEADER, array("Authorization: Basic " . base64_encode("{$username}:{$password}")));
-				curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);	
+				curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);
 				curl_setopt($curl_session, CURLOPT_POST, 1);
 				curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);
 				curl_setopt($curl_session, CURLOPT_POSTFIELDS, "action=showbackups&hostname={$hostname}");
@@ -333,97 +345,91 @@ EOF;
 					fwrite($fd, curl_error($curl_session));
 					fclose($fd);
 				} else {
-				    curl_close($curl_session);
+					curl_close($curl_session);
 				}
 				// Loop through and create new confvers
 				$data_split = split("\n", $data);
 				$confvers = array();
-				foreach($data_split as $ds) {
+				foreach ($data_split as $ds) {
 					$ds_split = split($oper_sep, $ds);
 					$tmp_array = array();
 					$tmp_array['username'] = $ds_split[0];
 					$tmp_array['reason'] = $ds_split[1];
 					$tmp_array['time'] = $ds_split[2];
-					if($ds_split[2] && $ds_split[0])
+					if ($ds_split[2] && $ds_split[0]) {
 						$confvers[] = $tmp_array;
+					}
 				}
-				if ($input_errors)
+				if ($input_errors) {
 					print_input_errors($input_errors);
+				}
 			?>
 		</td>
 	</tr>
-			<tr>
-				<td colspan="2">
-					<center>
-					<b>Hostname:</b>
-					<select id="hostname" name="hostname" onChange="document.location='autoconfigbackup.php?hostname=' + this.value;">
-						<?
-						$host_not_found = true;
-						foreach($hostnames as $hn):
-						?>
-						<option value='<?=$hn?>' <? if ($hn == $hostname) {echo " selected=\"selected\""; $host_not_found = false;}?>>
-							<?=$hn?>
-						</option>
-						<?endforeach?>
-						<? if ($host_not_found) { ?>
-							<option value='<?=$hostname?>' SELECTED><?=$hostname?></option>
-						<? } ?>
-					</select>
-				</td>
-			</tr>
-	
+	<tr>
+		<td colspan="2">
+			<div style="text-align: center;">
+			<strong>Hostname:</strong>
+			<select id="hostname" name="hostname" onchange="document.location='autoconfigbackup.php?hostname=' + this.value;">
+				<?
+				$host_not_found = true;
+				foreach ($hostnames as $hn):
+				?>
+				<option value='<?=$hn?>' <? if ($hn == $hostname) {echo " selected=\"selected\""; $host_not_found = false;} ?>>
+					<?=$hn?>
+				</option>
+				<?endforeach?>
+				<? if ($host_not_found) { ?>
+					<option value='<?=$hostname?>' SELECTED><?=$hostname?></option>
+				<? } ?>
+			</select>
+			</div>
+		</td>
+	</tr>
 	<tr>
 		<td width="30%" class="listhdrr">Date</td>
 		<td width="70%" class="listhdrr">Configuration Change</td>
 	</tr>
-<?php 
+<?php
 	$counter = 0;
 	echo "<script type=\"text/javascript\">";
 	echo "$('loading').innerHTML = '';";
-	echo "</script>";	
-	foreach($confvers as $cv): 
+	echo "</script>";
+	foreach ($confvers as $cv):
 ?>
 		<tr valign="top">
-		  <td class="listlr"> <?= $cv['time']; ?></td>
+			<td class="listlr"> <?= $cv['time']; ?></td>
 			<td class="listbg"> <?= $cv['reason']; ?></td>
-			<td colspan="2" valign="middle" class="list" nowrap>
-			  <a title="Restore this revision" onClick="return confirm('Are you sure you want to restore <?= $cv['time']; ?>?')" href="autoconfigbackup.php?hostname=<?=urlencode($hostname)?>&newver=<?=urlencode($cv['time']);?>">
-				<img src="/themes/<?= $g['theme']; ?>/images/icons/icon_plus.gif" width="17" height="17" border="0">
-			  </a>
-			  <a title="Show info" href="autoconfigbackup.php?download=<?=urlencode($cv['time']);?>&hostname=<?=urlencode($hostname)?>&reason=<?php echo urlencode($cv['reason']);?>">
-				<img src="/themes/<?= $g['theme']; ?>/images/icons/icon_down.gif" width="17" height="17" border="0">
-			  </a>
-			  <a title="Delete" onClick="return confirm('Are you sure you want to delete <?= $cv['time']; ?>?')"href="autoconfigbackup.php?hostname=<?=urlencode($hostname)?>&rmver=<?=urlencode($cv['time']);?>">
-				<img src="/themes/<?= $g['theme']; ?>/images/icons/icon_x.gif" width="17" height="17" border="0">
-			  </a>
-		  </td>
+			<td colspan="2" valign="middle" class="list" nowrap="nowrap">
+				<a title="Restore this revision" onclick="return confirm('Are you sure you want to restore <?= $cv['time']; ?>?')" href="autoconfigbackup.php?hostname=<?=urlencode($hostname)?>&newver=<?=urlencode($cv['time']);?>">
+				<img src="/themes/<?= $g['theme']; ?>/images/icons/icon_plus.gif" width="17" height="17" border="0" alt="" />
+				</a>
+				<a title="Show info" href="autoconfigbackup.php?download=<?=urlencode($cv['time']);?>&hostname=<?=urlencode($hostname)?>&reason=<?php echo urlencode($cv['reason']);?>">
+				<img src="/themes/<?= $g['theme']; ?>/images/icons/icon_down.gif" width="17" height="17" border="0" alt="" />
+				</a>
+				<a title="Delete" onclick="return confirm('Are you sure you want to delete <?= $cv['time']; ?>?')"href="autoconfigbackup.php?hostname=<?=urlencode($hostname)?>&rmver=<?=urlencode($cv['time']);?>">
+				<img src="/themes/<?= $g['theme']; ?>/images/icons/icon_x.gif" width="17" height="17" border="0" alt="" />
+				</a>
+			</td>
 		</tr>
 <?php
-		$counter++; 
+		$counter++;
 	endforeach;
-	if($counter == 0)
-		echo "<tr><td colspan='3'><center>Sorry, we could not locate any backups at portal.pfsense.org for this hostname ({$hostname}).</td></tr>";
-	else 
-		echo "<tr><td colspan='3'><center><br/>Backups hosted currently for this hostname on portal.pfsense.org: {$counter}.</td></tr>";	
+	if ($counter == 0) {
+		echo "<tr><td colspan='3' align='center'>Sorry, we could not locate any backups at portal.pfsense.org for this hostname ({$hostname}).</td></tr>";
+	} else {
+		echo "<tr><td colspan='3' align='center'><br />Backups hosted currently for this hostname on portal.pfsense.org: {$counter}.</td></tr>";
+	}
 ?>
 	</table>
 	</div>
-    </td>
-	<tr>
-		<td>
-	  		<p>
-	  			<strong>
-					&nbsp;&nbsp;
-					<span class="red">
-						Hint:&nbsp;
-	  				</span>
-	  			</strong>
-	  			Click the + sign next to the revision you would like to restore.
-			</p>	
-		</td>
-	</tr>
-  </tr>
-</table>
+	</td>
+		<tr><td>
+			<div>
+				<strong>&nbsp;&nbsp;<span class="red">Hint:&nbsp;</span></strong>Click the + sign next to the revision you would like to restore.
+			</div>
+		</td></tr>
+</tr></table>
 </form>
 <?php include("fend.inc"); ?>
 </body>

--- a/config/autoconfigbackup/autoconfigbackup.xml
+++ b/config/autoconfigbackup/autoconfigbackup.xml
@@ -3,41 +3,47 @@
 <?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-        <![CDATA[
-		/* $Id$ */
-		/*
-		   autoconfigbackup.xml 
-		   part of pfSense (https://www.pfsense.org)
-		   Copyright (C) 2008-2014 Electric Sheep Fencing LP 
-		   All rights reserved.
+<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
+/*
+	autoconfigbackup.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2008-2015 Electric Sheep Fencing LP
+	All rights reserved.
+*/
+/* ====================================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-		   Redistribution and use in source and binary forms, with or without
-		   modification, are permitted provided that the following conditions are met:
 
-		    1. Redistributions of source code must retain the above copyright notice,
-		       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-		    2. Redistributions in binary form must reproduce the above copyright
-		       notice, this list of conditions and the following disclaimer in the
-		       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-		   THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-		   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-		   AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-		   AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-		   OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-		   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-		   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-		   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-		   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-		   POSSIBILITY OF SUCH DAMAGE.
-		*/
-        ]]>
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
 	</copyright>
-    <description>Automatically backs up your pfSense configuration.  All contents are encrypted before being sent to the server.  Requires Gold Subscription from https://portal.pfsense.org</description>
-    <requirements>pfSense Portal subscription</requirements>
+	<description>Automatically backs up your pfSense configuration. All contents are encrypted before being sent to the server. Requires Gold Subscription from https://portal.pfsense.org</description>
+	<requirements>pfSense Portal subscription</requirements>
 	<name>AutoConfigBackup</name>
-	<version>1.28</version>
+	<version>1.29</version>
 	<title>Diagnostics: Auto Configuration Backup</title>
 	<savetext>Change</savetext>
 	<include_file>/usr/local/pkg/autoconfigbackup.inc</include_file>
@@ -49,38 +55,31 @@
 		<url>/autoconfigbackup.php</url>
 	</menu>
 	<additional_files_needed>
-	    <prefix>/usr/local/pkg/write_config/</prefix>
-	    <chmod>0755</chmod>
+		<prefix>/usr/local/pkg/write_config/</prefix>
 		<item>https://packages.pfsense.org/packages/config/autoconfigbackup/parse_config_upload.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
-	    <prefix>/usr/local/www/</prefix>
-	    <chmod>0755</chmod>
+		<prefix>/usr/local/www/</prefix>
 		<item>https://packages.pfsense.org/packages/config/autoconfigbackup/autoconfigbackup.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
-	    <prefix>/usr/local/pkg/</prefix>
-	    <chmod>0755</chmod>
+		<prefix>/usr/local/pkg/</prefix>
 		<item>https://packages.pfsense.org/packages/config/autoconfigbackup/autoconfigbackup.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
-	    <prefix>/etc/inc/</prefix>
-	    <chmod>0755</chmod>
+		<prefix>/etc/inc/</prefix>
 		<item>https://packages.pfsense.org/packages/config/autoconfigbackup/crypt_acb.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
-	    <prefix>/usr/local/www/</prefix>
-	    <chmod>0755</chmod>
+		<prefix>/usr/local/www/</prefix>
 		<item>https://packages.pfsense.org/packages/config/autoconfigbackup/autoconfigbackup_backup.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
-	    <prefix>/usr/local/pkg/write_config/</prefix>
-	    <chmod>0755</chmod>
+		<prefix>/usr/local/pkg/write_config/</prefix>
 		<item>https://packages.pfsense.org/packages/config/autoconfigbackup/parse_config_upload.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
-	    <prefix>/usr/local/www/</prefix>
-	    <chmod>0755</chmod>
+		<prefix>/usr/local/www/</prefix>
 		<item>https://packages.pfsense.org/packages/config/autoconfigbackup/autoconfigbackup_stats.php</item>
 	</additional_files_needed>
 	<tabs>
@@ -116,37 +115,32 @@
 			<type>password</type>
 		</field>
 		<field>
-			<fielddescr>Enter Password again</fielddescr>
+			<fielddescr>Enter Password Again</fielddescr>
 			<fieldname>passwordagain</fieldname>
 			<type>password</type>
 		</field>
 		<field>
 			<fielddescr>Encryption Password</fielddescr>
-			<description>This password will be used to encrypt config.xml before uploading. We recommend not setting this to the same thing as your portal.pfsense.org account. Keep record of this password in a safe place - without it, your configurations will be impossible to restore.</description>
+			<description>
+				<![CDATA[
+				This password will be used to encrypt config.xml before uploading. We recommend <strong>not</strong> setting this to the same password as your portal.pfsense.org account.<br />
+				<span class="errmsg">Keep record of this password in a safe place - without it, your configurations will be impossible to restore.</span>
+				]]>
+			</description>
 			<fieldname>crypto_password</fieldname>
 			<type>password</type>
 		</field>
 		<field>
-			<fielddescr>Encryption Password again</fielddescr>
+			<fielddescr>Encryption Password Again</fielddescr>
 			<description>Enter the encryption password again.</description>
 			<fieldname>crypto_password2</fieldname>
 			<type>password</type>
 		</field>
-    </fields>
+	</fields>
 	<custom_php_validation_command>
-		custom_php_validation_command($_POST, $input_errors);
+		acb_custom_php_validation_command($_POST, $input_errors);
 	</custom_php_validation_command>
 	<custom_php_resync_config_command>
-        <![CDATA[		
-			conf_mount_rw();
-			@unlink("/cf/conf/lastpfSbackup.txt");
-			conf_mount_ro();
-			if(!function_exists("filter_configure")) 
-				require_once("filter.inc");
-			filter_configure();
-			if($savemsg) 
-				$savemsg .= "<br/>";
-			$savemsg .= "A configuration backup has been queued.";
-        ]]>		
+		acb_custom_php_resync_config_command();
 	</custom_php_resync_config_command>
 </packagegui>

--- a/config/autoconfigbackup/autoconfigbackup_backup.php
+++ b/config/autoconfigbackup/autoconfigbackup_backup.php
@@ -1,128 +1,120 @@
 <?php
-/* $Id$ */
 /*
-    autoconfigbackup_backup.php
-    Copyright (C) 2008 Scott Ullrich
-    All rights reserved.
+	autoconfigbackup_backup.php
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2008 Scott Ullrich
+	Copyright (C) 2008-2015 Electric Sheep Fencing LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require("globals.inc");
 require("guiconfig.inc");
 require("autoconfigbackup.inc");
 
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version < 2.0)
+global $pf_version;
+$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+if ($pf_version < 2.0) {
 	require("crypt_acb.php");
+}
 
-if(!$config['installedpackages']['autoconfigbackup']['config'][0]['username']) {
+if (!$config['installedpackages']['autoconfigbackup']['config'][0]['username']) {
 	Header("Location: /pkg_edit.php?xml=autoconfigbackup.xml&id=0&savemsg=Please+setup+Auto+Config+Backup");
 	exit;
 }
 
-if($_POST) {	
-	if($_REQUEST['nooverwrite'])
+if ($_POST) {
+	if ($_REQUEST['nooverwrite']) {
 		touch("/tmp/acb_nooverwrite");
-	if($_REQUEST['reason']) 
+	}
+	if ($_REQUEST['reason']) {
 		write_config($_REQUEST['reason']);
-	else 
+	} else {
 		write_config("Backup invoked via Auto Config Backup.");
+	}
 	$config = parse_config(true);
 	conf_mount_rw();
-	@unlink("/cf/conf/lastpfSbackup.txt", "");
+	unlink_if_exists("/cf/conf/lastpfSbackup.txt");
 	conf_mount_ro();
 	upload_config($_REQUEST['reason']);
 	$savemsg = "Backup completed successfully.";
-	$donotshowheader=true;
+	$donotshowheader = true;
 }
 
 $pgtitle = "Diagnostics: Auto Configuration Backup Now";
-
 include("head.inc");
 
 ?>
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 <div id='maincontent'>
 <?php
-	include("fbegin.inc"); 
-	if ($pf_version < 2.0)
+	include("fbegin.inc");
+	if ($pf_version < 2.0) {
 		echo "<p class=\"pgtitle\">{$pgtitle}</p>";
-	if($savemsg) {
+	}
+	if ($savemsg) {
 		print_info_box($savemsg);
-	}	
-	if ($input_errors)
+	}
+	if ($input_errors) {
 		print_input_errors($input_errors);
-
+	}
 ?>
 <form method="post" action="autoconfigbackup_backup.php">
-<table width="100%" border="0" cellpadding="0" cellspacing="0">  
-	<tr>
-		<td>
-			<div id='feedbackdiv'>
-			</div>
-			<?php
-				$tab_array = array();
-				$tab_array[] = array("Settings", false, "/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0");
-				$tab_array[] = array("Restore", false, "/autoconfigbackup.php");
-				$tab_array[] = array("Backup now", true, "/autoconfigbackup_backup.php");
-				$tab_array[] = array("Stats", false, "/autoconfigbackup_stats.php");
-				display_top_tabs($tab_array);
-			?>			
-  		</td>
-	</tr>
-  	<tr>
-    	<td>
-			<table id="backuptable" class="tabcont" align="center" width="100%" border="0" cellpadding="6" cellspacing="0">
+<table width="100%" border="0" cellpadding="0" cellspacing="0">
+<tr><td>
+	<div id='feedbackdiv'></div>
+	<?php
+		$tab_array = array();
+		$tab_array[] = array("Settings", false, "/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0");
+		$tab_array[] = array("Restore", false, "/autoconfigbackup.php");
+		$tab_array[] = array("Backup now", true, "/autoconfigbackup_backup.php");
+		$tab_array[] = array("Stats", false, "/autoconfigbackup_stats.php");
+		display_top_tabs($tab_array);
+	?>
+</td></tr>
+<tr><td>
+	<table id="backuptable" class="tabcont" align="center" width="100%" border="0" cellpadding="6" cellspacing="0">
+		<tr><td colspan="2" align="left">
+			<table>
 				<tr>
-					<td colspan="2" align="left">
-						<table>
-							<tr>
-								<td align="right">
-									Enter the backup reason:
-								</td>
-								<td>
-									<input name="reason" id="reason" size="80">
-								</td>
-							</tr>
-							<tr>
-								<td>
-									&nbsp;
-								</td>
-							</tr>
-							<tr>
-								<td align="right">
-									<input type="submit" name="Backup" value="Backup">
-								</td>
-							</tr>
-						</table>
+					<td align="right">Enter the backup reason:</td>
+					<td>
+						<input name="reason" id="reason" size="80" />
+					</td>
+				</tr>
+				<tr>
+					<td>&nbsp;</td>
+				</tr>
+				<tr>
+					<td align="right">
+						<input type="submit" name="Backup" value="Backup" />
 					</td>
 				</tr>
 			</table>
-		</td>
-	</tr>
-	</div>
-	</td>
-  </tr>
+		</td></tr>
+	</table>
+</td></tr>
+</div>
+</td></tr>
 </table>
 </form>
 <?php include("fend.inc"); ?>

--- a/config/autoconfigbackup/autoconfigbackup_stats.php
+++ b/config/autoconfigbackup/autoconfigbackup_stats.php
@@ -92,7 +92,7 @@ if ($_REQUEST['delhostname']) {
 	}
 }
 
-$pgtitle = "Diagnostics: Auto Configuration Stats";
+$pgtitle = "Diagnostics: Auto Configuration Backup Stats";
 include("head.inc");
 
 ?>

--- a/config/autoconfigbackup/autoconfigbackup_stats.php
+++ b/config/autoconfigbackup/autoconfigbackup_stats.php
@@ -1,98 +1,98 @@
 <?php
-/* $Id$ */
 /*
-    autoconfigbackup_stats.php
-    Copyright (C) 2008 Scott Ullrich
-    All rights reserved.
+	autoconfigbackup_stats.php
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2008 Scott Ullrich
+	Copyright (C) 2008-2015 Electric Sheep Fencing LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require("globals.inc");
 require("guiconfig.inc");
 require("autoconfigbackup.inc");
 
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version < 2.0)
+global $pf_version, $config, $g;
+$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+if ($pf_version < 2.0) {
 	require("crypt_acb.php");
+}
 
 // Seperator used during client / server communications
-$oper_sep			= "\|\|";
+$oper_sep = "\|\|";
 
-// Encryption password 
-$decrypt_password 	= $config['installedpackages']['autoconfigbackup']['config'][0]['crypto_password'];
+// Encryption password
+$decrypt_password = $config['installedpackages']['autoconfigbackup']['config'][0]['crypto_password'];
 
 // Defined username
-$username			= $config['installedpackages']['autoconfigbackup']['config'][0]['username'];
+$username = $config['installedpackages']['autoconfigbackup']['config'][0]['username'];
 
 // Defined password
-$password			= $config['installedpackages']['autoconfigbackup']['config'][0]['password'];
+$password = $config['installedpackages']['autoconfigbackup']['config'][0]['password'];
 
 // URL to restore.php
-$get_url			= "https://portal.pfsense.org/pfSconfigbackups/restore.php";
+$get_url = "https://portal.pfsense.org/pfSconfigbackups/restore.php";
 
 // URL to delete.php
-$del_url			= "https://portal.pfsense.org/pfSconfigbackups/delete.php";
+$del_url = "https://portal.pfsense.org/pfSconfigbackups/delete.php";
 
 // URL to stats.php
-$stats_url			= "https://portal.pfsense.org/pfSconfigbackups/showstats.php";
+$stats_url = "https://portal.pfsense.org/pfSconfigbackups/showstats.php";
 
 // Set hostname
-$hostname			= $config['system']['hostname'] . "." . $config['system']['domain'];
+$hostname = $config['system']['hostname'] . "." . $config['system']['domain'];
 
-if(!$username) {
+if (!$username) {
 	Header("Location: /pkg_edit.php?xml=autoconfigbackup.xml&id=0&savemsg=Please+setup+Auto+Config+Backup");
 	exit;
 }
 
-if($_REQUEST['delhostname']) {
+if ($_REQUEST['delhostname']) {
 	$curl_session = curl_init();
 	curl_setopt($curl_session, CURLOPT_URL, $del_url);
 	curl_setopt($curl_session, CURLOPT_HTTPHEADER, array("Authorization: Basic " . base64_encode("{$username}:{$password}")));
-	curl_setopt($curl_session, CURLOPT_POST, 2);				
-	curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);	
-	curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);	
+	curl_setopt($curl_session, CURLOPT_POST, 2);
+	curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);
+	curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);
 	curl_setopt($curl_session, CURLOPT_POSTFIELDS, "action=deletehostname&delhostname=" . urlencode($_REQUEST['delhostname']));
 	curl_setopt($curl_session, CURLOPT_USERAGENT, $g['product_name'] . '/' . rtrim(file_get_contents("/etc/version")));
 	// Proxy
 	curl_setopt_array($curl_session, configure_proxy());
-	
+
 	$data = curl_exec($curl_session);
 	if (curl_errno($curl_session)) {
 		$fd = fopen("/tmp/acb_deletedebug.txt", "w");
-		fwrite($fd, $get_url . "" . "action=deletehostname&hostname=" . 
-			urlencode($_REQUEST['delhostname']) . "\n\n");
+		fwrite($fd, $get_url . "" . "action=deletehostname&hostname=" . urlencode($_REQUEST['delhostname']) . "\n\n");
 		fwrite($fd, $data);
 		fwrite($fd, curl_error($curl_session));
 		fclose($fd);
 		$savemsg = "An error occurred while trying to remove the item from portal.pfsense.org.";
 	} else {
-	    curl_close($curl_session);
+		curl_close($curl_session);
 		$savemsg = "ALL backup revisions for {$_REQUEST['delhostname']} have been removed.";
 	}
 }
 
 $pgtitle = "Diagnostics: Auto Configuration Stats";
-
 include("head.inc");
 
 ?>
@@ -100,57 +100,54 @@ include("head.inc");
 <script src="/javascript/scriptaculous/prototype.js" type="text/javascript"></script>
 <div id='maincontent'>
 <?php
-	include("fbegin.inc"); 
-	if ($pf_version < 2.0)
+	include("fbegin.inc");
+	if ($pf_version < 2.0) {
 		echo "<p class=\"pgtitle\">{$pgtitle}</p>";
-	if($savemsg) {
+	}
+	if ($savemsg) {
 		print_info_box($savemsg);
-	}	
-	if ($input_errors)
+	}
+	if ($input_errors) {
 		print_input_errors($input_errors);
-
+	}
 ?>
 <form method="post" action="autoconfigbackup_stats.php">
-<table width="100%" border="0" cellpadding="0" cellspacing="0">  
-	<tr>
-		<td>
-			<div id='feedbackdiv'>
-			</div>
-			<?php
-				$tab_array = array();
-				$tab_array[] = array("Settings", false, "/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0");
-				$tab_array[] = array("Restore", false, "/autoconfigbackup.php");
-				$tab_array[] = array("Backup now", false, "/autoconfigbackup_backup.php");
-				$tab_array[] = array("Stats", true, "/autoconfigbackup_stats.php");
-				display_top_tabs($tab_array);
-			?>			
-  		</td>
-	</tr>
-  <tr>
-    <td>
+<table width="100%" border="0" cellpadding="0" cellspacing="0">
+<tr><td>
+<div id='feedbackdiv'></div>
+	<?php
+		$tab_array = array();
+		$tab_array[] = array("Settings", false, "/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0");
+		$tab_array[] = array("Restore", false, "/autoconfigbackup.php");
+		$tab_array[] = array("Backup now", false, "/autoconfigbackup_backup.php");
+		$tab_array[] = array("Stats", true, "/autoconfigbackup_stats.php");
+		display_top_tabs($tab_array);
+	?>
+</td></tr>
+<tr><td>
 	<table id="backuptable" class="tabcont" align="center" width="100%" border="0" cellpadding="6" cellspacing="0">
 	<tr>
 		<td colspan="2" align="left">
 			<div id="loading">
-				<img src="themes/metallic/images/misc/loader.gif"> Loading, please wait...
+				<img src="themes/metallic/images/misc/loader.gif" alt="" /> Loading, please wait...
 			</div>
 	</tr>
 	<tr>
 		<td width="30%" class="listhdrr">Hostname</td>
 		<td width="70%" class="listhdrr">Backup count</td>
-	</tr>			
-<?php 
+	</tr>
+<?php
 	// Populate available backups
 	$curl_session = curl_init();
-	curl_setopt($curl_session, CURLOPT_URL, $stats_url);  
+	curl_setopt($curl_session, CURLOPT_URL, $stats_url);
 	curl_setopt($curl_session, CURLOPT_HTTPHEADER, array("Authorization: Basic " . base64_encode("{$username}:{$password}")));
-	curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);	
+	curl_setopt($curl_session, CURLOPT_SSL_VERIFYPEER, 0);
 	curl_setopt($curl_session, CURLOPT_POST, 1);
 	curl_setopt($curl_session, CURLOPT_RETURNTRANSFER, 1);
 	curl_setopt($curl_session, CURLOPT_POSTFIELDS, "action=showstats");
 	curl_setopt($curl_session, CURLOPT_USERAGENT, $g['product_name'] . '/' . rtrim(file_get_contents("/etc/version")));
-        // Proxy
-        curl_setopt_array($curl_session, configure_proxy());
+	// Proxy
+	curl_setopt_array($curl_session, configure_proxy());
 
 	$data = curl_exec($curl_session);
 	if (curl_errno($curl_session)) {
@@ -160,62 +157,58 @@ include("head.inc");
 		fwrite($fd, curl_error($curl_session));
 		fclose($fd);
 	} else {
-	    curl_close($curl_session);
+		curl_close($curl_session);
 	}
 	// Loop through and create new confvers
-	$data_split = split("\n", $data);
+	$data_split = explode("\n", $data);
 	$statvers = array();
 	foreach($data_split as $ds) {
 		$ds_split = split($oper_sep, $ds);
 		$tmp_array = array();
 		$tmp_array['hostname'] = $ds_split[0];
 		$tmp_array['hostnamecount'] = $ds_split[1];
-		if($ds_split[0] && $ds_split[1])
+		if ($ds_split[0] && $ds_split[1]) {
 			$statvers[] = $tmp_array;
+		}
 	}
 	$counter = 0;
 	echo "<script type=\"text/javascript\">";
 	echo "$('loading').innerHTML = '';";
 	echo "</script>";
 	$total_backups = 0;
-	foreach($statvers as $cv): 
+	foreach ($statvers as $cv):
 ?>
 		<tr valign="top">
 			<td class="listlr">
 				<?= $cv['hostname']; ?>
 			</td>
-			<td class="listbg"> 
+			<td class="listbg">
 				<?= $cv['hostnamecount']; ?>
 			</td>
 			<td>
-			<nobr>
-			  <a title="View all backups for this host" href="autoconfigbackup.php?hostname=<?=urlencode($cv['hostname'])?>">
-				<img src="/themes/<?= $g['theme']; ?>/images/icons/icon_e.gif" width="17" height="17" border="0">
-			  </a>
-			  <a title="Delete all backups for this host" onClick="return confirm('Are you sure you want to delete *ALL BACKUPS FOR THIS HOSTNAME* <?= $cv['hostname']; ?>?')" href="autoconfigbackup_stats.php?delhostname=<?=urlencode($cv['hostname'])?>">
-				<img src="/themes/<?= $g['theme']; ?>/images/icons/icon_x.gif" width="17" height="17" border="0">
-			  </a>
-			</nobr>
+			<span style="white-space: nowrap;">
+				<a title="View all backups for this host" href="autoconfigbackup.php?hostname=<?=urlencode($cv['hostname'])?>">
+					<img src="/themes/<?= $g['theme']; ?>/images/icons/icon_e.gif" width="17" height="17" border="0" alt="" />
+				</a>
+				<a title="Delete all backups for this host" onclick="return confirm('Are you sure you want to delete *ALL BACKUPS FOR THIS HOSTNAME* <?= $cv['hostname']; ?>?')" href="autoconfigbackup_stats.php?delhostname=<?=urlencode($cv['hostname'])?>">
+					<img src="/themes/<?= $g['theme']; ?>/images/icons/icon_x.gif" width="17" height="17" border="0" alt="" />
+				</a>
+			</span>
 			</td>
 		</tr>
 <?php
-		$total_backups = $total_backups + $cv['hostnamecount'];
-		$counter++; 
+	$total_backups = $total_backups + $cv['hostnamecount'];
+	$counter++;
 	endforeach;
-	if($counter == 0)
-		echo "<tr><td colspan='3'><center>Sorry, we could not load the status information for the account ($username).</td></tr>";
+	if ($counter == 0)
+		echo "<tr><td colspan='3' align='center'>Sorry, we could not load the status information for the account ($username).</td></tr>";
 ?>
-	<tr>
-		<td align="right">
-			Total
-		</td>
-		<td>
-			<?=$total_backups?>
-		</td>
-	</tr>
-	</td>
-  </tr>
-</table>
+		<tr>
+			<td align="right">Total&nbsp;</td>
+			<td><?=$total_backups?></td>
+		</tr>
+	</td></tr>
+	</table>
 </td></tr>
 </table>
 </form>

--- a/config/autoconfigbackup/crypt_acb.php
+++ b/config/autoconfigbackup/crypt_acb.php
@@ -1,135 +1,135 @@
 <?php
-
-/* $Id$ */
 /*
-    Copyright (C) 2008 Shrew Soft Inc
-    All rights reserved.
+	crypt_acb.php
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2008 Shrew Soft Inc
+	Copyright (C) 2008-2015 Electric Sheep Fencing LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-    this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
-    DISABLE_PHP_LINT_CHECKING
+	DISABLE_PHP_LINT_CHECKING
 */
+function crypt_data($val, $pass, $opt) {
+	$file = tempnam("/tmp", "php-encrypt");
+	file_put_contents("{$file}.dec", $val);
+	exec("/usr/bin/openssl enc {$opt} -aes-256-cbc -in {$file}.dec -out {$file}.enc -k " . escapeshellarg($pass));
+	if (file_exists("{$file}.enc")) {
+		$result = file_get_contents("{$file}.enc");
+	} else {
+		$result = "";
+		log_error("Failed to encrypt/decrypt data!");
+	}
+	unlink_if_exists($file);
+	unlink_if_exists("{$file}.dec");
+	unlink_if_exists("{$file}.enc");
+	return $result;
+}
 
-	function crypt_data($val, $pass, $opt) {
-		$file = tempnam("/tmp", "php-encrypt");
-		file_put_contents("{$file}.dec", $val);
-		exec("/usr/bin/openssl enc {$opt} -aes-256-cbc -in {$file}.dec -out {$file}.enc -k " . escapeshellarg($pass));
-		if (file_exists("{$file}.enc"))
-			$result = file_get_contents("{$file}.enc");
-		else {
-			$result = "";
-			log_error("Failed to encrypt/decrypt data!");
-		}
-		@unlink($file);
-		@unlink("{$file}.dec");
-		@unlink("{$file}.enc");
-		return $result;
+function crypt_dataA(& $data, $pass, $opt) {
+	log_error("entering crypt_data()");
+	$pspec = "/usr/bin/openssl enc {$opt} -aes-256-cbc -k {$pass}";
+	$dspec = array( 0 => array("pipe", "r"),
+			1 => array("pipe", "w"),
+			2 => array("pipe", "e"));
+	log_error("proc_open");
+	$fp = proc_open($pspec, $dspec, $pipes);
+	if (!$fp) {
+		return false;
+	}
+	log_error("writing to pipe[0]");
+	fwrite($pipes[0], $data);
+	log_error("closing pipe[0]");
+	fclose($pipes[0]);
+
+	log_error("enter while()");
+
+	while (!feof($pipes[1])) {
+		$rslt .= fread($pipes[1], 8192);
 	}
 
-	function crypt_dataA(& $data, $pass, $opt) {
-		log_error("entering crypt_data()");
-		$pspec = "/usr/bin/openssl enc {$opt} -aes-256-cbc -k {$pass}";
-		$dspec = array( 0 => array("pipe", "r"),
-				1 => array("pipe", "w"),
-				2 => array("pipe", "e"));
-		log_error("proc_open");
-		$fp = proc_open($pspec, $dspec, $pipes);
-		if (!$fp)
-			return false;
-		log_error("writing to pipe[0]");
-		fwrite($pipes[0], $data);
-		log_error("closing pipe[0]");
-		fclose($pipes[0]);
-		
-		log_error("enter while()");
-		
-		while (!feof($pipes[1])) {
-		  $rslt .= fread($pipes[1], 8192);
-		}
-		
-		log_error("exit while()");
-		
-		fclose($pipes[1]);
+	log_error("exit while()");
+	fclose($pipes[1]);
+	proc_close($fp);
+	return $rslt;
+}
 
-		proc_close($fp);
+function encrypt_data(& $data, $pass) {
+	return trim(base64_encode(crypt_data($data, $pass, "-e")));
+}
 
-		return $rslt;
+function decrypt_data(& $data, $pass) {
+	return trim(crypt_data(base64_decode($data), $pass, "-d"));
+}
+
+function tagfile_reformat($in, & $out, $tag) {
+
+	$out = "---- BEGIN {$tag} ----\n";
+
+	$size = 80;
+	$oset = 0;
+	while ($size >= 64) {
+		$line = substr($in, $oset, 64);
+		$out .= $line."\n";
+		$size = strlen($line);
+		$oset += $size;
 	}
 
-	function encrypt_data(& $data, $pass) {
-		return trim(base64_encode(crypt_data($data, $pass, "-e")));
+	$out .= "---- END {$tag} ----";
+
+	$out = trim($out);
+
+	return true;
+}
+
+function tagfile_deformat($in, &$out, $tag) {
+
+	$btag_val = "---- BEGIN {$tag} ----";
+	$etag_val = "---- END {$tag} ----";
+
+	$btag_len = strlen($btag_val);
+	$etag_len = strlen($etag_val);
+
+	$btag_pos = stripos($in, $btag_val);
+	$etag_pos = stripos($in, $etag_val);
+
+	if (($btag_pos === false) || ($etag_pos === false)) {
+		return false;
 	}
 
-	function decrypt_data(& $data, $pass) {
-		return trim(crypt_data(base64_decode($data), $pass, "-d"));
-	}
+	$body_pos = $btag_pos + $btag_len;
+	$body_len = strlen($in);
+	$body_len -= strlen($btag_len);
+	$body_len -= strlen($etag_len);
 
-	function tagfile_reformat($in, & $out, $tag) {
+	$out = substr($in, $body_pos, $body_len);
 
-		$out = "---- BEGIN {$tag} ----\n";
+	$out = trim($out);
 
-		$size = 80;
-		$oset = 0;
-		while ($size >= 64) {
-			$line = substr($in, $oset, 64);
-			$out .= $line."\n";
-			$size = strlen($line);
-			$oset += $size;
-		}
+	return true;
+}
 
-		$out .= "---- END {$tag} ----";
+function stripos($str, $needle) {
+	return strpos(strtolower($str), strtolower($needle));
+}
 
-		$out = trim($out);
-
-		return true;
-	}
-
-	function tagfile_deformat($in, & $out, $tag) {
-
-		$btag_val = "---- BEGIN {$tag} ----";
-		$etag_val = "---- END {$tag} ----";
-
-		$btag_len = strlen($btag_val);
-		$etag_len = strlen($etag_val);
-
-		$btag_pos = stripos($in, $btag_val);
-		$etag_pos = stripos($in, $etag_val);
-
-		if (($btag_pos === false) || ($etag_pos === false))
-			return false;
-
-		$body_pos = $btag_pos + $btag_len;
-		$body_len = strlen($in);
-		$body_len -= strlen($btag_len);
-		$body_len -= strlen($etag_len);
-
-		$out = substr($in, $body_pos, $body_len);
-
-		$out = trim($out);
-
-		return true;
-	}
-	
-	function stripos($str,$needle) {
-		return strpos(strtolower($str), strtolower($needle));
-	}
-
+?>

--- a/config/autoconfigbackup/crypt_acb.php
+++ b/config/autoconfigbackup/crypt_acb.php
@@ -132,4 +132,3 @@ function stripos($str, $needle) {
 	return strpos(strtolower($str), strtolower($needle));
 }
 
-?>

--- a/config/autoconfigbackup/parse_config_upload.inc
+++ b/config/autoconfigbackup/parse_config_upload.inc
@@ -1,7 +1,6 @@
 <?php
 
-if(file_exists("/usr/local/pkg/autoconfigbackup.inc")) {
+if (file_exists("/usr/local/pkg/autoconfigbackup.inc")) {
 	require_once("/usr/local/pkg/autoconfigbackup.inc");
 	upload_config();
 }
-

--- a/config/autoconfigbackup/parse_config_upload.php
+++ b/config/autoconfigbackup/parse_config_upload.php
@@ -1,7 +1,6 @@
 <?php
 
-if(file_exists("/usr/local/pkg/autoconfigbackup.inc")) {
+if (file_exists("/usr/local/pkg/autoconfigbackup.inc")) {
 	require_once("/usr/local/pkg/autoconfigbackup.inc");
 	upload_config();
 }
-

--- a/config/autoconfigbackup/upload_config_filter.php
+++ b/config/autoconfigbackup/upload_config_filter.php
@@ -1,7 +1,6 @@
 <?php
 
-if(file_exists("/usr/local/pkg/autoconfigbackup.inc")) {
+if (file_exists("/usr/local/pkg/autoconfigbackup.inc")) {
 	require_once("/usr/local/pkg/autoconfigbackup.inc");
 	upload_config();
 }
-


### PR DESCRIPTION
**N.B. I cannot test this at all without subscription account. Also, there are some clearly whacky cases like intentionally missing closing PHP tags etc. Kindly test yourself before commit. You have been warned.** :stuck_out_tongue_closed_eyes: 

autoconfigbackup.inc
- Update copyright header
- Code style and whitespace fixes
- Use platform_booting()
- Replace backticks with shell_exec()
- Move custom_php_resync_config_command() function from XML to autoconfigbackup.inc and give it an unique prefix
- Also give an unique prefix to custom_php_validation_command()

autoconfigbackup.php
- Fix copyright header
- Code style and whitespace fixes
- Replace deprecated split() with explode(); still one split() occurrence left - cannot be simply replaced with explode() since that changes the output and I have no clue what the code is supposed to do plus no way to test it without subscription account
- Replace backticks with shell_exec()
- Some XHTML fixes

autoconfigbackup.xml
- Move custom_php_resync_config_command() function to autoconfigbackup.inc and give it an unique prefix
- Also give a unique prefix to custom_php_validation_command()
- Fix copyright header
- Fix file permissions (no need for these to be executable)
- Whitespace fixes

autoconfigbackup_backup.php
- Fix copyright header
- Code style and whitespace fixes
- XHTML fixes

autoconfigbackup_stats.php
- Fix copyright header
- Code style and whitespace fixes
- XHTML fixes
- Replace deprecated split() with explode(); still one split() occurrence left - cannot be simply replaced with explode() since that changes the output and I have no clue what the code is supposed to do plus no way to test it without subscription account

crypt_acb.php
- Fix copyright header
- Code style and whitespace fixes
- **N.B.: This code produces "Fatal error: Cannot redeclare stripos()" on any PHP5+ version, really no idea why's it still here for which prehistoric pfS versions. Not touching it otherwise.**

parse_config_upload.inc, parse_config_upload.php, upload_config_filter.php
- Missing/trailing whitespace. All these files are intentionally (653a43f) missing the closing PHP tag for god knows what reason. 