### PR TITLE
arpwatch - do not create sendmail hardlinks... Evil.

### DIFF
--- a/config/arpwatch/arpwatch.xml
+++ b/config/arpwatch/arpwatch.xml
@@ -149,9 +149,15 @@
 	<custom_php_install_command>
 	<![CDATA[
 		unlink_if_exists("/usr/local/etc/rc.d/arpwatch.sh");
-		@link("/usr/sbin/sm.php", "/usr/sbin/sendmail");
+		unlink_if_exists("/usr/sbin/sendmail");
+		symlink("/usr/sbin/sm.php", "/usr/sbin/sendmail");
 	]]>
 	</custom_php_install_command>
+	<custom_php_deinstall_command>
+		<![CDATA[
+		unlink_if_exists("/usr/sbin/sendmail");
+		]]>
+	</custom_php_deinstall_command>
 	<custom_php_resync_config_command>
 	<![CDATA[
 		sync_package_arpwatch();

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1123,7 +1123,7 @@
 		<build_pbi>
 			<port>net-mgmt/arpwatch</port>
 		</build_pbi>
-		<version>1.1.3</version>
+		<version>1.1.4</version>
 		<status>ALPHA</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/arpwatch/arpwatch.xml</config_file>


### PR DESCRIPTION
You can end up with orphaned /usr/sbin/sendmail as a copy of sm.php script, causing cron and other unwanted spam even after uninstalling the package. I recall couple of users complaining on the forum, examples: 
https://forum.pfsense.org/index.php/topic,68004.0.html
https://forum.pfsense.org/index.php?topic=74000.msg406041#msg406041

This still is not a proper fix, this shouldn't require and create /usr/sbin/sendmail at all. Debian ships this with a patch adding -s option to specify sendmail path:

```
-s
flag is used to specify the path to the sendmail program.
Any program that takes the option -odi and then text from stdin
can be substituted. This is useful for redirecting reports
to log files instead of mail.
```