### PR TITLE
havp code style cleanup and fixes

### DIFF
--- a/config/havp/antivirus.php
+++ b/config/havp/antivirus.php
@@ -1,383 +1,393 @@
 <?php
-/* $Id$ */
 /*
-    antivirus.php
-    Copyright (C) 2010 Serg Dvoriancev
-    All rights reserved.
+	antivirus.php
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2009-2010 Sergey Dvoriancev <dv_serg@mail.ru>
+	Copyright (C) 2014 Andrew Nikitin <andrey.b.nikitin@gmail.com>.
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require_once("guiconfig.inc");
 require_once("pkg-utils.inc");
 require_once("service-utils.inc");
-
-include("head.inc");
- 
-header("Content-type: text/html; charset=utf-8");
+require_once("/usr/local/pkg/havp.inc");
 
 $pgtitle = "Antivirus: General page";
+include("head.inc");
 
-if (file_exists("/usr/local/pkg/havp.inc"))
-   require_once("/usr/local/pkg/havp.inc");
-else echo "No havp.inc found";
-
-define('PATH_CLAMDB',   '/var/db/clamav');
-define('PATH_HAVPLOG',  '/var/log/havp/access.log');
+define('PATH_CLAMDB', '/var/db/clamav');
+define('PATH_HAVPLOG', '/var/log/havp/access.log');
 define('PATH_AVSTATUS', '/var/tmp/havp.status');
 
-function get_avdb_info()
-{
-    $r    = '';
-    $path = PATH_CLAMDB . "/{$filename}";
-    $fl   = get_dir(PATH_CLAMDB . "/");
+function get_avdb_info() {
+	$r = '';
+	$path = PATH_CLAMDB . "/{$filename}";
+	$fl = get_dir(PATH_CLAMDB . "/");
 
-    array_shift($fl);
-    array_shift($fl);
+	array_shift($fl);
+	array_shift($fl);
 
-    foreach ($fl as $fname) {
-        $path = PATH_CLAMDB . "/{$fname}";
-        $ext  = end(explode(".", $fname));
+	foreach ($fl as $fname) {
+		$path = PATH_CLAMDB . "/{$fname}";
+		$ext = end(explode(".", $fname));
 
-        if ( $ext == "cvd" || $ext == "cld") {
-            $stl = "style='padding-top: 0px; padding-bottom: 0px; padding-left: 4px; padding-right: 4px; border-left: 1px solid #999999;'";
-            if (file_exists($path)) {
-                $handle = '';
-                if ($handle = fopen($path, "r")) {
-                    $fsize = sprintf("%.2f M", filesize($path)/1024/1024);
-            
-                    $s = fread($handle, 1024);
-                    $s = explode(':', $s);
+		if ($ext == "cvd" || $ext == "cld") {
+			$stl = "style='padding-top: 0px; padding-bottom: 0px; padding-left: 4px; padding-right: 4px; border-left: 1px solid #999999;'";
+			if (file_exists($path)) {
+				$handle = '';
+				if ($handle = fopen($path, "r")) {
+					$fsize = sprintf("%.2f M", filesize($path)/1024/1024);
 
-                    # datetime
-                    $dt = explode(" ", $s[1]);
-                    $s[1] = strftime("%Y.%m.%d", strtotime("{$dt[0]} {$dt[1]} {$dt[2]}"));
-                    if ($s[0] == 'ClamAV-VDB')
-                        $r .= "<tr class='listr'><td $stl>{$fname}</td><td $stl>{$s[1]}</td><td $stl align='right'>$fsize</td><td $stl align='right'>{$s[2]}</td><td $stl align='right'>{$s[3]}</td><td $stl>{$s[7]}</td></tr>";
-                }
-                fclose($handle);
-            }
-        }
-    }
+					$s = fread($handle, 1024);
+					$s = explode(':', $s);
 
-    return $r;
+					// datetime
+					$dt = explode(" ", $s[1]);
+					$s[1] = strftime("%Y.%m.%d", strtotime("{$dt[0]} {$dt[1]} {$dt[2]}"));
+					if ($s[0] == 'ClamAV-VDB') {
+						$r .= "<tr class='listr'><td $stl>{$fname}</td><td $stl>{$s[1]}</td><td $stl align='right'>$fsize</td><td $stl align='right'>{$s[2]}</td><td $stl align='right'>{$s[3]}</td><td $stl>{$s[7]}</td></tr>";
+					}
+				}
+				fclose($handle);
+			}
+		}
+	}
+
+	return $r;
 }
 
-function get_av_statistic()
-{
-    return function_exists("havp_get_av_statistic") ? havp_get_av_statistic() : "Function 'havp_get_av_statistic' not found.";
+function get_av_statistic() {
+	return function_exists("havp_get_av_statistic") ? havp_get_av_statistic() : "Function 'havp_get_av_statistic' not found.";
 }
 
-function get_av_viruslog()
-{
-    return function_exists("havp_get_av_viruslog") ? havp_get_av_viruslog() : "Function 'havp_get_av_viruslog' not found.";
+function get_av_viruslog() {
+	return function_exists("havp_get_av_viruslog") ? havp_get_av_viruslog() : "Function 'havp_get_av_viruslog' not found.";
 }
 
-function get_scanlist()
-{
-    return function_exists("havp_get_filescanlist") ? havp_get_filescanlist() : "Function 'havp_get_filescanlist()' not found.";
+function get_scanlist() {
+	return function_exists("havp_get_filescanlist") ? havp_get_filescanlist() : "Function 'havp_get_filescanlist()' not found.";
 }
 
-function get_scan_log()
-{
-    $s = function_exists("havp_get_scan_log") ? havp_get_scan_log() : "Function 'havp_get_scan_log()' not found.";
-    $s = str_replace("\n", "<br>", $s);
-    return $s;
+function get_scan_log() {
+	$s = function_exists("havp_get_scan_log") ? havp_get_scan_log() : "Function 'havp_get_scan_log()' not found.";
+	$s = str_replace("\n", "<br />", $s);
+	return $s;
 }
 
-function pfsense_version_A()
-{
-    return function_exists("pfsense_version_") ? pfsense_version_() : 1;
+function havp_status() {
+	$s = "";
+	if (HVDEF_HAVP_STATUS_FILE && file_exists(HVDEF_HAVP_STATUS_FILE)) {
+		$s = file_get_contents(HVDEF_HAVP_STATUS_FILE);
+	}
+	return $s;
 }
 
-function havp_status()
-{
-    $s = "";
-    if (HVDEF_HAVP_STATUS_FILE && file_exists(HVDEF_HAVP_STATUS_FILE))
-        $s = file_get_contents(HVDEF_HAVP_STATUS_FILE);
-    return $s;
+function clamd_status() {
+	$s = "";
+	if (HVDEF_CLAM_STATUS_FILE && file_exists(HVDEF_CLAM_STATUS_FILE)) {
+		$s = file_get_contents(HVDEF_CLAM_STATUS_FILE);
+	}
+	return $s;
 }
 
-function clamd_status()
-{
-    $s = "";
-    if (HVDEF_CLAM_STATUS_FILE && file_exists(HVDEF_CLAM_STATUS_FILE))
-        $s = file_get_contents(HVDEF_CLAM_STATUS_FILE);
-    return $s;
+function avupdate_status() {
+	$s = "Not found.";
+	if (HVDEF_UPD_STATUS_FILE && file_exists(HVDEF_UPD_STATUS_FILE)) {
+		$s = file_get_contents(HVDEF_UPD_STATUS_FILE);
+	}
+	return str_replace( "\n", "<br />", $s );
 }
+/* ------------------------------------------------------------------------------ */
 
-function avupdate_status()
-{
-    $s = "Not found.";
-    if (HVDEF_UPD_STATUS_FILE && file_exists(HVDEF_UPD_STATUS_FILE))
-        $s = file_get_contents(HVDEF_UPD_STATUS_FILE);
-    return str_replace( "\n", "<br>", $s );
-}
-# ------------------------------------------------------------------------------
-
-/* start service */
-if($_POST['start'] != '') {
-	#start_service($_POST['start']);
-       if (file_exists(HVDEF_HAVP_STARTUP_SCRIPT)) {
-           mwexec_bg (HVDEF_HAVP_STARTUP_SCRIPT . " start");
-	    sleep(3);
-       }
-} else
-/* restart service */
-if($_POST['restart'] != '') {
-	#restart_service($_POST['restart']);
-       if (file_exists(HVDEF_HAVP_STARTUP_SCRIPT)) {
-           mwexec_bg (HVDEF_HAVP_STARTUP_SCRIPT . " restart");
-	    sleep(3);
-       }
-} else
-/* stop service */
-if($_POST['stop'] != '') {
-	#stop_service($_POST['stop']);
-       if (file_exists(HVDEF_HAVP_STARTUP_SCRIPT)) {
-           mwexec_bg (HVDEF_HAVP_STARTUP_SCRIPT . " stop");
-	    sleep(3);
-       }
+/* Start service */
+if ($_POST['start'] != '') {
+	// start_service($_POST['start']);
+	if (file_exists(HVDEF_HAVP_STARTUP_SCRIPT)) {
+		mwexec_bg (HVDEF_HAVP_STARTUP_SCRIPT . " start");
+		sleep(3);
+	}
+/* Restart service */
+} elseif ($_POST['restart'] != '') {
+	// restart_service($_POST['restart']);
+	if (file_exists(HVDEF_HAVP_STARTUP_SCRIPT)) {
+		mwexec_bg (HVDEF_HAVP_STARTUP_SCRIPT . " restart");
+		sleep(3);
+	}
+/* Stop service */
+} elseif ($_POST['stop'] != '') {
+	// stop_service($_POST['stop']);
+	if (file_exists(HVDEF_HAVP_STARTUP_SCRIPT)) {
+		mwexec_bg (HVDEF_HAVP_STARTUP_SCRIPT . " stop");
+		sleep(3);
+	}
 }
 
 /* Scan start */
 if ($_POST['scanpath'] != '') {
 	$scandir = $_POST['scanpath'];
-	if(function_exists("start_antivirus_scanner")) {
+	if (function_exists("start_antivirus_scanner")) {
 		start_antivirus_scanner($scandir);
-      }
-	else echo "No 'start_antivirus_scanner' function found.";
+	}
 }
 
 /* Start AV Update */
 if ($_POST['startupdate'] != '') {
-    if( function_exists("havp_update_AV")) {
-        havp_update_AV();
-    }
-#    else echo "No 'start_antivirus_scanner' function found.";
+	if (function_exists("havp_update_AV")) {
+		havp_update_AV();
+	}
 }
 
 /* Clear havp access log */
 if ($_POST['clearlog_x'] != '') {
-    file_put_contents(HVDEF_HAVP_ACCESSLOG, '');
+	file_put_contents(HVDEF_HAVP_ACCESSLOG, '');
 }
 
-# ------------------------------------------------------------------------------
+/* ------------------------------------------------------------------------------ */
 ?>
 
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 <?php include("fbegin.inc"); ?>
 
-<?php 
-if (pfsense_version_A() == '1') { 
-    echo "<p class=\"pgtitle\">$pgtitle</p>";
-} 
-?>
-
 <form action="antivirus.php" method="post">
 <?php if ($savemsg) print_info_box($savemsg); ?>
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <!-- Tabs -->
-  <tr>
-    <td>
+<tr><td>
 <?php
 	$tab_array = array();
 	$tab_array[] = array(gettext("General page"), true, "antivirus.php");
-	$tab_array[] = array(gettext("HTTP proxy"), false, "pkg_edit.php?xml=havp.xml&amp;id=0");
-	$tab_array[] = array(gettext("Settings"), false, "pkg_edit.php?xml=havp_avset.xml&amp;id=0");
+	$tab_array[] = array(gettext("HTTP proxy"), false, "pkg_edit.php?xml=havp.xml");
+	$tab_array[] = array(gettext("Settings"), false, "pkg_edit.php?xml=havp_avset.xml");
 	$tab_array[] = array(gettext("HAVP Log"), false, "havp_log.php");
 
 	display_top_tabs($tab_array);
 ?>
-    </td>
-  </tr>
-  <tr><td><div id="mainarea"><table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tr>
-    <td class="tabcont" valign="top">
-      <table width="100%" border="0" cellpadding="0" cellspacing="0">
-<!-- Service -->
-        <tr>
-          <td class="listhdrr">Service</td>
-          <td class="listhdrr">Status </td>
-          <td class="listhdrr">&nbsp; </td>
-          <td class="listhdrr">Version</td>
-<!--          <td class="listhdrr">Settings</td> -->
-        </tr>
-        <tr>
-          <td class="listlr">HTTP Antivirus Proxy ( <?php echo(havp_status()); ?> )</td>
-          <td class="listr" ><center>
-                  <?php
-                          $running = (is_service_running("havp", $ps) or is_process_running("havp"));
-                          if ($running) 
-                               echo "<img src=\"/themes/" . $g["theme"] . "/images/icons/icon_pass.gif\"  > Running";
-                          else echo "<img src=\"/themes/" . $g["theme"] . "/images/icons/icon_block.gif\"> Stopped";                          
-                  ?>
-          </td>
-          <td class="listr" nowrap>
-                  <?php
-                          if($running) {
-		                   echo "<input title='Restart Service' name='restart' type='image' value='havp' border=0 src='./themes/".$g['theme']."/images/icons/icon_service_restart.gif'>";
-		                   echo "&nbsp";
-		                   echo "<input title='Stop Service'    name='stop'    type='image' value='havp' border=0 src='./themes/".$g['theme']."/images/icons/icon_service_stop.gif'>";
-		            } else echo "<input title='Start Service'   name='start'   type='image' value='havp' border=0 src='./themes/".$g['theme']."/images/icons/icon_service_start.gif'>";		            
-		    ?>
-          </td>
-          <td class="listr">
-                  <?php echo exec("pkg_info | grep \"[h]avp\""); ?>
-          </td>
-<!--
-          <td class="listr">
-                  <a href="/pkg_edit.php?xml=havp.xml&amp;id=0">
-                      <?php echo "<input height=14 title='Show Proxy settings page' name='scan' type='image' value='scan' border=0 src='./themes/".$g['theme']."/images/icons/icon_service_start.gif'>"; ?>
-                      <font size="2">&nbsp;Proxy  Settings</size>                    
-                  </a>
-          </td>
--->
-        </tr>
-        <tr>
-          <td class="listlr">Antivirus Server ( <?php echo(clamd_status()); ?> )</td>
-          <td class="listr"><center>
-                  <?php
-                          $running = (is_service_running("clamd", $ps) or is_process_running("clamd"));
-                          if ($running) 
-                               echo "<img src=\"/themes/" . $g["theme"] . "/images/icons/icon_pass.gif\"  > Running";
-                          else echo "<img src=\"/themes/" . $g["theme"] . "/images/icons/icon_block.gif\"> Stopped";                          
-                  ?>
-          </td>
-          <td class="listr">&nbsp;</td>
-          <td class="listr">
-                  <?php echo exec("clamd -V"); ?>
-          </td>
-<!--
-          <td class="listr">
-                  <a href="/pkg_edit.php?xml=havp_avset.xml&id=0">
-                      <?php echo "<input height=14 title='Show Antivirus settings page' name='scan' type='image' value='scan' border=0 src='./themes/".$g['theme']."/images/icons/icon_service_start.gif'>"; ?>
-                      <font size="2">&nbsp;Antivirus Settings</size>                    
-                  </a>
-          </td>
--->
-        </tr>
+</td></tr>
+<tr><td>
+<div id="mainarea"><table width="100%" border="0" cellpadding="0" cellspacing="0">
+<tr><td class="tabcont" valign="top">
+	<table width="100%" border="0" cellpadding="0" cellspacing="0">
+		<!-- Service -->
+		<tr>
+			<td class="listhdrr">Service</td>
+			<td class="listhdrr">Status </td>
+			<td class="listhdrr">&nbsp; </td>
+			<td class="listhdrr">Version</td>
+			<!-- <td class="listhdrr">Settings</td> -->
+		</tr>
+		<tr>
+			<td class="listlr">HTTP Antivirus Proxy ( <?php echo(havp_status()); ?> )</td>
+			<td class="listr" ><center>
+			<?php
+				$running = (is_service_running("havp", $ps) or is_process_running("havp"));
+				if ($running) {
+					echo "<img src=\"/themes/" . $g['theme'] . "/images/icons/icon_pass.gif\" alt=\"\" /> Running";
+				} else {
+					echo "<img src=\"/themes/" . $g['theme'] . "/images/icons/icon_block.gif\" alt=\"\" /> Stopped";
+				}
+			?>
+			</td>
+			<td class="listr" nowrap="nowrap">
+			<?php
+				if ($running) {
+					echo "<input title='Restart Service' name='restart' type='image' value='havp' src='./themes/" . $g['theme'] . "/images/icons/icon_service_restart.gif' />";
+					echo "&nbsp";
+					echo "<input title='Stop Service' name='stop' type='image' value='havp' src='./themes/" . $g['theme'] . "/images/icons/icon_service_stop.gif' />";
+				} else {
+					echo "<input title='Start Service' name='start' type='image' value='havp' src='./themes/" . $g['theme'] . "/images/icons/icon_service_start.gif' />";
+				}
+			?>
+			</td>
+			<td class="listr">
+				<!-- Obviously broken on any 2.2+ version -->
+				<?php echo exec("pkg_info | grep \"[h]avp\""); ?>
+			</td>
+			<!--
+			<td class="listr">
+				<a href="/pkg_edit.php?xml=havp.xml">
+					<?php echo "<input height='14' title='Show Proxy settings page' name='scan' type='image' value='scan' src='./themes/" . $g['theme'] . "/images/icons/icon_service_start.gif' />"; ?>
+					&nbsp;Proxy Settings
+				</a>
+			</td>
+			-->
+		</tr>
+		<tr>
+			<td class="listlr">Antivirus Server ( <?php echo(clamd_status()); ?> )</td>
+			<td class="listr"><center>
+			<?php
+				$running = (is_service_running("clamd", $ps) or is_process_running("clamd"));
+				if ($running) {
+					echo "<img src=\"/themes/" . $g["theme"] . "/images/icons/icon_pass.gif\" alt=\"\" /> Running";
+				} else {
+					echo "<img src=\"/themes/" . $g["theme"] . "/images/icons/icon_block.gif\" alt=\"\" /> Stopped";
+				}
+			?>
+			</td>
+			<td class="listr">&nbsp;</td>
+			<td class="listr">
+			<?php echo exec("clamd -V"); ?>
+			</td>
+			<!--
+			<td class="listr">
+				<a href="/pkg_edit.php?xml=havp_avset.xml">
+					<?php echo "<input height='14' title='Show Antivirus settings page' name='scan' type='image' value='scan' src='./themes/" . $g['theme'] . "/images/icons/icon_service_start.gif' />"; ?>
+					&nbsp;Antivirus Settings
+				</a>
+			</td>
+			-->
+		</tr>
 
-        <tr><td>&nbsp;</td></tr>
-<!-- Update -->
-        <tr>
-          <td class="listhdrr" colspan="3">Antivirus Update</td>
-          <td class="listhdrr" colspan="1">Update status</td></tr>
-        </tr>
-        <tr>
-          <td class="listlr" colspan="3" nowrap>
-                  <?php echo "<input height=14 title='Start antivirus update' name='startupdate' type='image' value='startupdate' border=0 src='./themes/".$g['theme']."/images/icons/icon_service_start.gif'>"; ?>
-                  <font size="-1">&nbsp;Start Update</font>
-          </td>
-          <td class="listr" colspan="1">
-                  <?php echo avupdate_status(); ?>
-          </td>
-        </tr>
-        <tr>
-          <td class="listlr"colspan="3">Antivirus Base Info</td>
-          <td colspan="1">
-            <table width="100%" border="0" cellspacing="0" cellpadding="1" ><tbody>
-              <tr  align="center"><td class="listhdrr">Database</td><td class="listhdrr">Date</td><td class="listhdrr">Size</td><td class="listhdrr">Ver.</td><td class="listhdrr">Signatures</td><td class="listhdrr">Builder</td></tr>
-              <?php echo get_avdb_info(); ?>
-            </tbody></table>
-          </td>
-        </tr>
-        <tr><td>&nbsp;</td></tr>
-<!-- File Scanner -->
-        <tr>
-          <td class="listhdrr" colspan="3">File scanner</td>
-          <td class="listhdrr" colspan="1">Scanner status</td>
-        </tr>
-        <tr>
-          <td class="vtable" colspan="3">
-              <table width="100%" border="0" cellpadding="6" cellspacing="0">
-                <tr>
-                  <td class="listlr">
-                        &nbsp;Path: <br>
-                        <input size="60%" id="scanpath" name="scanpath" value=""><br>
-                        &nbsp;Enter file path or catalog for scanning.
-                        <hr>
-                        <?php
-                          $scanlist = get_scanlist();
-                          if (is_array($scanlist))
-                              foreach($scanlist as $scan) {
-                                  echo "<span onclick=\"document.getElementById('scanpath').value='{$scan['path']}';\" style=\"cursor: pointer;\">\n";
-                                  echo "<img src='./themes/".$g['theme']."/images/icons/icon_pass.gif'>\n";
-                                  echo "<u>{$scan['descr']}</u>\n";
-                                  echo "</span>";
-                                  echo "<br>";
-                              }
-                        ?>
-                  </td>
-                </tr>	              
-                <tr>
-                  <td class="vncellr" nowrap>
-                        <?php echo "<input height=14 title='Scan selected file or catalog' name='scan' type='image' value='scan' border=0 src='./themes/".$g['theme']."/images/icons/icon_service_start.gif'>"; ?>
-                        <font size="-1">&nbsp;Start Scanner</font>
-                  </td>
-                </tr>
-              </table>
-          </td>
-          <td class="listr" colspan="1">
-              <?php echo get_scan_log(); ?>
-          </td>
-        </tr>
-        <tr><td>&nbsp;</td></tr>
-<!-- Last Viruses -->
-        <tr>
-          <td colspan="4">
-            <table width="100%" border="0" cellspacing="0" cellpadding="1" ><tbody>
-              <tr class="vncellt"><td class="listhdrr" colspan="4">Last Viruses</td></tr>
-              <?php 
-                  $count = 30;
-                  $stl   = "style='padding-right: 4px;'";
-                  $s = get_av_viruslog();                       
-                  krsort($s); # reverse sort
-                  if (is_array($s) && !empty($s)) {
-                      foreach($s as $val) {
-                          if (!$count) break;
-                          $ln = explode(' ', $val);
-                          echo "<tr><td nowrap $stl>{$ln[0]} {$ln[1]}</td><td nowrap $stl>{$ln[2]}</td><td>{$ln[5]}</td><td nowrap>{$ln[9]}</td></tr>";
-                          $count--;
-                      }
-                  }
-                  else echo "<tr><td $stl>Not found</td></tr>";
-              ?>              
-              <tr class="listr"><td class="listr" colspan="4"><?php echo get_av_statistic(); ?><?php echo "<div style='float:right;'><input title='Clear antivirus log' name='clearlog' type='image' value='havp' border=0 src='./themes/".$g['theme']."/images/icons/icon_x.gif'>"; ?><font size="-1">&nbsp;Clear log</font></div></td></tr>	              
-            </tbody></table>
-          </td>
-        </tr>
-      </table>
-    </td>
-  </tr>
+		<tr><td>&nbsp;</td></tr>
+		<!-- Update -->
+		<tr>
+			<td class="listhdrr" colspan="3">Antivirus Update</td>
+			<td class="listhdrr" colspan="1">Update Status</td>
+		</tr>
+		<tr>
+			<td class="listlr" colspan="3" nowrap="nowrap">
+			<?php echo "<input height='14' title='Start antivirus update' name='startupdate' type='image' value='startupdate' src='./themes/" . $g['theme'] . "/images/icons/icon_service_start.gif' />"; ?>
+				&nbsp;Start Update
+			</td>
+			<td class="listr" colspan="1">
+			<?php echo avupdate_status(); ?>
+			</td>
+		</tr>
+		<tr>
+			<td class="listlr"colspan="3">Antivirus Base Info</td>
+			<td colspan="1">
+				<table width="100%" border="0" cellspacing="0" cellpadding="1" ><tbody>
+				<tr align="center">
+					<td class="listhdrr">Database</td>
+					<td class="listhdrr">Date</td>
+					<td class="listhdrr">Size</td>
+					<td class="listhdrr">Ver.</td>
+					<td class="listhdrr">Signatures</td>
+					<td class="listhdrr">Builder</td>
+				</tr>
+				<?php echo get_avdb_info(); ?>
+				</tbody></table>
+			</td>
+		</tr>
+
+		<tr><td>&nbsp;</td></tr>
+		<!-- File Scanner -->
+		<tr>
+			<td class="listhdrr" colspan="3">File Scanner</td>
+			<td class="listhdrr" colspan="1">Scanner Status</td>
+		</tr>
+		<tr>
+			<td class="vtable" colspan="3">
+				<table width="100%" border="0" cellpadding="6" cellspacing="0">
+				<tr>
+					<td class="listlr">
+					&nbsp;Path: <br />
+					<input size="60%" id="scanpath" name="scanpath" value="" /><br />
+					&nbsp;Enter file path or catalog for scanning.
+					<hr />
+					<?php
+						$scanlist = get_scanlist();
+						if (is_array($scanlist)) {
+							foreach ($scanlist as $scan) {
+								echo "<span onclick=\"document.getElementById('scanpath').value='{$scan['path']}';\" style=\"cursor: pointer;\">\n";
+								echo "<img src='./themes/" . $g['theme'] . "/images/icons/icon_pass.gif' alt='' />\n";
+								echo "<span style='text-decoration: underline;'>{$scan['descr']}</span>\n";
+								echo "</span>";
+								echo "<br />";
+							}
+						}
+					?>
+					</td>
+				</tr>
+				<tr>
+					<td class="vncellr" nowrap="nowrap">
+						<?php echo "<input height='14' title='Scan selected file or catalog' name='scan' type='image' value='scan' src='./themes/" . $g['theme'] . "/images/icons/icon_service_start.gif' />"; ?>
+						&nbsp;Start Scanner
+					</td>
+				</tr>
+				</table>
+			</td>
+			<td class="listr" colspan="1">
+			<?php echo get_scan_log(); ?>
+			</td>
+		</tr>
+
+		<tr><td>&nbsp;</td></tr>
+		<!-- Last Viruses -->
+		<tr>
+			<td colspan="4">
+				<table width="100%" border="0" cellspacing="0" cellpadding="1" >
+				<tbody>
+				<tr class="vncellt">
+					<td class="listhdrr" colspan="4">Last Viruses</td>
+				</tr>
+				<?php
+				$count = 30;
+				$stl = "style='padding-right: 4px;'";
+				$s = get_av_viruslog();
+				// reverse sort
+				krsort($s);
+				if (is_array($s) && !empty($s)) {
+					foreach ($s as $val) {
+						if (!$count) {
+							break;
+						}
+						$ln = explode(' ', $val);
+						echo "<tr><td nowrap='nowrap' $stl>{$ln[0]} {$ln[1]}</td><td nowrap='nowrap' $stl>{$ln[2]}</td><td>{$ln[5]}</td><td nowrap='nowrap'>{$ln[9]}</td></tr>";
+						$count--;
+					}
+				} else {
+					echo "<tr><td $stl>Not found</td></tr>";
+				}
+			?>
+				<tr class="listr">
+					<td class="listr" colspan="4">
+						<?php echo get_av_statistic(); ?>
+						<?php echo "<div style='float: right;'><input title='Clear antivirus log' name='clearlog' type='image' value='havp' src='./themes/" . $g['theme'] . "/images/icons/icon_x.gif' />"; ?>&nbsp;Clear log</div>
+					</td>
+				</tr>
+				</tbody>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+</td></tr>
 </table>
-</div></tr></td></table>
+
+</div>
+
+</tr></td>
+</table>
 </form>
 
 <?php include("fend.inc"); ?>
 
-<script type="text/javascript"> 
-  NiftyCheck(); 
-  Rounded("div#mainarea","bl br","#FFF","#eeeeee","smooth");
+<script type="text/javascript">
+//<![CDATA[
+	NiftyCheck();
+	Rounded("div#mainarea","bl br","#FFF","#eeeeee","smooth");
+//]]>
 </script>
 
 </body>

--- a/config/havp/havp.inc
+++ b/config/havp/havp.inc
@@ -1,35 +1,33 @@
 <?php
 /*
-        havp.inc
-        Part of pfSense package
-        Copyright (C) 2009 Serg Dvorianceev
-        All rights reserved.
+	havp.inc
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2009-2010 Sergey Dvoriancev <dv_serg@mail.ru>
+	Copyright (C) 2014 Andrew Nikitin <andrey.b.nikitin@gmail.com>.
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
-
-/* ! for HAVP v.0.88 ! */
-/* ! Real virus collection for tests http://www.nvkz.kuzbass.net/as/ ! */
-
 require_once('globals.inc');
 require_once('config.inc');
 require_once('util.inc');
@@ -38,941 +36,980 @@ require_once('pfsense-utils.inc');
 require_once('pkg-utils.inc');
 require_once('service-utils.inc');
 
-if(!function_exists("filter_configure"))
+if (!function_exists("filter_configure")) {
 	require_once("filter.inc");
-
-# ------------------------------------------------------------------------------
-# globals
-# ------------------------------------------------------------------------------
-# Debug / uncomment next for debug /
-define('HV_DEBUG',             'false');
-
-# use Clamd daemon (another - use libclam)
-# define('HV_USE_CLAMD',         'true');
-define('HV_CLAMD_TCPSOCKET',   'true');
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# RAM Disk - use as 'tmp' dir for more quick work
-#    note: this options allow RAM Disk allocation
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# set 'true' for enable RAM Disk
-define('HV_USE_TMPRAMDISK', 'true');
-# set 'false' for disable RAM Disk on VM (if you have troubles on VM)
-define('HV_VM_TMPRAMDISK',  'true');
-
-# ------------------------------------------------------------------------------
-# forms
-# ------------------------------------------------------------------------------
-define('HVFORM_HAVP',         'havp');
-define('HVFORM_FSCAN',        'havpfscan');
-define('HVFORM_AVSET',        'havpavset');
-
-# ------------------------------------------------------------------------------
-# defines
-# ------------------------------------------------------------------------------
-# havp
-define('HVDEF_ADDR',                    '127.0.0.1');
-define('HVDEF_PROXYPORT',	            '8080');
-define('HVDEF_MAXSCANSIZE',             '5000000'); # [bytes] ! do not enter 0 or big size !
-define('HVDEF_MAXARCSCANSIZE',          '5000000'); # [bytes] ! do not enter 0 or big size !
-define('HVDEF_PID_FILE',                '/var/run/havp.pid');
-
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version == "2.1" || $pf_version == "2.2")
-		define("HVDEF_WORK_DIR", "/usr/pbi/havp-" . php_uname("m") . "/local/etc");
-	else
-		define("HVDEF_WORK_DIR", "/usr/local/etc/havp");
+}
 
 
-$pfSversion = str_replace("\s", "", file_get_contents("/etc/version"));
-if(preg_match("/^2./",$pfSversion))
-	define('HVDEF_LOG_DIR',			'/var/log/havp');
-else
-	define('HVDEF_LOG_DIR',			'/var/log');
+/*
+* ------------------------------------------------------------------------------
+* Globals
+* ------------------------------------------------------------------------------
+* Set to true to enable debug
+*/
+define('HV_DEBUG',		'false');
 
-define('HVDEF_TEMP_DIR',                '/var/tmp');
-define('HVDEF_HAVPTEMP_DIR',            HVDEF_TEMP_DIR.'/havp');
-define('HVDEF_RAMTEMP_DIR',             HVDEF_TEMP_DIR.'/havpRAM');
-define('HVDEF_SCANTEMPFILE',            '/havp-XXXXXX');
-define('HVDEF_TEMPLATES',               '/usr/local/share/examples/havp/templates');
-define('HVDEF_TEMPLATES_EX',            HVDEF_TEMPLATES . '_ex');
-define('HVDEF_FILTER_RULES',            '/tmp/rules.havp');
-define('HVDEF_HAVP_CONFIG',             HVDEF_WORK_DIR.'/havp.config');
-define('HVDEF_HAVP_XMLCONF',            HVDEF_WORK_DIR.'/havp_conf.xml');
-define('HVDEF_HAVP_WHITELIST',          HVDEF_WORK_DIR.'/whitelist');
-define('HVDEF_HAVP_BLACKLIST',          HVDEF_WORK_DIR.'/blacklist');
-define('HVDEF_HAVP_ACCESSLOG',          HVDEF_LOG_DIR .'/access.log');
-define('HVDEF_HAVP_ERRORLOG',           HVDEF_LOG_DIR .'/havp.log');
-define('HVDEF_HAVP_MINSRV',             '3');
-define('HVDEF_HAVP_MAXSRV',             '100');
+/* Use clamd daemon or libclam */
+//define('HV_USE_CLAMD',	'true');
+define('HV_CLAMD_TCPSOCKET',	'true');
 
-# Clam
-define('HVDEF_CLAM_RUNDIR',             '/var/run/clamav');
-#define('HVDEF_CLAM_RUNDIR',             '/var/run');
-define('HVDEF_CLAM_DBDIR',              '/var/db/clamav');
-if(preg_match("/^2./",$pfSversion))
-	define('HVDEF_AVLOG_DIR',               '/var/log/clamav');
-else
-	define('HVDEF_AVLOG_DIR',               '/var/log');
+/*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* RAM Disk - use as 'tmp' dir for faster scanning
+* Note: these options allow RAM Disk allocation
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Set 'true' to enable RAM Disk
+*/
+define('HV_USE_TMPRAMDISK',	'true');
+/* Set 'false' to disable RAM Disk on VM in case you have troubles */
+define('HV_VM_TMPRAMDISK',	'true');
 
-define('HVDEF_CLAM_SOCKET',             HVDEF_CLAM_RUNDIR.'/clamd.sock');
-define('HVDEF_CLAM_PID',                HVDEF_CLAM_RUNDIR.'/clamd.pid');
-define('HVDEF_CLAM_LOG',                HVDEF_AVLOG_DIR . '/clamd.log');
-define('HVDEF_CLAM_WORKDIR',            '/usr/local/etc');
-define('HVDEF_CLAM_CONFIG',             '/usr/local/etc/clamd.conf');
-define('HVDEF_CLAM_TCPSOCKET',          '3310');
-define('HVDEF_FRESHCLAM_CONF',          '/usr/local/etc/freshclam.conf');
-define('HVDEF_FRESHCLAM_LOG',           HVDEF_AVLOG_DIR . '/freshclam.log');
-define('HVDEF_CLAMSCAN_LOG',            '/var/log/clamscan.log');
-define('HVDEF_STATUS_FILE',             '/var/tmp/havp.status');
+/*
+* ------------------------------------------------------------------------------
+* Forms
+* ------------------------------------------------------------------------------
+*/
+define('HVFORM_HAVP',		'havp');
+define('HVFORM_FSCAN',		'havpfscan');
+define('HVFORM_AVSET',		'havpavset');
 
-# script's
-define('HVDEF_SCRIPT_DIR',              '/usr/local/etc/rc.d');
-define('HVDEF_AVCRON_SCRIPT',           '/clamav-freshclam');
-define('HVDEF_FILTER_RESYNC_SCRIPT',    '/usr/local/pkg/pf/havp_filter_resync.sh');
-define('HVDEF_HAVP_STARTUP_SCRIPT',     HVDEF_SCRIPT_DIR . '/havp.sh');
-define('HVDEF_CLAM_STARTUP_SCRIPT',     HVDEF_SCRIPT_DIR . '/clamd');
-define('HVDEF_AVUPD_SCRIPT',            HVDEF_SCRIPT_DIR . '/havp_avupdate');
+/*
+* ------------------------------------------------------------------------------
+* Defines
+* ------------------------------------------------------------------------------
+*/
+/* HAVP */
+define('HVDEF_ADDR',		'127.0.0.1');
+define('HVDEF_PROXYPORT',	'8080');
+define('HVDEF_MAXSCANSIZE',	'5000000'); // [bytes] ! do not enter 0 or big size !
+define('HVDEF_MAXARCSCANSIZE',	'5000000'); // [bytes] ! do not enter 0 or big size !
+define('HVDEF_PID_FILE',	'/var/run/havp.pid');
 
-# status
-define('HVDEF_HAVP_STATUS_FILE',        '/tmp/havp.status');
-define('HVDEF_CLAM_STATUS_FILE',        '/tmp/clam.status');
-define('HVDEF_UPD_STATUS_FILE',         '/tmp/havp.update.status');
-define('HVDEF_FRESHCLAM_STATUS_FILE',   '/tmp/havp.freshclam.status');
+$pf_version=substr(trim(file_get_contents("/etc/version")), 0, 3);
+if ($pf_version == "2.1" || $pf_version == "2.2") {
+	define("HVDEF_WORK_DIR", "/usr/pbi/havp-" . php_uname("m") . "/local/etc");
+} else {
+	define("HVDEF_WORK_DIR", "/usr/local/etc/havp");
+}
 
-# cron
-define('HVDEF_CLAM_UPD_CRONNAME',       'havp_clam_update');
-define('HVDEF_CLAM_UPD_CRONCMD',        HVDEF_SCRIPT_DIR . HVDEF_AVCRON_SCRIPT . " start");
-define('HVDEF_CLAM_UPD_CRONKEY',        HVDEF_AVCRON_SCRIPT);
+define('HVDEF_LOG_DIR',		'/var/log/havp');
+define('HVDEF_TEMP_DIR',	'/var/tmp');
+define('HVDEF_HAVPTEMP_DIR',	HVDEF_TEMP_DIR . '/havp');
+define('HVDEF_RAMTEMP_DIR',	HVDEF_TEMP_DIR . '/havpRAM');
+define('HVDEF_SCANTEMPFILE',	'/havp-XXXXXX');
+define('HVDEF_TEMPLATES',	'/usr/local/share/examples/havp/templates');
+define('HVDEF_TEMPLATES_EX',	HVDEF_TEMPLATES . '_ex');
+define('HVDEF_FILTER_RULES',	'/tmp/rules.havp');
+define('HVDEF_HAVP_CONFIG',	HVDEF_WORK_DIR . '/havp.config');
+define('HVDEF_HAVP_XMLCONF',	HVDEF_WORK_DIR . '/havp_conf.xml');
+define('HVDEF_HAVP_WHITELIST',	HVDEF_WORK_DIR . '/whitelist');
+define('HVDEF_HAVP_BLACKLIST',	HVDEF_WORK_DIR . '/blacklist');
+define('HVDEF_HAVP_ACCESSLOG',	HVDEF_LOG_DIR . '/access.log');
+define('HVDEF_HAVP_ERRORLOG',	HVDEF_LOG_DIR . '/havp.log');
+define('HVDEF_HAVP_MINSRV',	'3');
+define('HVDEF_HAVP_MAXSRV',	'100');
 
-# user
-define('HVDEF_USER',                    'havp');
-define('HVDEF_GROUP',                   'havp');
-define('HVDEF_AVUSER',                  HVDEF_USER);
+/* ClamAV */
+define('HVDEF_CLAM_RUNDIR',	'/var/run/clamav');
+define('HVDEF_CLAM_DBDIR',	'/var/db/clamav');
+define('HVDEF_AVLOG_DIR',	'/var/log/clamav');
+define('HVDEF_CLAM_SOCKET',	HVDEF_CLAM_RUNDIR . '/clamd.sock');
+define('HVDEF_CLAM_PID',	HVDEF_CLAM_RUNDIR . '/clamd.pid');
+define('HVDEF_CLAM_LOG',	HVDEF_AVLOG_DIR . '/clamd.log');
+define('HVDEF_CLAM_WORKDIR',	'/usr/local/etc');
+define('HVDEF_CLAM_CONFIG',	'/usr/local/etc/clamd.conf');
+define('HVDEF_CLAM_TCPSOCKET',	'3310');
+define('HVDEF_FRESHCLAM_CONF',	'/usr/local/etc/freshclam.conf');
+define('HVDEF_FRESHCLAM_LOG',	HVDEF_AVLOG_DIR . '/freshclam.log');
+define('HVDEF_CLAMSCAN_LOG',	'/var/log/clamscan.log');
+define('HVDEF_STATUS_FILE',	'/var/tmp/havp.status');
 
-# fields
-define('HV_SCANTEMPFILE',	 'hv_scan_tempfile');
+/* Scripts */
+define('HVDEF_SCRIPT_DIR',		'/usr/local/etc/rc.d');
+define('HVDEF_AVCRON_SCRIPT',		'/clamav-freshclam');
+define('HVDEF_FILTER_RESYNC_SCRIPT',	'/usr/local/pkg/pf/havp_filter_resync.sh');
+define('HVDEF_HAVP_STARTUP_SCRIPT',	HVDEF_SCRIPT_DIR . '/havp.sh');
+define('HVDEF_CLAM_STARTUP_SCRIPT',	HVDEF_SCRIPT_DIR . '/clamd');
+define('HVDEF_AVUPD_SCRIPT',		HVDEF_SCRIPT_DIR . '/havp_avupdate');
 
-# ------------------------------------------------------------------------------
-# XML fields
-# ------------------------------------------------------------------------------
-define('F_ENABLE',              'enable');
-define('F_USECLAMD',            'useclamd');
-define('F_PROXYMODE',           'proxymode');
-define('F_PROXYINTERFACE',      'proxyinterface');
-define('F_PROXYBINDIFACE',      'proxybindiface');  # internal var
-define('F_PROXYPORT',           'proxyport');
-define('F_PARENTPROXY',         'parentproxy');
-define('F_LANGUAGE',            'lang');
-define('F_MAXDOWNLOADSIZE',     'maxdownloadsize');
-define('F_RANGE',               'range');
-define('F_WHITELIST',           'whitelist');
-define('F_BLACKLIST',           'blacklist');
-define('F_ENABLEFORWARDEDIP',   'enableforwardedip');
-define('F_ENABLEXFORWARDEDFOR', 'enablexforwardedfor');
-define('F_ENABLERAMDISK',       'enableramdisk');
-# scanner
-define('F_FAILSCANERROR',       'failscanerror');
-define('F_SCANMAXSIZE',         'scanmaxsize');
-define('F_SCANIMG',             'scanimg');
-define('F_SCANARC',             'scanarc');
-define('F_SCANSTREAM',          'scanstream');
-define('F_SCANARCMAXSIZE',      'scanarcmaxsize');
-define('F_SCANBROKENEXE',       'scanbrokenexe');
-# antivirus options
-define('F_HAVPUPDATE',        'havpavupdate');
-define('F_DBREGION',          'dbregion');
-define('F_AVUPDATESERVER',    'avupdateserver');
-# log
-define('F_SYSLOG',            'syslog');
-define('F_LOG',               'log');
-define('F_AVSETSYSLOG',       'avsetsyslog');
-define('F_AVSETLOG',          'avsetlog');
-#
-define('F_TEMPLATEPATH',      'templatepath');    # internal var
-# file scanner [HVFORM_FSCAN]
-define('F_SCANFILEPATH',      'scanfilepath');
-# ���� ��������� ��� ��� � ��� � ��� ������
-define('F_DISABLEXFORWARD',   'disablexforward'); # + forwarded ip
-define('F_FORWARDEDIP',       'forwardedip');
+/* Status */
+define('HVDEF_HAVP_STATUS_FILE',	'/tmp/havp.status');
+define('HVDEF_CLAM_STATUS_FILE',	'/tmp/clam.status');
+define('HVDEF_UPD_STATUS_FILE',		'/tmp/havp.update.status');
+define('HVDEF_FRESHCLAM_STATUS_FILE',	'/tmp/havp.freshclam.status');
 
-# ------------------------------------------------------------------------------
-# global config
-# ------------------------------------------------------------------------------
+/* Cron */
+define('HVDEF_CLAM_UPD_CRONNAME',	'havp_clam_update');
+define('HVDEF_CLAM_UPD_CRONCMD',	HVDEF_SCRIPT_DIR . HVDEF_AVCRON_SCRIPT . " start");
+define('HVDEF_CLAM_UPD_CRONKEY',	HVDEF_AVCRON_SCRIPT);
+
+/* User */
+define('HVDEF_USER',		'havp');
+define('HVDEF_GROUP',		'havp');
+define('HVDEF_AVUSER',		HVDEF_USER);
+
+define('HV_SCANTEMPFILE',	'hv_scan_tempfile');
+
+/*
+* ------------------------------------------------------------------------------
+* XML fields
+* ------------------------------------------------------------------------------
+*/
+define('F_ENABLE',		'enable');
+define('F_USECLAMD',		'useclamd');
+define('F_PROXYMODE',		'proxymode');
+define('F_PROXYINTERFACE',	'proxyinterface');
+define('F_PROXYBINDIFACE',	'proxybindiface'); // internal var
+define('F_PROXYPORT',		'proxyport');
+define('F_PARENTPROXY',		'parentproxy');
+define('F_LANGUAGE',		'lang');
+define('F_MAXDOWNLOADSIZE',	'maxdownloadsize');
+define('F_RANGE',		'range');
+define('F_WHITELIST',		'whitelist');
+define('F_BLACKLIST',		'blacklist');
+define('F_ENABLEFORWARDEDIP',	'enableforwardedip');
+define('F_ENABLEXFORWARDEDFOR',	'enablexforwardedfor');
+define('F_ENABLERAMDISK',	'enableramdisk');
+/* Scanner */
+define('F_FAILSCANERROR',	'failscanerror');
+define('F_SCANMAXSIZE',		'scanmaxsize');
+define('F_SCANIMG',		'scanimg');
+define('F_SCANARC',		'scanarc');
+define('F_SCANSTREAM',		'scanstream');
+define('F_SCANARCMAXSIZE',	'scanarcmaxsize');
+define('F_SCANBROKENEXE',	'scanbrokenexe');
+/* Antivirus Options */
+define('F_HAVPUPDATE',		'havpavupdate');
+define('F_DBREGION',		'dbregion');
+define('F_AVUPDATESERVER',	'avupdateserver');
+/* Logging */
+define('F_SYSLOG',		'syslog');
+define('F_LOG',			'log');
+define('F_AVSETSYSLOG',		'avsetsyslog');
+define('F_AVSETLOG',		'avsetlog');
+
+define('F_TEMPLATEPATH',	'templatepath'); // internal var
+/* File Scanner [HVFORM_FSCAN] */
+define('F_SCANFILEPATH',	'scanfilepath');
+define('F_DISABLEXFORWARD',	'disablexforward');
+define('F_FORWARDEDIP',		'forwardedip');
+
+/*
+* ------------------------------------------------------------------------------
+* Global Config
+* ------------------------------------------------------------------------------
+*/
 $havp_config = array();
 $havp_config[HV_SCANTEMPFILE] = HVDEF_HAVPTEMP_DIR . HVDEF_SCANTEMPFILE;
 
-# ------------------------------------------------------------------------------
-# Initialization
-# ------------------------------------------------------------------------------
+/*
+* ------------------------------------------------------------------------------
+* Initialization
+* ------------------------------------------------------------------------------
+*/
 havp_convert_pfxml_xml();
 
-# ==============================================================================
-# Installation and config
-# ==============================================================================
-function havp_install()
-{
-    update_status("HAVP check system..\n");
-    havp_check_system();
-    havp_fix();
+/*
+* ==============================================================================
+* Installation and config
+* ==============================================================================
+*/
+function havp_install() {
+	update_status("HAVP check system ...\n");
+	havp_check_system();
+	// Remove stale scripts
+	unlink_if_exists(HVDEF_SCRIPT_DIR . "/havp");
+	unlink_if_exists(HVDEF_SCRIPT_DIR . "/clamd.sh");
 
-    havp_avset_resync();
-    havp_update_AV();
+	havp_avset_resync();
+	havp_update_AV();
 
-
-    update_status("Start update Antivirus bases. Wait 5-20 min before use ..");
+	update_status("Starting update of AV databases. Wait 5-20 min before use ...");
 }
-# ------------------------------------------------------------------------------
-function havp_deinstall()
-{
-    havp_setup_cron(HVDEF_AVUPD_SCRIPT,"", "");
-    mwexec("killall -9 havp");
-    mwexec("rm -rf " . HVDEF_HAVP_STARTUP_SCRIPT);
-    mwexec("rm -rf " . HVDEF_FILTER_RESYNC_SCRIPT);
-    mwexec("rm -rf " . HVDEF_PID_FILE);
-#    mwexec("rm -rf " . HVDEF_CLAM_STARTUP_SCRIPT);
-#    mwexec("rm -rf " . HVDEF_AVUPD_SCRIPT);
-#    mwexec("rm -rf " . HVDEF_CLAM_PID);
-#    mwexec("rm -rf " . HVDEF_CLAM_SOCKET);
-    umountRAMDisk();
+
+function havp_deinstall() {
+	$crontask = "/usr/bin/nice -n20 " . HVDEF_AVUPD_SCRIPT;
+	install_cron_job($crontask, false);
+	mwexec("/usr/bin/killall -9 havp");
+	unlink_if_exists(HVDEF_HAVP_STARTUP_SCRIPT);
+	unlink_if_exists(HVDEF_FILTER_RESYNC_SCRIPT);
+	unlink_if_exists(HVDEF_PID_FILE);
+	// unlink_if_exists(HVDEF_CLAM_STARTUP_SCRIPT);
+	// unlink_if_exists(HVDEF_AVUPD_SCRIPT);
+	// unlink_if_exists(HVDEF_CLAM_PID);
+	// unlink_if_exists(HVDEF_CLAM_SOCKET);
+	umountRAMDisk();
 }
-# ==============================================================================
-# Events
-# ==============================================================================
-# before form
-# ------------------------------------------------------------------------------
-function havp_before_form(&$pkg)
-{
-}
-# ------------------------------------------------------------------------------
-function havp_fscan_before_form(&$pkg)
-{
-    if(is_array($pkg['fields']['field'])) {
-        foreach($pkg['fields']['field'] as $key => $field) {
-        	if ($field['fieldname'] === F_SCANFILEPATH) {
-        		$pkg['fields']['field'][$key]['description'] .= havp_fscan_html();
-                break;
-        	}
-        }
-    }
-}
-# ------------------------------------------------------------------------------
-# validation
-# ------------------------------------------------------------------------------
-function havp_validate_settings($post, &$input_errors)
-{
-    $submit = isset($_GET['submit']) ? $_GET['submit'] : $_POST['submit'];
-
-    # manual update AV database
-    if ($submit === 'Update_AV') {
-        havp_update_AV();
-    }
-    # Scan file or dir
-    elseif($submit === 'Start_scan') {
-        if (file_exists($post[F_SCANFILEPATH]))
-            start_antivirus_scanner($post[F_SCANFILEPATH]);
-        else $input_errors[] = "File or path not exists '{$post[F_SCANFILEPATH]}'.";
-    }
-    else {
-        # ifaces
-        if (!isset($post[F_PROXYINTERFACE]) || empty($post[F_PROXYINTERFACE])) {
-            $post[F_PROXYINTERFACE] = "lan";
-        }
-
-        # port validate
-        $prxport = trim($post[F_PROXYPORT]);
-        if (!empty($prxport) && !is_port($prxport))
-            $input_errors[] = 'You must enter a valid port number in the \'Proxy port\' field';
-
-        # parent proxy validate
-        $parent = trim($post[F_PARENT]);
-
-        # max download size validate
-        $maxval = trim($post[F_MAXDOWNLOADSIZE]);
-        if (!empty($maxval) && !is_numericint($maxval)) # is_port - validate value
-            $input_errors[] = 'You must enter a valid numeric value in \'Max download size\' field.';
-
-        # scan max file size validate
-        $maxval = trim($post[F_SCANMAXSIZE]);
-        if (!empty($maxval) && !is_numericint($maxval)) # is_port - validate value
-            $input_errors[] = 'You must enter a valid numeric value in \'Scan max file size\' field.';
-
-        # whitelist validate
-        $lst = str_replace(array(" ", ";"), "\n", $post[F_WHITELIST]);
-        $lst = explode("\n", $lst);
-        foreach ($lst as $dm) {
-            $dm = trim($dm);
-            if ($dm && check_bw_domain($dm) === false)
-                $input_errors[] = "Invalid whitelist element '$dm'. Example: '*domain.com, domain.com/*path*'.";
-        }
-
-        # blacklist validate
-        $lst = str_replace(array(" ", ";"), "\n", $post[F_BLACKLIST]);
-        $lst = explode("\n", $lst);
-        foreach ($lst as $dm) {
-            $dm = trim($dm);
-            if ($dm && check_bw_domain($dm) === false)
-                $input_errors[] = "Invalid blacklist element '$dm'. Example: '*domain.com, domain.com/*path*'.";
-        }
-    }
-
-}
-# ------------------------------------------------------------------------------
-# resync
-# ------------------------------------------------------------------------------
-function havp_resync()
-{
-    global $havp_config;
-
-    havp_convert_pfxml_xml();
-    havp_check_system();
-
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # whitelist and blacklist
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # also white-listed by default:
-    $whitelist = havp_whitelist_def() . "\n" . str_replace(";", "\n", $havp_config[F_WHITELIST]);
-    $blacklist = str_replace(";", "\n", $havp_config[F_BLACKLIST]);
-    # fix: stupid havp parser - error on 0x0D:
-    $whitelist = str_replace("\r", "", $whitelist);
-    $blacklist = str_replace("\r", "", $blacklist);
-    file_put_contents(HVDEF_HAVP_WHITELIST, $whitelist);
-    file_put_contents(HVDEF_HAVP_BLACKLIST, $blacklist);
-
-    # reconfigure clamd
-    havp_reconfigure_clamd();
-
-    # config havp
-    file_put_contents   (HVDEF_HAVP_CONFIG, havp_config_havp());
-    havp_set_file_access(HVDEF_WORK_DIR, HVDEF_USER, '0755');
-
-    if ($havp_config[F_ENABLE] === 'true') {
-        mwexec_bg(HVDEF_HAVP_STARTUP_SCRIPT . " restart");
-        log_error("Starting HAVP");
-    }
-    else {
-        mwexec_bg(HVDEF_HAVP_STARTUP_SCRIPT . " stop");
-        log_error("Stopping HAVP");
-    }
-
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # reconfigure squid
-    havp_configure_squid();
-
-    # reconfigure AV parts
-    havp_reconfigure_freshclam();
-    havp_reconfigure_cron();
-
-    # configure system filter for 2.xx
-    if (pfsense_version_() !== '1') filter_configure();
-
-}
-# ------------------------------------------------------------------------------
-function havp_avset_resync()
-{
-    havp_convert_pfxml_xml();
-    havp_check_system();
-    # reconfigure
-    havp_reconfigure_clamd();
-    havp_reconfigure_freshclam();
-    havp_reconfigure_cron();
-}
-# ==============================================================================
-# check system
-# ==============================================================================
-function havp_check_system()
-{
-    global $havp_config;
-
-    # check user group
-    $grp = exec('pw group show ' . HVDEF_GROUP);
-    if (strpos($grp, HVDEF_GROUP) !== 0) {
-        exec('pw group add ' . HVDEF_GROUP);
-    	 log_error("Antivirus: Group '" . HVDEF_GROUP . "' was added.");
-    }
-    $usr = exec('pw usershow -n ' . HVDEF_USER);
-    if (strpos($usr, HVDEF_USER) !== 0) {
-        exec('pw useradd ' . HVDEF_USER . ' -g ' . HVDEF_GROUP . ' -h - -s "/sbin/nologin" -d "/nonexistent" -c "havp daemon"');
-    	 log_error("Antivirus: User '" . HVDEF_USER . "' was added.");
-    }
-
-    # workdir permissions
-    havp_set_file_access(HVDEF_WORK_DIR, HVDEF_USER, '');
-
-    # havp tempdir
-    if (!file_exists(HVDEF_HAVPTEMP_DIR))
-    	mwexec("mkdir -p " . HVDEF_HAVPTEMP_DIR);
-    havp_set_file_access(HVDEF_HAVPTEMP_DIR, HVDEF_USER, '');
-
-    # clamav dbdir
-    if (!file_exists(HVDEF_CLAM_DBDIR))
-	mwexec("mkdir -p " . HVDEF_CLAM_DBDIR);
-    havp_set_file_access(HVDEF_CLAM_DBDIR, HVDEF_AVUSER, '');
-
-    # RAM tempdir
-    if (!file_exists(HVDEF_RAMTEMP_DIR))
-    	mwexec("mkdir -p " . HVDEF_RAMTEMP_DIR);
-    havp_set_file_access(HVDEF_RAMTEMP_DIR, HVDEF_USER, '');
-
-    # template permissions
-    if (!file_exists(HVDEF_TEMPLATES_EX))
-        mwexec("mkdir -p " . HVDEF_TEMPLATES_EX);
-    havp_set_file_access(HVDEF_TEMPLATES,    HVDEF_USER, '');
-    havp_set_file_access(HVDEF_TEMPLATES_EX, HVDEF_USER, '');
-
-    # havp log dir
-    if (!file_exists(HVDEF_LOG_DIR))
-    	mwexec("mkdir -p " . HVDEF_LOG_DIR);
-    havp_set_file_access(HVDEF_LOG_DIR, HVDEF_USER, '');
-    # log files exists ?
-    if (!file_exists(HVDEF_HAVP_ACCESSLOG)) file_put_contents(HVDEF_HAVP_ACCESSLOG, '');
-    if (!file_exists(HVDEF_HAVP_ERRORLOG))  file_put_contents(HVDEF_HAVP_ERRORLOG,  '');
-    # log dir permissions
-    havp_set_file_access(HVDEF_LOG_DIR, HVDEF_USER, '0764');
-
-    # pid file
-    if (!file_exists(HVDEF_PID_FILE)) file_put_contents(HVDEF_PID_FILE, '');
-    havp_set_file_access(HVDEF_PID_FILE, HVDEF_USER, '0664');
-
-    # freshclam config permissions
-    if (!file_exists(HVDEF_FRESHCLAM_CONF)) file_put_contents(HVDEF_FRESHCLAM_CONF, '');
-    havp_set_file_access(HVDEF_FRESHCLAM_CONF, HVDEF_AVUSER, '0664');
-
-    # clam log dir
-    if (!file_exists(HVDEF_AVLOG_DIR))
-    	mwexec("mkdir -p " . HVDEF_AVLOG_DIR);
-    havp_set_file_access(HVDEF_AVLOG_DIR, HVDEF_USER, '');
-    # log files exists ?
-    if (!file_exists(HVDEF_CLAM_LOG))      file_put_contents(HVDEF_CLAM_LOG, '');
-    if (!file_exists(HVDEF_FRESHCLAM_LOG)) file_put_contents(HVDEF_FRESHCLAM_LOG, '');
-    # log dir permissions
-    # if (!file_exists(HVDEF_AVLOG_DIR))
-    #    mwexec("mkdir -p " . HVDEF_AVLOG_DIR);
-    havp_set_file_access(HVDEF_AVLOG_DIR, HVDEF_USER, '0777');
-
-    # =-= ClamAV =-=
-    # catalog for Pid and Socket files
-    if (!file_exists(HVDEF_CLAM_RUNDIR))
-        mwexec("mkdir -p " . HVDEF_CLAM_RUNDIR);
-    havp_set_file_access(HVDEF_CLAM_RUNDIR, HVDEF_USER, '0774');
-
-    # AV update script
-    file_put_contents(HVDEF_AVUPD_SCRIPT, havp_AVupdate_script());
-    havp_set_file_access(HVDEF_AVUPD_SCRIPT, HVDEF_AVUSER, '0755');
-
-    # AV update notification script
-#    file_put_contents(HVDEF_ON_AVUPD_SCRIPT,    havp_on_avupd_script());
-#    havp_set_file_access(HVDEF_ON_AVUPD_SCRIPT, HVDEF_AVUSER, '0755');
-
-    # startup script's (havp and clamd)
-    havp_startup_script();
-    hv_clamd_startup_script();
-
-    # havp filter script
-    if (pfsense_version_() == '1') {
-        # script exists only for 1.2.x
-        file_put_contents(HVDEF_FILTER_RESYNC_SCRIPT, havp_filter_resync_script());
-        havp_set_file_access(HVDEF_FILTER_RESYNC_SCRIPT, HVDEF_AVUSER, '0755');
-    } else {
-        # delete script if exists
-        if (file_exists(HVDEF_FILTER_RESYNC_SCRIPT))
-            mwexec("rm -f " . HVDEF_FILTER_RESYNC_SCRIPT);
-    }
-
-    # mount RAMDisk
-    mountRAMdisk(true);
-}
-# ==============================================================================
-# Reconfigure package parts
-# ==============================================================================
-function havp_reconfigure_clamd()
-{
-    file_put_contents   (HVDEF_CLAM_CONFIG, havp_config_clam());
-    havp_set_file_access(HVDEF_CLAM_CONFIG, HVDEF_USER, '0664');
-}
-# ------------------------------------------------------------------------------
-function havp_reconfigure_freshclam()
-{
-    # config freshclam
-    file_put_contents   (HVDEF_FRESHCLAM_CONF, havp_config_freshclam());
-    havp_set_file_access(HVDEF_FRESHCLAM_CONF, HVDEF_USER, '0664');
-}
-# ------------------------------------------------------------------------------
-function havp_reconfigure_cron()
-{
-    global $havp_config;
-
-    # cron task
-    $on     = false;
-    $optval = array("", "*/1", "*/2", "*/3", "*/4", "*/6", "*/8", "*/12", "0");
-    $opt    = array("0", "*", "*", "*", "*", "root", "/usr/bin/nice -n20 " . HVDEF_AVUPD_SCRIPT);
-    $opt[1] = $optval[$havp_config[F_HAVPUPDATE]];
-    $on     = ($opt[1] !== "");
-
-    havp_setup_cron(HVDEF_AVUPD_SCRIPT, $opt, $on);
-}
-# ------------------------------------------------------------------------------
-# Convert conf to XML
-# ------------------------------------------------------------------------------
-function havp_convert_pfxml_xml()
-{
-    global $config, $havp_config;
-
-    $pfconf = $config['installedpackages'][HVFORM_HAVP]['config'][0];
-
-    # === GUI Fields ===
-    $havp_config[F_ENABLE]          = ( $pfconf[F_ENABLE] === 'on' ? 'true' : 'false' );
-    # ClamAV mode
-    $havp_config[F_USECLAMD]        = $pfconf[F_USECLAMD];
-    # proxy
-    $havp_config[F_PROXYMODE]       = ( !empty($pfconf[F_PROXYMODE]) ? $pfconf[F_PROXYMODE] : 'standard' );
-# ToDo: add check squid transparent
-    $havp_config[F_PROXYINTERFACE]  = $pfconf[F_PROXYINTERFACE];
-    $havp_config[F_PROXYPORT]       = ( !empty($pfconf[F_PROXYPORT]) ? $pfconf[F_PROXYPORT] : HVDEF_PROXYPORT );
-# ToDo: add check squid proxy port
-    # parent proxy
-    # [F_PARENTPROXY] = "proxy_ip:port"
-    $pfconf[F_PARENTPROXY]          = trim($pfconf[F_PARENTPROXY]);
-    if (!empty($pfconf[F_PARENTPROXY])) {
-    	$parent = explode(":", trim($pfconf[F_PARENTPROXY]));
-    	$havp_config[F_PARENTPROXY] = array( 'ip' => $parent[0], 'port' => $parent[1] );
+/*
+* ==============================================================================
+* Events
+* ==============================================================================
+* Before form
+* ------------------------------------------------------------------------------
+*/
+function havp_fscan_before_form(&$pkg) {
+	if (is_array($pkg['fields']['field'])) {
+		foreach ($pkg['fields']['field'] as $key => $field) {
+			if ($field['fieldname'] === F_SCANFILEPATH) {
+				$pkg['fields']['field'][$key]['description'] .= havp_fscan_html();
+				break;
+			}
+		}
 	}
-	else $havp_config[F_PARENTPROXY] = '';
-    # language
-    $havp_config[F_LANGUAGE]            = trim($pfconf[F_LANGUAGE]);
-    # proxy settings
-    $havp_config[F_ENABLEFORWARDEDIP]   = ( $pfconf[F_ENABLEFORWARDEDIP]   === 'on' ? 'true' : 'false' );
-    $havp_config[F_ENABLEXFORWARDEDFOR] = ( $pfconf[F_ENABLEXFORWARDEDFOR] === 'on' ? 'true' : 'false' );
-    $havp_config[F_MAXDOWNLOADSIZE]     = ( is_numeric($pfconf[F_MAXDOWNLOADSIZE]) ? $pfconf[F_MAXDOWNLOADSIZE] : 0 );
-    $havp_config[F_RANGE]               = ( $pfconf[F_RANGE]               === 'on' ? 'true' : 'false' );
-    $havp_config[F_ENABLERAMDISK]       = ( $pfconf[F_ENABLERAMDISK]       === 'on' ? 'true' : 'false' );
-    # whitelist
-    $havp_config[F_WHITELIST]           = base64_decode($pfconf[F_WHITELIST]);
-    $havp_config[F_WHITELIST]           = str_replace(";", "\n", $havp_config[F_WHITELIST]);
-    $havp_config[F_WHITELIST]           = str_replace(";", " ",  $havp_config[F_WHITELIST]);
-    # blacklist
-    $havp_config[F_BLACKLIST]           = base64_decode($pfconf[F_BLACKLIST]);
-    $havp_config[F_BLACKLIST]           = str_replace(";", "\n", $havp_config[F_BLACKLIST]);
-    $havp_config[F_BLACKLIST]           = str_replace(";", " ",  $havp_config[F_BLACKLIST]);
-
-    # =-= Temp RAMDisk =-=
-    # use RAMDisk if only capacity > calculated [MAXSCANSIZE * 50 connections]
-    # =-=
-    # before config manage Temp Dir = RAMDisk|Hard Disk
-    $havp_config[HV_SCANTEMPFILE]  = HVDEF_HAVPTEMP_DIR . HVDEF_SCANTEMPFILE;
-    if ($havp_config[F_ENABLERAMDISK] === 'true') {
-        $sys_capacity = get_memory();
-        $mem_capacity = intval($sys_capacity[0]) / 4;                     # [Mb]
-        $calculated   = 50 * $havp_config[F_SCANMAXSIZE] / (1024 * 1024); # [Mb]
-
-        # this is restriction need for balancing between pfSense and HAVP work speed
-        # we can not allocate memory at the expense of other services of the pfSense
-        if ($mem_capacity > $calculated) {
-    	    # re-define temp file to RAM Disk
-            $havp_config[HV_SCANTEMPFILE]  = HVDEF_RAMTEMP_DIR . HVDEF_SCANTEMPFILE;
-        }
-        else
-            log_error("havp: RAMDisk not used. Diagnostic: system {$sys_capacity[0]}Mb, avialable {$mem_capacity}Mb, calculated {$calculated}Mb. Try reducing 'MAXSCANSIZE' value.");
-    }
-    # scanner
-    $havp_config[F_FAILSCANERROR]   = ( $pfconf[F_FAILSCANERROR] === 'on' ? 'true' : 'false' );
-    $havp_config[F_SCANMAXSIZE]     = ( is_numeric($pfconf[F_SCANMAXSIZE])  ? $pfconf[F_SCANMAXSIZE] : HVDEF_MAXSCANSIZE ) * 1024; # KB -> Byte
-    $havp_config[F_SCANIMG]         = ( $pfconf[F_SCANIMG]    === 'on' ? 'true' : 'false' );
-    $havp_config[F_SCANARC]         = ( $pfconf[F_SCANARC]    === 'on' ? 'true' : 'false' );
-    $havp_config[F_SCANSTREAM]      = ( $pfconf[F_SCANSTREAM] === 'on' ? 'true' : 'false' );
-	$havp_config[F_SCANBROKENEXE]   = ( $pfconf[F_SCANBROKENEXE] === 'on' ? 'true' : 'false' );
-    $havp_config[F_SCANARCMAXSIZE]  = ( is_numeric($pfconf[F_SCANARCMAXSIZE]) ? $pfconf[F_SCANARCMAXSIZE] : HVDEF_MAXARCSCANSIZE );
-    # log
-    $havp_config[F_SYSLOG]          = ( $pfconf[F_SYSLOG]      === 'on' ? 'true' : 'false' );
-    $havp_config[F_LOG]             = ( $pfconf[F_LOG]         === 'on' ? 'true' : 'false' );
-    #
-    # =-= Internal variables =-=
-    # proxy
-    $havp_config[F_PROXYBINDIFACE] = 'localhost';
-    # language template files path
-    $lng = $havp_config[F_LANGUAGE] ? $havp_config[F_LANGUAGE] : "en";
-    $havp_config[F_TEMPLATEPATH]    = ( file_exists(HVDEF_TEMPLATES_EX  . "/$lng") ? HVDEF_TEMPLATES_EX : HVDEF_TEMPLATES );
-    $havp_config[F_TEMPLATEPATH]   .= "/$lng";
-    #
-    # =-= HVFORM_AVSET =-=
-    # av settings
-    $pf_avset_conf = $config['installedpackages'][HVFORM_AVSET]['config'][0];
-    $havp_config[F_HAVPUPDATE]      = $pf_avset_conf[F_HAVPUPDATE];
-    $havp_config[F_DBREGION]        = $pf_avset_conf[F_DBREGION];
-    $havp_config[F_AVUPDATESERVER]  = $pf_avset_conf[F_AVUPDATESERVER];
-    # avlog
-    $havp_config[F_AVSETSYSLOG]     = $pf_avset_conf[F_AVSETSYSLOG] === 'on' ? 'true' : 'false';
-    $havp_config[F_AVSETLOG]        = $pf_avset_conf[F_AVSETLOG]    === 'on' ? 'true' : 'false';
-
-    #
-    # store havp config cache
-    $cfg_xml = dump_xml_config($havp_config, 'havp');
-    file_put_contents(HVDEF_HAVP_XMLCONF, $cfg_xml);
-
-    return $havp_config;
 }
-# ------------------------------------------------------------------------------
-# config
-# ------------------------------------------------------------------------------
-# HAVP config
-function havp_config_havp()
-{
-    global $havp_config;
+/*
+* ------------------------------------------------------------------------------
+* Validation
+* ------------------------------------------------------------------------------
+*/
+function havp_validate_settings($post, &$input_errors) {
+	$submit = isset($_GET['submit']) ? $_GET['submit'] : $_POST['submit'];
 
-    $conf = array();
-    $conf[] =
-"# ============================================================
+	/* Manual AV database update */
+	if ($submit === 'Update_AV') {
+		havp_update_AV();
+	} elseif ($submit === 'Start_scan') {
+	/* Scan file or directory */
+		if (file_exists($post[F_SCANFILEPATH])) {
+			start_antivirus_scanner($post[F_SCANFILEPATH]);
+		} else {
+			$input_errors[] = "File or path does not exist: '{$post[F_SCANFILEPATH]}'.";
+		}
+	} else {
+		/* Interfaces */
+		if (!isset($post[F_PROXYINTERFACE]) || empty($post[F_PROXYINTERFACE])) {
+			$post[F_PROXYINTERFACE] = "lan";
+		}
+
+		/* Port validation */
+		$prxport = trim($post[F_PROXYPORT]);
+		if (!empty($prxport) && !is_port($prxport)) {
+			$input_errors[] = 'You must enter a valid port number in the \'Proxy Port\' field';
+		}
+
+		/* Parent proxy validation */
+		$parent = trim($post[F_PARENT]);
+
+		/* Max Download Size validation */
+		$maxval = trim($post[F_MAXDOWNLOADSIZE]);
+		if (!empty($maxval) && !is_numericint($maxval)) {
+			$input_errors[] = 'You must enter a valid numeric value in \'Max download size\' field.';
+		}
+
+		/* Scan Max File Size validation */
+		$maxval = trim($post[F_SCANMAXSIZE]);
+		if (!empty($maxval) && !is_numericint($maxval)) {
+			$input_errors[] = 'You must enter a valid numeric value in \'Scan Max File Size\' field.';
+		}
+
+		/* Whitelist validation */
+		$lst = str_replace(array(" ", ";"), "\n", $post[F_WHITELIST]);
+		$lst = explode("\n", $lst);
+		foreach ($lst as $dm) {
+			$dm = trim($dm);
+			if ($dm && check_bw_domain($dm) === false) {
+				$input_errors[] = "Invalid whitelist element: {$dm}. Valid examples: '*domain.com, domain.com/*path*'.";
+			}
+		}
+
+		/* Blacklist validation */
+		$lst = str_replace(array(" ", ";"), "\n", $post[F_BLACKLIST]);
+		$lst = explode("\n", $lst);
+		foreach ($lst as $dm) {
+			$dm = trim($dm);
+			if ($dm && check_bw_domain($dm) === false) {
+				$input_errors[] = "Invalid blacklist element: {$dm}. Valid examples: '*domain.com, domain.com/*path*'.";
+			}
+		}
+	}
+}
+/*
+* ------------------------------------------------------------------------------
+* Resync
+* ------------------------------------------------------------------------------
+*/
+function havp_resync() {
+	global $havp_config;
+
+	havp_convert_pfxml_xml();
+	havp_check_system();
+
+	/*
+	* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	* Whitelist and Blacklist
+	* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	*/
+	// Also white-listed by default:
+	$whitelist = havp_whitelist_def() . "\n" . str_replace(";", "\n", $havp_config[F_WHITELIST]);
+	$blacklist = str_replace(";", "\n", $havp_config[F_BLACKLIST]);
+	// Fix: stupid HAVP parser - error on 0x0D:
+	$whitelist = str_replace("\r", "", $whitelist);
+	$blacklist = str_replace("\r", "", $blacklist);
+	file_put_contents(HVDEF_HAVP_WHITELIST, $whitelist);
+	file_put_contents(HVDEF_HAVP_BLACKLIST, $blacklist);
+
+	/* Reconfigure clamd */
+	havp_reconfigure_clamd();
+
+	/* Configure HAVP */
+	file_put_contents (HVDEF_HAVP_CONFIG, havp_config_havp());
+	havp_set_file_access(HVDEF_WORK_DIR, HVDEF_USER, '0755');
+
+	if ($havp_config[F_ENABLE] === 'true') {
+		mwexec_bg(HVDEF_HAVP_STARTUP_SCRIPT . " restart");
+		log_error("Starting HAVP");
+	} else {
+		mwexec_bg(HVDEF_HAVP_STARTUP_SCRIPT . " stop");
+		log_error("Stopping HAVP");
+	}
+
+	/* Reconfigure Squid */
+	havp_configure_squid();
+
+	/* Reconfigure AV parts */
+	havp_reconfigure_freshclam();
+	havp_reconfigure_cron();
+
+	/* Configure firewall */
+	filter_configure();
+}
+
+function havp_avset_resync() {
+	havp_convert_pfxml_xml();
+	havp_check_system();
+	/* Reconfigure */
+	havp_reconfigure_clamd();
+	havp_reconfigure_freshclam();
+	havp_reconfigure_cron();
+}
+/*
+* ==============================================================================
+* Check system
+* ==============================================================================
+*/
+function havp_check_system() {
+	global $havp_config;
+
+	/* Check/create user/group accounts */
+	$grp = exec('/usr/sbin/pw group show ' . HVDEF_GROUP);
+	if (strpos($grp, HVDEF_GROUP) !== 0) {
+		exec('/usr/sbin/pw group add ' . HVDEF_GROUP);
+		log_error("Antivirus: Group '" . HVDEF_GROUP . "' was added.");
+	}
+	$usr = exec('/usr/sbin/pw usershow -n ' . HVDEF_USER);
+	if (strpos($usr, HVDEF_USER) !== 0) {
+		exec('/usr/sbin/pw useradd ' . HVDEF_USER . ' -g ' . HVDEF_GROUP . ' -h - -s "/sbin/nologin" -d "/nonexistent" -c "havp daemon"');
+		log_error("Antivirus: User '" . HVDEF_USER . "' was added.");
+	}
+
+	/* Workdir permissions */
+	havp_set_file_access(HVDEF_WORK_DIR, HVDEF_USER, '');
+
+	/* HAVP tempdir */
+	if (!file_exists(HVDEF_HAVPTEMP_DIR)) {
+		mwexec("/bin/mkdir -p " . HVDEF_HAVPTEMP_DIR);
+	}
+	havp_set_file_access(HVDEF_HAVPTEMP_DIR, HVDEF_USER, '');
+
+	/* ClamAV dbdir */
+	if (!file_exists(HVDEF_CLAM_DBDIR)) {
+		mwexec("/bin/mkdir -p " . HVDEF_CLAM_DBDIR);
+	}
+	havp_set_file_access(HVDEF_CLAM_DBDIR, HVDEF_AVUSER, '');
+
+	/* RAM tempdir */
+	if (!file_exists(HVDEF_RAMTEMP_DIR)) {
+		mwexec("/bin/mkdir -p " . HVDEF_RAMTEMP_DIR);
+	}
+	havp_set_file_access(HVDEF_RAMTEMP_DIR, HVDEF_USER, '');
+
+	/* Template directory and permissions */
+	if (!file_exists(HVDEF_TEMPLATES_EX)) {
+		mwexec("/bin/mkdir -p " . HVDEF_TEMPLATES_EX);
+	}
+	havp_set_file_access(HVDEF_TEMPLATES, HVDEF_USER, '');
+	havp_set_file_access(HVDEF_TEMPLATES_EX, HVDEF_USER, '');
+
+	/* HAVP log dir */
+	if (!file_exists(HVDEF_LOG_DIR)) {
+		mwexec("/bin/mkdir -p " . HVDEF_LOG_DIR);
+	}
+	havp_set_file_access(HVDEF_LOG_DIR, HVDEF_USER, '');
+	/* Create log files if needed */
+	if (!file_exists(HVDEF_HAVP_ACCESSLOG)) {
+		file_put_contents(HVDEF_HAVP_ACCESSLOG, '');
+	}
+	if (!file_exists(HVDEF_HAVP_ERRORLOG)) {
+		file_put_contents(HVDEF_HAVP_ERRORLOG, '');
+	}
+	/* Log dir permissions */
+	havp_set_file_access(HVDEF_LOG_DIR, HVDEF_USER, '0764');
+
+	/* PID file */
+	if (!file_exists(HVDEF_PID_FILE)) {
+		file_put_contents(HVDEF_PID_FILE, '');
+	}
+	havp_set_file_access(HVDEF_PID_FILE, HVDEF_USER, '0664');
+
+	/* freshclam config permissions */
+	if (!file_exists(HVDEF_FRESHCLAM_CONF)) {
+		file_put_contents(HVDEF_FRESHCLAM_CONF, '');
+	}
+	havp_set_file_access(HVDEF_FRESHCLAM_CONF, HVDEF_AVUSER, '0664');
+
+	/* AV log dir */
+	if (!file_exists(HVDEF_AVLOG_DIR)) {
+		mwexec("mkdir -p " . HVDEF_AVLOG_DIR);
+	}
+	havp_set_file_access(HVDEF_AVLOG_DIR, HVDEF_USER, '');
+
+	/* Create AV log files if needed */
+	if (!file_exists(HVDEF_CLAM_LOG)) {
+		file_put_contents(HVDEF_CLAM_LOG, '');
+	}
+	if (!file_exists(HVDEF_FRESHCLAM_LOG)) {
+		file_put_contents(HVDEF_FRESHCLAM_LOG, '');
+	}
+	/* Log dir permissions */
+	havp_set_file_access(HVDEF_AVLOG_DIR, HVDEF_USER, '0777');
+
+	/* ClamAV */
+	/* Directory for pid and socket files */
+	if (!file_exists(HVDEF_CLAM_RUNDIR)) {
+		mwexec("mkdir -p " . HVDEF_CLAM_RUNDIR);
+	}
+	havp_set_file_access(HVDEF_CLAM_RUNDIR, HVDEF_USER, '0774');
+
+	/* AV update script */
+	file_put_contents(HVDEF_AVUPD_SCRIPT, havp_AVupdate_script());
+	havp_set_file_access(HVDEF_AVUPD_SCRIPT, HVDEF_AVUSER, '0755');
+
+	/* AV update notification script */
+	// file_put_contents(HVDEF_ON_AVUPD_SCRIPT, havp_on_avupd_script());
+	// havp_set_file_access(HVDEF_ON_AVUPD_SCRIPT, HVDEF_AVUSER, '0755');
+
+	/* Startup scripts (HAVP and clamd) */
+	havp_startup_script();
+	hv_clamd_startup_script();
+
+	/* Delete stale script that was used for pfSense 1.2.x */
+	unlink_if_exists(HVDEF_FILTER_RESYNC_SCRIPT);
+
+	/* mount RAMDisk */
+	mountRAMdisk(true);
+}
+/*
+* ==============================================================================
+* Reconfigure package parts
+* ==============================================================================
+*/
+function havp_reconfigure_clamd() {
+	file_put_contents(HVDEF_CLAM_CONFIG, havp_config_clam());
+	havp_set_file_access(HVDEF_CLAM_CONFIG, HVDEF_USER, '0664');
+}
+
+function havp_reconfigure_freshclam() {
+	file_put_contents (HVDEF_FRESHCLAM_CONF, havp_config_freshclam());
+	havp_set_file_access(HVDEF_FRESHCLAM_CONF, HVDEF_USER, '0664');
+}
+
+function havp_reconfigure_cron() {
+	global $config;
+
+	/* Cron task */
+	$on = false;
+	$optval = array("", "*/1", "*/2", "*/3", "*/4", "*/6", "*/8", "*/12", "0");
+	$opt = array("0", "*", "*", "*", "*", "root");
+	$opt[1] = $optval[$havp_config[F_HAVPUPDATE]];
+	$on = ($opt[1] !== "");
+	$crontask = "/usr/bin/nice -n20 " . HVDEF_AVUPD_SCRIPT;
+
+	// Delete old cron task if it exists
+	if (is_array($config['cron']['item'])) {
+		foreach ($config['cron']['item'] as $item) {
+			if (strpos($item['command'], $crontask) !== false) {
+				install_cron_job($crontask, false);
+			}
+		}
+	}
+
+	// Set new cron task
+	if ($on === true) {
+		install_cron_job($crontask, $on, $opt);
+	}
+}
+/*
+* ------------------------------------------------------------------------------
+* Convert configuration to XML
+* ------------------------------------------------------------------------------
+*/
+function havp_convert_pfxml_xml() {
+	global $config, $havp_config;
+
+	$pfconf = $config['installedpackages'][HVFORM_HAVP]['config'][0];
+
+	/* === GUI Fields === */
+	$havp_config[F_ENABLE] = ($pfconf[F_ENABLE] === 'on' ? 'true' : 'false');
+
+	/* ClamAV mode */
+	$havp_config[F_USECLAMD] = $pfconf[F_USECLAMD];
+
+	/* Proxy */
+	$havp_config[F_PROXYMODE] = $pfconf[F_PROXYMODE] ?: 'standard';
+	// TODO: Add check for Squid transparent
+	$havp_config[F_PROXYINTERFACE] = $pfconf[F_PROXYINTERFACE];
+	// TODO: Add check for Squid proxy port
+	$havp_config[F_PROXYPORT] = $pfconf[F_PROXYPORT] ?: HVDEF_PROXYPORT;
+
+	/* Parent proxy */
+	// [F_PARENTPROXY] = "proxy_ip:port"
+	$pfconf[F_PARENTPROXY] = trim($pfconf[F_PARENTPROXY]);
+	if (!empty($pfconf[F_PARENTPROXY])) {
+		$parent = explode(":", trim($pfconf[F_PARENTPROXY]));
+		$havp_config[F_PARENTPROXY] = array('ip' => $parent[0], 'port' => $parent[1]);
+	} else {
+		$havp_config[F_PARENTPROXY] = '';
+	}
+
+	/* Language */
+	$havp_config[F_LANGUAGE] = trim($pfconf[F_LANGUAGE]);
+
+	/* HAVP proxy settings */
+	$havp_config[F_ENABLEFORWARDEDIP] = ($pfconf[F_ENABLEFORWARDEDIP] === 'on' ? 'true' : 'false');
+	$havp_config[F_ENABLEXFORWARDEDFOR] = ($pfconf[F_ENABLEXFORWARDEDFOR] === 'on' ? 'true' : 'false');
+	$havp_config[F_MAXDOWNLOADSIZE]	= (is_numeric($pfconf[F_MAXDOWNLOADSIZE]) ? $pfconf[F_MAXDOWNLOADSIZE] : 0);
+	$havp_config[F_RANGE] = ($pfconf[F_RANGE] === 'on' ? 'true' : 'false' );
+	$havp_config[F_ENABLERAMDISK] = ($pfconf[F_ENABLERAMDISK] === 'on' ? 'true' : 'false');
+	// Whitelist
+	$havp_config[F_WHITELIST] = base64_decode($pfconf[F_WHITELIST]);
+	$havp_config[F_WHITELIST] = str_replace(";", "\n", $havp_config[F_WHITELIST]);
+	$havp_config[F_WHITELIST] = str_replace(";", " ", $havp_config[F_WHITELIST]);
+	// Blacklist
+	$havp_config[F_BLACKLIST] = base64_decode($pfconf[F_BLACKLIST]);
+	$havp_config[F_BLACKLIST] = str_replace(";", "\n", $havp_config[F_BLACKLIST]);
+	$havp_config[F_BLACKLIST] = str_replace(";", " ", $havp_config[F_BLACKLIST]);
+
+	/*
+	* ------------------------------------------------------------------------------
+	* Temp RAMDisk
+	* ------------------------------------------------------------------------------
+	* Use RAMDisk only if capacity > calculated [MAXSCANSIZE * 50 connections]
+	* Set up temp dir accordingly
+	*/
+	$havp_config[HV_SCANTEMPFILE] = HVDEF_HAVPTEMP_DIR . HVDEF_SCANTEMPFILE;
+	if ($havp_config[F_ENABLERAMDISK] === 'true') {
+		$sys_capacity = get_memory();
+		$mem_capacity = intval($sys_capacity[0]) / 4; // [MB]
+		$calculated = 50 * $havp_config[F_SCANMAXSIZE] / (1024 * 1024); // [MB]
+	}
+	/*
+	* This restriction is required for balancing between pfSense and HAVP work speed
+	* We cannot allocate memory at the expense of other services running on pfSense
+	*/
+	if ($mem_capacity > $calculated) {
+		// Redefine temp file to RAM Disk
+		$havp_config[HV_SCANTEMPFILE] = HVDEF_RAMTEMP_DIR . HVDEF_SCANTEMPFILE;
+	} else {
+		log_error("HAVP: RAMDisk not used. Diagnostic: system {$sys_capacity[0]}MB, available {$mem_capacity}MB, calculated {$calculated}MB. Try reducing 'MAXSCANSIZE' value.");
+	}
+
+	/* Scanner */
+	$havp_config[F_FAILSCANERROR] = ( $pfconf[F_FAILSCANERROR] === 'on' ? 'true' : 'false' );
+	$havp_config[F_SCANMAXSIZE] = ( is_numeric($pfconf[F_SCANMAXSIZE]) ? $pfconf[F_SCANMAXSIZE] : HVDEF_MAXSCANSIZE ) * 1024; // KB -> Byte
+	$havp_config[F_SCANIMG] = ( $pfconf[F_SCANIMG] === 'on' ? 'true' : 'false' );
+	$havp_config[F_SCANARC]	= ( $pfconf[F_SCANARC] === 'on' ? 'true' : 'false' );
+	$havp_config[F_SCANSTREAM] = ( $pfconf[F_SCANSTREAM] === 'on' ? 'true' : 'false' );
+	$havp_config[F_SCANBROKENEXE] = ( $pfconf[F_SCANBROKENEXE] === 'on' ? 'true' : 'false' );
+	$havp_config[F_SCANARCMAXSIZE] = ( is_numeric($pfconf[F_SCANARCMAXSIZE]) ? $pfconf[F_SCANARCMAXSIZE] : HVDEF_MAXARCSCANSIZE );
+
+	/* Log */
+	$havp_config[F_SYSLOG] = ($pfconf[F_SYSLOG] === 'on' ? 'true' : 'false');
+	$havp_config[F_LOG] = ($pfconf[F_LOG] === 'on' ? 'true' : 'false');
+
+	/*
+	* ------------------------------------------------------------------------------
+	* Internal variables
+	* ------------------------------------------------------------------------------
+	*/
+	/* Proxy */
+	$havp_config[F_PROXYBINDIFACE]	= 'localhost';
+	/* Language template files path */
+	$lng = $havp_config[F_LANGUAGE]	? $havp_config[F_LANGUAGE] : "en";
+	$havp_config[F_TEMPLATEPATH]	= (file_exists(HVDEF_TEMPLATES_EX . "/$lng") ? HVDEF_TEMPLATES_EX : HVDEF_TEMPLATES );
+	$havp_config[F_TEMPLATEPATH]	.= "/$lng";
+	/* AV settings */
+	$pf_avset_conf = $config['installedpackages'][HVFORM_AVSET]['config'][0];
+	$havp_config[F_HAVPUPDATE] = $pf_avset_conf[F_HAVPUPDATE];
+	$havp_config[F_DBREGION] = $pf_avset_conf[F_DBREGION];
+	$havp_config[F_AVUPDATESERVER] = $pf_avset_conf[F_AVUPDATESERVER];
+	/* AV log */
+	$havp_config[F_AVSETSYSLOG] = $pf_avset_conf[F_AVSETSYSLOG] === 'on' ? 'true' : 'false';
+	$havp_config[F_AVSETLOG] = $pf_avset_conf[F_AVSETLOG] === 'on' ? 'true' : 'false';
+
+	/* Store HAVP config cache */
+	$cfg_xml = dump_xml_config($havp_config, 'havp');
+	file_put_contents(HVDEF_HAVP_XMLCONF, $cfg_xml);
+
+	return $havp_config;
+}
+/*
+* ------------------------------------------------------------------------------
+* Configuration
+* ------------------------------------------------------------------------------
+*/
+/* HAVP config */
+function havp_config_havp() {
+	global $havp_config;
+
+	$conf = array();
+	$conf[] = <<< EOF
+# ============================================================
 # HAVP config file
-# This file generated automaticly with HAVP configurator (part of pfSense)
-# (C)2008 Serg Dvoriancev
+# This file generated with HAVP configurator (part of pfSense)
+# DO NOT EDIT manually, changes will be overwritten!
+# (C) 2008 Serg Dvoriancev
 # email: dv_serg@mail.ru
 # ============================================================
-";
-    $conf[] = "USER           " . HVDEF_USER;
-    $conf[] = "GROUP          " . HVDEF_GROUP;
-    $conf[] = "DAEMON         true";
-    $conf[] = "PIDFILE        " . HVDEF_PID_FILE;
-    $conf[] = "\n# For small home use, 8 should be minimum.";
-    $conf[] = "# For 500 users corporate use, start at 40.";
-    $conf[] = "SERVERNUMBER   " . HVDEF_HAVP_MINSRV;
-    $conf[] = "MAXSERVERS     " . HVDEF_HAVP_MAXSRV;
-    # log
-    $conf[] = "\n# log ";
-    $conf[] = "ACCESSLOG      " . HVDEF_HAVP_ACCESSLOG;
-    $conf[] = "ERRORLOG       " . ($havp_config[F_LOG] === 'true' ? HVDEF_HAVP_ERRORLOG : "/dev/null");
-    # syslog
-    $conf[] = "\n# syslog";
-    $conf[] = "USESYSLOG      {$havp_config[F_SYSLOG]}";
-    $conf[] = "SYSLOGNAME     havp";
-    $conf[] = "SYSLOGFACILITY daemon";
-    $conf[] = "SYSLOGLEVEL    " . (HV_DEBUG === 'true' ? "debug" : "info");     # err | warning | info | debug
-    #
-    $conf[] = "\n# Level of HAVP logging\n#  0 = Only serious errors and information\n#  1 = Less interesting information is included";
-    $conf[] = "LOG_OKS        false";                                       # false - access_log requests viruses only, true - access_log all requests
-    $conf[] = "LOGLEVEL       " . ( HV_DEBUG === 'true' ? "1"    : "0" );   # 0 - work level, 1 - debug level
-    # temp
-    $conf[] = "\n# temp ";
-    $conf[] = "SCANTEMPFILE   " . $havp_config[HV_SCANTEMPFILE];
-    $conf[] = "TEMPDIR        " . HVDEF_TEMP_DIR;
-    #
-    $conf[] = "\n#";
-    $conf[] = "DBRELOAD       180";
-    $conf[] = "TRANSPARENT    " . ( $havp_config[F_PROXYMODE] === 'transparent' ? "true" : "false" );
-    # X-FORWARD, X-FORWARDED-FOR options
-    $conf[] = "\n# if HAVP is used as parent proxy by some other proxy, this allows to write the real users IP to log, instead of proxy IP.";
-    $conf[] = "FORWARDED_IP    " . $havp_config[F_ENABLEFORWARDEDIP];
-    $conf[] = "X_FORWARDED_FOR " . $havp_config[F_ENABLEXFORWARDEDFOR];
-    # parent proxy = [proxy:port]
-    if (!empty($havp_config[F_PARENTPROXY])) {
-        $conf[] = "\n# parent proxy ";
-        $conf[] = "PARENTPROXY     {$havp_config[F_PARENTPROXY]['ip']}";
-        $conf[] = "PARENTPORT      {$havp_config[F_PARENTPROXY]['port']}";
-    }
-    # proxy listening on
-    $conf[] = "\n# havp is listening on ";
-    $conf[] = "PORT           {$havp_config[F_PROXYPORT]}";
-    # bind to ip address
-    $bind_iface = get_real_interface_address($havp_config[F_PROXYBINDIFACE]);
-	$conf[] = "BIND_ADDRESS   {$bind_iface[0]}";
-    # template files language
-    $conf[] = "\n# Path to template files ";
-    $conf[] = "TEMPLATEPATH   {$havp_config[F_TEMPLATEPATH]}";
-    #
-    $conf[] = "\n# whitelist and blacklist";
-    $conf[] = "WHITELISTFIRST true";
-    $conf[] = "WHITELIST      " . HVDEF_HAVP_WHITELIST;
-    $conf[] = "BLACKLIST      " . HVDEF_HAVP_BLACKLIST;
-    # failscanerror - pass/block files if scanner error
-    $conf[] = "\n# block file if error scanning";
-    $conf[] = "FAILSCANERROR  {$havp_config[F_FAILSCANERROR]}";
-    #
-    $conf[] = "\n# scanner ";
-    $conf[] = "SCANNERTIMEOUT 10";
-    #
-    if ($havp_config[F_SCANSTREAM] === 'true') {
-        #
-        $conf[] = "\n# always allow range, if stream scan enabled";
-        $conf[] = "RANGE           true";
-        $conf[] = "\n# stream scan enabled";
-        $conf[] = "STREAMUSERAGENT Player Winamp iTunes QuickTime Audio RMA/ MAD/ Foobar2000 XMMS";
-        $conf[] = "STREAMSCANSIZE  2000";
-    }
-    else {
-    	# renew downloads ?
-        $conf[] = "RANGE           {$havp_config[F_RANGE]}";
-        $conf[] = "\n# stream scan disabled";
-        $conf[] = "STREAMSCANSIZE  0";
-    }
-
-    # scan options
-    $conf[] = "SCANIMAGES      {$havp_config[F_SCANIMG]}";
-    $conf[] = "MAXSCANSIZE     {$havp_config[F_SCANMAXSIZE]}";
-    #
-    $conf[] = "KEEPBACKBUFFER  200000";
-    $conf[] = "KEEPBACKTIME    5";
-    #
-    $conf[] = "# After Trickling Time (seconds), some bytes are sent to browser to keep the connection alive";
-    $conf[] = "TRICKLING       10";
-    $conf[] = "TRICKLINGBYTES  1";
-    #
-    $conf[] = "# Downloads larger than MAXDOWNLOADSIZE will be blocked.";
-    $conf[] = "MAXDOWNLOADSIZE {$havp_config[F_MAXDOWNLOADSIZE]}";
-    #
-    $conf[] = "\n# ClamAV Library Scanner (libclamav) ";
-    $conf[] = "ENABLECLAMLIB        " . ($havp_config[F_USECLAMD] !== 'true' ? "true" : "false");
-    # use clamd, if configured
-    if ($havp_config[F_USECLAMD] === 'true') {
-        $conf[] = "\n# Clamd scanner (Clam daemon)";
-        $conf[] = "ENABLECLAMD          true";
-        # clamd socket
-        if (HV_CLAMD_TCPSOCKET === 'true') {
-             $conf[] = "CLAMDSERVER          127.0.0.1";
-             $conf[] = "CLAMDPORT            " . HVDEF_CLAM_TCPSOCKET;
-        }
-        else $conf[] = "CLAMDSOCKET          " . HVDEF_CLAM_SOCKET;
-    }
-    $conf[] = "";
-    return implode("\n", $conf);
-}
-# ------------------------------------------------------------------------------
-# Clamd config
-# ------------------------------------------------------------------------------
-function havp_config_clam()
-{
-    global $havp_config;
-
-    $conf   = array();
-    $conf[] =
-"# ==============================================================================
-# CLAMD config file
-# This file generated automaticly with HAVP configurator (part of pfSense)
-# (C)2008 Serg Dvoriancev
-# email: dv_serg@mail.ru
-# ==============================================================================
-";
-    $conf[] = "# log";
-    $conf[] = "LogFileUnlock             yes";
-    $conf[] = "LogFileMaxSize            2M";
-    $conf[] = "LogTime                   yes";
-    $conf[] = "LogClean                  no";
-    $conf[] = "LogFacility               LOG_LOCAL6";
-    $conf[] = "LogVerbose                " . ( HV_DEBUG === "true" ? "yes" : "no" );
-
-    # Syslog
-    $islog    = $havp_config[F_AVSETLOG]    === 'true';
-    $issyslog = $havp_config[F_AVSETSYSLOG] === 'true';
-    $conf[] = "LogSyslog                 " . ($islog && $issyslog ? 'yes' : 'no');
-    if ($islog && !$issyslog)
-        $conf[] = "LogFile                   " . HVDEF_CLAM_LOG;
-    #
-    $conf[] = "\n# sysdirs";
-    $conf[] = "PidFile                   " . HVDEF_CLAM_PID;
-    $conf[] = "TemporaryDirectory        " . HVDEF_TEMP_DIR;
-    $conf[] = "DatabaseDirectory         /var/db/clamav";
-    #
-    $conf[] = "\n# socket";
-    $conf[] = "LocalSocket               " . HVDEF_CLAM_SOCKET;
-    $conf[] = "FixStaleSocket            yes";
-    #
-    if (HV_CLAMD_TCPSOCKET === 'true') {
-        $conf[] = "TCPAddr                   127.0.0.1";
-        $conf[] = "TCPSocket                 " . HVDEF_CLAM_TCPSOCKET;
-    }
-    $conf[] = "MaxConnectionQueueLength  30";
-    #
-    $conf[] = "\n# daemon";
-    $conf[] = "MaxThreads                100";
-    #
-    $conf[] = "\n# scanner";
-    $conf[] = "MaxDirectoryRecursion     255";
-    $conf[] = "FollowDirectorySymlinks   no";    # not need scan symbol links dirs
-    $conf[] = "FollowFileSymlinks        yes";
-    $conf[] = "# perform a database check.(sec) [3600 sec = 60 min]";
-    $conf[] = "SelfCheck                 3600";
-    $conf[] = "# detect possibly unwanted applications.";
-    $conf[] = "DetectPUA                 no";    # possible unwanted applications
-    $conf[] = "AlgorithmicDetection      yes";
-    $conf[] = "# executable";
-	if ($havp_config[F_SCANBROKENEXE] === 'true')
-	{$conf[] = "DetectBrokenExecutables   yes";}
-	else
-	{$conf[] = "DetectBrokenExecutables   no";}	
+EOF;
+	$conf[] = "USER " . HVDEF_USER;
+	$conf[] = "GROUP " . HVDEF_GROUP;
+	$conf[] = "DAEMON true";
+	$conf[] = "PIDFILE " . HVDEF_PID_FILE;
+	$conf[] = "\n# For small home use, 8 should be minimum.";
+	$conf[] = "# For 500 users corporate use, start at 40.";
+	$conf[] = "SERVERNUMBER " . HVDEF_HAVP_MINSRV;
+	$conf[] = "MAXSERVERS " . HVDEF_HAVP_MAXSRV;
+	// Log
+	$conf[] = "\n# log ";
+	$conf[] = "ACCESSLOG " . HVDEF_HAVP_ACCESSLOG;
+	$conf[] = "ERRORLOG " . ($havp_config[F_LOG] === 'true' ? HVDEF_HAVP_ERRORLOG : "/dev/null");
+	// Syslog
+	$conf[] = "\n# syslog";
+	$conf[] = "USESYSLOG {$havp_config[F_SYSLOG]}";
+	$conf[] = "SYSLOGNAME havp";
+	$conf[] = "SYSLOGFACILITY daemon";
+	$conf[] = "SYSLOGLEVEL " . (HV_DEBUG === 'true' ? "debug" : "info"); // err | warning | info | debug
+	// Loglevel
+	$conf[] = "\n# Level of HAVP logging\n#  0 = Only serious errors and information\n#  1 = Less interesting information is included";
+	$conf[] = "LOG_OKS false"; // false - access_log requests viruses only, true - access_log all requests
+	$conf[] = "LOGLEVEL " . ( HV_DEBUG === 'true' ? "1" : "0" ); // 0 - work level, 1 - debug level
+	// Temp dir/file
+	$conf[] = "\n# temp ";
+	$conf[] = "SCANTEMPFILE " . $havp_config[HV_SCANTEMPFILE];
+	$conf[] = "TEMPDIR " . HVDEF_TEMP_DIR;
 	#
-    $conf[] = "ScanPE                    yes";
-    $conf[] = "ScanELF                   yes";
-    $conf[] = "# documents";
-    $conf[] = "ScanOLE2                  yes";
-    $conf[] = "ScanPDF                   yes";
-    $conf[] = "# email";
-    $conf[] = "ScanMail                  yes";
-    $conf[] = "MailFollowURLs            no";
-    $conf[] = "PhishingSignatures        yes";
-    $conf[] = "PhishingScanURLs          yes";
-    $conf[] = "PhishingAlwaysBlockSSLMismatch no";
-    $conf[] = "PhishingAlwaysBlockCloak  no";
-    $conf[] = "# html";
-    $conf[] = "ScanHTML                  yes";
-    $conf[] = "# archives";
-    $conf[] = "ScanArchive               yes";
-#    $conf[] = "ArchiveLimitMemoryUsage   no"; # deprecated on 0.95
-    $conf[] = "ArchiveBlockEncrypted     no";
-    $conf[] = "# limits";
-    $conf[] = "MaxScanSize               50M";
-    $conf[] = "MaxFileSize               30M";
-    $conf[] = "MaxRecursion              255";
-    $conf[] = "MaxFiles                  10000";
-    #
-    $conf[] = "\n# system";
-    $conf[] = "User                      root"; # . HVDEF_USER; # mast have full access to files for scan
-    $conf[] = "AllowSupplementaryGroups  yes";
-    $conf[] = "Debug                     " . (HV_DEBUG === 'true' ? "yes" : "no");
-    #
-    $conf[] = "";
-    return implode("\n", $conf);
-}
-# ------------------------------------------------------------------------------
-# FreshClamAV config
-# ------------------------------------------------------------------------------
-function havp_config_freshclam()
-{
-    global $havp_config;
-    $pfconf = $havp_config;
-    $conf = array();
+	$conf[] = "\n#";
+	$conf[] = "DBRELOAD 180";
+	$conf[] = "TRANSPARENT " . ( $havp_config[F_PROXYMODE] === 'transparent' ? "true" : "false" );
+	// X-FORWARD, X-FORWARDED-FOR options
+	$conf[] = "\n# if HAVP is used as parent proxy by some other proxy, this allows to write the real users IP to log, instead of proxy IP.";
+	$conf[] = "FORWARDED_IP " . $havp_config[F_ENABLEFORWARDEDIP];
+	$conf[] = "X_FORWARDED_FOR " . $havp_config[F_ENABLEXFORWARDEDFOR];
+	// Parent proxy = [proxy:port]
+	if (!empty($havp_config[F_PARENTPROXY])) {
+		$conf[] = "\n# parent proxy ";
+		$conf[] = "PARENTPROXY {$havp_config[F_PARENTPROXY]['ip']}";
+		$conf[] = "PARENTPORT {$havp_config[F_PARENTPROXY]['port']}";
+	}
+	// Proxy listening on
+	$conf[] = "\n# havp is listening on ";
+	$conf[] = "PORT {$havp_config[F_PROXYPORT]}";
+	// Bind to IP address
+	$bind_iface = get_real_interface_address($havp_config[F_PROXYBINDIFACE]);
+	$conf[] = "BIND_ADDRESS {$bind_iface[0]}";
+	// Language template files
+	$conf[] = "\n# Path to template files ";
+	$conf[] = "TEMPLATEPATH {$havp_config[F_TEMPLATEPATH]}";
+	// Whitelist and blacklist
+	$conf[] = "\n# whitelist and blacklist";
+	$conf[] = "WHITELISTFIRST true";
+	$conf[] = "WHITELIST " . HVDEF_HAVP_WHITELIST;
+	$conf[] = "BLACKLIST " . HVDEF_HAVP_BLACKLIST;
+	// Pass/block files on scanner error
+	$conf[] = "\n# block file if error scanning";
+	$conf[] = "FAILSCANERROR {$havp_config[F_FAILSCANERROR]}";
+	// Scanner timeout
+	$conf[] = "\n# scanner ";
+	$conf[] = "SCANNERTIMEOUT 10";
+	// Scan multimedia streams?
+	if ($havp_config[F_SCANSTREAM] === 'true') {
+		$conf[] = "\n# always allow range, if stream scan enabled";
+		$conf[] = "RANGE true";
+		$conf[] = "\n# stream scan enabled";
+		$conf[] = "STREAMUSERAGENT Player Winamp iTunes QuickTime Audio RMA/ MAD/ Foobar2000 XMMS";
+		$conf[] = "STREAMSCANSIZE 2000";
+	} else {
+	// Resume downloads?
+		$conf[] = "RANGE {$havp_config[F_RANGE]}";
+		$conf[] = "\n# stream scan disabled";
+		$conf[] = "STREAMSCANSIZE 0";
+	}
 
-    $conf[] =
-"# ==============================================================================
-# freshclam(HAVP) config file
-# This file generated automaticly with HAVP configurator (part of pfSense)
-# (C)2008 Serg Dvoriancev
+	// Scan options
+	$conf[] = "SCANIMAGES {$havp_config[F_SCANIMG]}";
+	$conf[] = "MAXSCANSIZE {$havp_config[F_SCANMAXSIZE]}";
+	$conf[] = "KEEPBACKBUFFER 200000";
+	$conf[] = "KEEPBACKTIME 5";
+	$conf[] = "# After Trickling Time (seconds), some bytes are sent to browser to keep the connection alive";
+	$conf[] = "TRICKLING 10";
+	$conf[] = "TRICKLINGBYTES 1";
+	$conf[] = "# Downloads larger than MAXDOWNLOADSIZE will be blocked.";
+	$conf[] = "MAXDOWNLOADSIZE {$havp_config[F_MAXDOWNLOADSIZE]}";
+	$conf[] = "\n# ClamAV Library Scanner (libclamav) ";
+	$conf[] = "ENABLECLAMLIB " . ($havp_config[F_USECLAMD] !== 'true' ? "true" : "false");
+	// Use clamd if configured
+	if ($havp_config[F_USECLAMD] === 'true') {
+		$conf[] = "\n# Clamd scanner (Clam daemon)";
+		$conf[] = "ENABLECLAMD true";
+		// Clamd socket
+		if (HV_CLAMD_TCPSOCKET === 'true') {
+			$conf[] = "CLAMDSERVER 127.0.0.1";
+			$conf[] = "CLAMDPORT " . HVDEF_CLAM_TCPSOCKET;
+		} else {
+			$conf[] = "CLAMDSOCKET " . HVDEF_CLAM_SOCKET;
+		}
+	}
+	$conf[] = "";
+	return implode("\n", $conf);
+}
+/*
+* ------------------------------------------------------------------------------
+* Clamd config
+* ------------------------------------------------------------------------------
+*/
+function havp_config_clam() {
+	global $havp_config;
+
+	$conf = array();
+	$conf[] = <<< EOF
+# ==============================================================================
+# CLAMD config file
+# This file generated with HAVP configurator (part of pfSense)
+# DO NOT EDIT manually, changes will be overwritten!
+# (C) 2008 Serg Dvoriancev
 # email: dv_serg@mail.ru
 # ==============================================================================
-";
-    $conf[] = "DatabaseDirectory /var/db/clamav";
+EOF;
+	// Log
+	$conf[] = "# log";
+	$conf[] = "LogFileUnlock yes";
+	$conf[] = "LogFileMaxSize 2M";
+	$conf[] = "LogTime yes";
+	$conf[] = "LogClean no";
+	$conf[] = "LogFacility LOG_LOCAL6";
+	$conf[] = "LogVerbose " . ( HV_DEBUG === "true" ? "yes" : "no" );
+	# Syslog
+	$islog = $havp_config[F_AVSETLOG] === 'true';
+	$issyslog = $havp_config[F_AVSETSYSLOG] === 'true';
+	$conf[] = "LogSyslog " . ($islog && $issyslog ? 'yes' : 'no');
+	if ($islog && !$issyslog) {
+		$conf[] = "LogFile " . HVDEF_CLAM_LOG;
+	}
+	// Sysdirs
+	$conf[] = "\n# sysdirs";
+	$conf[] = "PidFile " . HVDEF_CLAM_PID;
+	$conf[] = "TemporaryDirectory " . HVDEF_TEMP_DIR;
+	$conf[] = "DatabaseDirectory /var/db/clamav";
+	// Socket
+	$conf[] = "\n# socket";
+	$conf[] = "LocalSocket " . HVDEF_CLAM_SOCKET;
+	$conf[] = "FixStaleSocket yes";
+	if (HV_CLAMD_TCPSOCKET === 'true') {
+		$conf[] = "TCPAddr 127.0.0.1";
+		$conf[] = "TCPSocket " . HVDEF_CLAM_TCPSOCKET;
+	}
+	$conf[] = "MaxConnectionQueueLength 30";
+	// Daemon
+	$conf[] = "\n# daemon";
+	$conf[] = "MaxThreads 100";
+	// Scanner
+	$conf[] = "\n# scanner";
+	$conf[] = "MaxDirectoryRecursion 255";
+	$conf[] = "FollowDirectorySymlinks no"; // No need to scan symlinked dirs
+	$conf[] = "FollowFileSymlinks yes";
+	$conf[] = "# perform a database check.(sec) [3600 sec = 60 min]";
+	$conf[] = "SelfCheck 3600";
+	$conf[] = "# detect possibly unwanted applications.";
+	$conf[] = "DetectPUA no"; // Possibly unwanted applications
+	$conf[] = "AlgorithmicDetection yes";
+	// Broken executables scanning
+	$conf[] = "# executable";
+	if ($havp_config[F_SCANBROKENEXE] === 'true') {
+		$conf[] = "DetectBrokenExecutables yes";
+	} else {
+		$conf[] = "DetectBrokenExecutables no";
+	}
+	// Other scanner options
+	$conf[] = "ScanPE yes";
+	$conf[] = "ScanELF yes";
+	$conf[] = "# documents";
+	$conf[] = "ScanOLE2 yes";
+	$conf[] = "ScanPDF yes";
+	$conf[] = "# email";
+	$conf[] = "ScanMail yes";
+	$conf[] = "MailFollowURLs no";
+	$conf[] = "PhishingSignatures yes";
+	$conf[] = "PhishingScanURLs yes";
+	$conf[] = "PhishingAlwaysBlockSSLMismatch no";
+	$conf[] = "PhishingAlwaysBlockCloak no";
+	$conf[] = "# html";
+	$conf[] = "ScanHTML yes";
+	$conf[] = "# archives";
+	$conf[] = "ScanArchive yes";
+	$conf[] = "ArchiveBlockEncrypted no";
+	$conf[] = "# limits";
+	$conf[] = "MaxScanSize 50M";
+	$conf[] = "MaxFileSize 30M";
+	$conf[] = "MaxRecursion 255";
+	$conf[] = "MaxFiles 10000";
+	// User/Group
+	$conf[] = "\n# system";
+	$conf[] = "User root"; // HVDEF_USER; must have full access to files for scan
+	$conf[] = "AllowSupplementaryGroups yes";
+	$conf[] = "Debug " . (HV_DEBUG === 'true' ? "yes" : "no");
+	$conf[] = "";
+	return implode("\n", $conf);
+}
+/*
+* ------------------------------------------------------------------------------
+* FreshClam config
+* ------------------------------------------------------------------------------
+*/
+function havp_config_freshclam() {
+	global $havp_config;
+	$pfconf = $havp_config;
+	$conf = array();
 
-    # log
+	$conf[] = <<< EOF
+# ==============================================================================
+# Freshclam config file
+# This file generated with HAVP configurator (part of pfSense)
+# DO NOT EDIT manually, changes will be overwritten!
+# (C) 2008 Serg Dvoriancev
+# email: dv_serg@mail.ru
+# ==============================================================================
+EOF;
+	$conf[] = "DatabaseDirectory /var/db/clamav";
+	// Log
+	$conf[] = "LogFileMaxSize 2M";
+	$conf[] = "LogTime yes";
+	$conf[] = "LogVerbose " . ( HV_DEBUG === "true" ? "yes" : "no" );
+	$conf[] = "LogFacility LOG_LOCAL6"; // LOG_LOCAL6 | LOG_MAIL
+	// Syslog
+	$conf[] = "\n# syslog";
+	$is_syslog = ($pfconf[F_AVSETLOG] === 'true') && ($pfconf[F_AVSETSYSLOG] === 'true');
+	$conf[] = "LogSyslog " . ( $is_syslog ? 'yes' : 'no');
+	unset ($is_syslog);
+	// Update log
+	$conf[] = "UpdateLogFile " . HVDEF_FRESHCLAM_LOG;
+	// Other options
+	$conf[] = "\n# pid";
+	$conf[] = "PidFile /var/run/clamav/freshclam.pid";
+	$conf[] = "\n# db";
+	$conf[] = "DatabaseOwner havp";
+	$conf[] = "AllowSupplementaryGroups yes";
+	$conf[] = "DNSDatabaseInfo current.cvd.clamav.net";
 
-    $conf[] = "LogFileMaxSize           2M";
-    $conf[] = "LogTime                  yes";
-    $conf[] = "LogVerbose               " . ( HV_DEBUG === "true" ? "yes" : "no" );
-    $conf[] = "LogFacility              LOG_LOCAL6"; # LOG_LOCAL6 | LOG_MAIL
-    $conf[] = "\n# syslog";
+	$avsrv = $pfconf[F_AVUPDATESERVER];
+	$avsrv = explode(" ", trim($avsrv));
 
-    # Syslog
-    $is_syslog = ($pfconf[F_AVSETLOG] === 'true') && ($pfconf[F_AVSETSYSLOG] === 'true');
-    $conf[] = "LogSyslog                " . ( $is_syslog ? 'yes' : 'no');
-    unset ($is_syslog);
+	foreach ($avsrv as $asr) {
+		if (!empty($asr)) {
+			$conf[] = "DatabaseMirror $asr";
+		}
+	}
 
-    # log
-    # freshclam for 1.2.x have a bug with logfile permissions; now disable logfile for 1.2.x - only syslog
-    $is_log = (pfsense_version_() != "1") && ($pfconf[F_AVSETLOG] === 'true');
-    if ($is_log) {
-        $conf[] = "UpdateLogFile            " . HVDEF_FRESHCLAM_LOG;
-    } else {
-        $conf[] = "# for pfsense 1.2.x Log disabled - permission bug exists!";
-    }
-    unset ($is_log);
-
-    $conf[] = "\n# pid";
-    $conf[] = "PidFile /var/run/clamav/freshclam.pid";
-
-    $conf[] = "\n# db";
-    $conf[] = "DatabaseOwner            havp";
-    $conf[] = "AllowSupplementaryGroups yes";
-    $conf[] = "DNSDatabaseInfo          current.cvd.clamav.net";
-
-    $avsrv = $pfconf[F_AVUPDATESERVER];
-    $avsrv = explode(" ", trim($avsrv));
-
-    foreach ($avsrv as $asr)
-    	if (!empty($asr))
-             $conf[] = "DatabaseMirror  $asr";
-
-	# regional mirror
-    if (!empty($pfconf[F_DBREGION])) {
-    	$conf[] = '# regional db';
+	// Regional mirrors
+	if (!empty($pfconf[F_DBREGION])) {
+		$conf[] = '# regional db';
 		switch($pfconf[F_DBREGION]) {
-			case 'au': $conf[] = "DatabaseMirror clamav.mirror.ayudahosting.com.au"; break; # australia
-			case 'ca': $conf[] = "DatabaseMirror clamav.mirror.rafal.ca"; break;  # canada
-			case 'cn': $conf[] = "DatabaseMirror 4most2.clamav.ialfa.net"; break; # china
-			case 'eu': $conf[] = "DatabaseMirror clamav.edpnet.net"; break;       # europe
-			case 'id': $conf[] = "DatabaseMirror db.clamav.or.id"; break;         # indonesia
-			case 'jp': $conf[] = "DatabaseMirror clamavdb2.ml-club.jp"; break;    # japan
-			case 'kr': $conf[] = "DatabaseMirror clamav.hostway.co.kr"; break;    # korea
-			case 'ml': $conf[] = "DatabaseMirror clamav.doubleukay.com"; break;   # malaysia
-			case 'ru': $conf[] = "DatabaseMirror clamav.citrin.ru"; break;        # russia
-			case 'sa': $conf[] = "DatabaseMirror clamav.dial-up.net"; break;      # south africa
-			case 'tw': $conf[] = "DatabaseMirror clamav.cs.pu.edu.tw"; break;     # taiwan
-			case 'uk': $conf[] = "DatabaseMirror clamav.oucs.ox.ac.uk"; break;    # united kingdom
-			case 'us': $conf[] = "DatabaseMirror db.us.clamav.net "; break;        # united states
+			case 'au': $conf[] = "DatabaseMirror db.au.clamav.net"; break; // Australia
+			case 'ca': $conf[] = "DatabaseMirror db.ca.clamav.net"; break; // Canada
+			case 'cn': $conf[] = "DatabaseMirror db.cn.clamav.net"; break; // China
+			case 'eu': $conf[] = "DatabaseMirror db.europe.clamav.net"; break; // Europe
+			case 'id': $conf[] = "DatabaseMirror db.id.clamav.net"; break; // Indonesia
+			case 'jp': $conf[] = "DatabaseMirror db.jp.clamav.net"; break; // Japan
+			case 'kr': $conf[] = "DatabaseMirror db.kr.clamav.net"; break; // Korea
+			case 'ml': $conf[] = "DatabaseMirror db.ml.clamav.net"; break; // Malaysia
+			case 'ru': $conf[] = "DatabaseMirror db.ru.clamav.net"; break; // Russia
+			case 'sa': $conf[] = "DatabaseMirror db.sa.clamav.net"; break; // South Africa
+			case 'tw': $conf[] = "DatabaseMirror db.tw.clamav.net"; break; // Taiwan
+			case 'uk': $conf[] = "DatabaseMirror db.uk.clamav.net"; break; // United kingdom
+			case 'us': $conf[] = "DatabaseMirror db.us.clamav.net"; break; // United states
 			default: break;
 		}
 	}
 
-    $conf[] = "DatabaseMirror db.at.clamav.net";
-    $conf[] = "DatabaseMirror db.au.clamav.net";
-    $conf[] = "DatabaseMirror db.ba.clamav.net";
-    $conf[] = "DatabaseMirror db.be.clamav.net";
-    $conf[] = "DatabaseMirror db.ca.clamav.net";
-    $conf[] = "DatabaseMirror db.ch.clamav.net";
-    $conf[] = "DatabaseMirror db.cn.clamav.net";
-    $conf[] = "DatabaseMirror db.cr.clamav.net";
-    $conf[] = "DatabaseMirror db.cy.clamav.net";
-    $conf[] = "DatabaseMirror db.cz.clamav.net";
-    $conf[] = "DatabaseMirror db.de.clamav.net";
-    $conf[] = "DatabaseMirror db.dk.clamav.net";
-    $conf[] = "DatabaseMirror db.ec.clamav.net";
-    $conf[] = "DatabaseMirror db.ee.clamav.net";
-    $conf[] = "DatabaseMirror db.es.clamav.net";
-    $conf[] = "DatabaseMirror db.fi.clamav.net";
-    $conf[] = "DatabaseMirror db.fr.clamav.net";
-    $conf[] = "DatabaseMirror db.gr.clamav.net";
-    $conf[] = "DatabaseMirror db.hk.clamav.net";
-    $conf[] = "DatabaseMirror db.hu.clamav.net";
-    $conf[] = "DatabaseMirror db.id.clamav.net";
-    $conf[] = "DatabaseMirror db.ie.clamav.net";
-    $conf[] = "DatabaseMirror db.it.clamav.net";
-    $conf[] = "DatabaseMirror db.jp.clamav.net";
-    $conf[] = "DatabaseMirror db.kr.clamav.net";
-    $conf[] = "DatabaseMirror db.li.clamav.net";
-    $conf[] = "DatabaseMirror db.lt.clamav.net";
-    $conf[] = "DatabaseMirror db.lv.clamav.net";
-    $conf[] = "DatabaseMirror db.mt.clamav.net";
-    $conf[] = "DatabaseMirror db.my.clamav.net";
-    $conf[] = "DatabaseMirror db.ml.clamav.net";
-    $conf[] = "DatabaseMirror db.no.clamav.net";
-    $conf[] = "DatabaseMirror db.pl.clamav.net";
-    $conf[] = "DatabaseMirror db.pt.clamav.net";
-    $conf[] = "DatabaseMirror db.ro.clamav.net";
-    $conf[] = "DatabaseMirror db.ru.clamav.net";
-    $conf[] = "DatabaseMirror db.se.clamav.net";
-    $conf[] = "DatabaseMirror db.sk.clamav.net";
-    $conf[] = "DatabaseMirror db.th.clamav.net";
-    $conf[] = "DatabaseMirror db.tr.clamav.net";
-    $conf[] = "DatabaseMirror db.tw.clamav.net";
-    $conf[] = "DatabaseMirror db.ua.clamav.net";
-    $conf[] = "DatabaseMirror db.uk.clamav.net";
-    $conf[] = "DatabaseMirror db.za.clamav.net";
+	$conf[] = "DatabaseMirror db.at.clamav.net";
+	$conf[] = "DatabaseMirror db.au.clamav.net";
+	$conf[] = "DatabaseMirror db.ba.clamav.net";
+	$conf[] = "DatabaseMirror db.be.clamav.net";
+	$conf[] = "DatabaseMirror db.ca.clamav.net";
+	$conf[] = "DatabaseMirror db.ch.clamav.net";
+	$conf[] = "DatabaseMirror db.cn.clamav.net";
+	$conf[] = "DatabaseMirror db.cr.clamav.net";
+	$conf[] = "DatabaseMirror db.cy.clamav.net";
+	$conf[] = "DatabaseMirror db.cz.clamav.net";
+	$conf[] = "DatabaseMirror db.de.clamav.net";
+	$conf[] = "DatabaseMirror db.dk.clamav.net";
+	$conf[] = "DatabaseMirror db.ec.clamav.net";
+	$conf[] = "DatabaseMirror db.ee.clamav.net";
+	$conf[] = "DatabaseMirror db.es.clamav.net";
+	$conf[] = "DatabaseMirror db.fi.clamav.net";
+	$conf[] = "DatabaseMirror db.fr.clamav.net";
+	$conf[] = "DatabaseMirror db.gr.clamav.net";
+	$conf[] = "DatabaseMirror db.hk.clamav.net";
+	$conf[] = "DatabaseMirror db.hu.clamav.net";
+	$conf[] = "DatabaseMirror db.id.clamav.net";
+	$conf[] = "DatabaseMirror db.ie.clamav.net";
+	$conf[] = "DatabaseMirror db.it.clamav.net";
+	$conf[] = "DatabaseMirror db.jp.clamav.net";
+	$conf[] = "DatabaseMirror db.kr.clamav.net";
+	$conf[] = "DatabaseMirror db.li.clamav.net";
+	$conf[] = "DatabaseMirror db.lt.clamav.net";
+	$conf[] = "DatabaseMirror db.lv.clamav.net";
+	$conf[] = "DatabaseMirror db.mt.clamav.net";
+	$conf[] = "DatabaseMirror db.my.clamav.net";
+	$conf[] = "DatabaseMirror db.ml.clamav.net";
+	$conf[] = "DatabaseMirror db.no.clamav.net";
+	$conf[] = "DatabaseMirror db.pl.clamav.net";
+	$conf[] = "DatabaseMirror db.pt.clamav.net";
+	$conf[] = "DatabaseMirror db.ro.clamav.net";
+	$conf[] = "DatabaseMirror db.ru.clamav.net";
+	$conf[] = "DatabaseMirror db.se.clamav.net";
+	$conf[] = "DatabaseMirror db.sk.clamav.net";
+	$conf[] = "DatabaseMirror db.th.clamav.net";
+	$conf[] = "DatabaseMirror db.tr.clamav.net";
+	$conf[] = "DatabaseMirror db.tw.clamav.net";
+	$conf[] = "DatabaseMirror db.ua.clamav.net";
+	$conf[] = "DatabaseMirror db.uk.clamav.net";
+	$conf[] = "DatabaseMirror db.za.clamav.net";
 
-    $conf[] = "\n# DO NOT TOUCH the following line ";
-    $conf[] = "DatabaseMirror database.clamav.net";
+	$conf[] = "\n# DO NOT TOUCH the following line ";
+	$conf[] = "DatabaseMirror database.clamav.net";
+	// Updates frequency
+	$conf[] = "\n# Number of database checks per day. Default: 12 (every two hours)";
+	$chks = 0;
+	$conf[] = "Checks $chks";
+	// Notifications
+	$conf[] = "# notification";
+	$conf[] = "OnUpdateExecute /bin/date \"+%Y.%m.%d %H:%M:%S Antivirus update success\" > " . HVDEF_FRESHCLAM_STATUS_FILE;
+	$conf[] = "OnErrorExecute /bin/date \"+%Y.%m.%d %H:%M:%S Antivirus update error\" > "  . HVDEF_FRESHCLAM_STATUS_FILE;
+	// Debug
+	$conf[] = "Debug " . (HV_DEBUG === 'true' ? "yes" : "no");
 
-    $conf[] = "\n# Number of database checks per day. Default: 12 (every two hours)";
-    $chks = 0;
-    $conf[] = "Checks $chks";
-
-    $conf[] = "# notification";
-    $conf[] = "OnUpdateExecute  date \"+%Y.%m.%d %H:%M:%S Antivirus update success\" > " . HVDEF_FRESHCLAM_STATUS_FILE;
-    $conf[] = "OnErrorExecute   date \"+%Y.%m.%d %H:%M:%S Antivirus update error\" > "   . HVDEF_FRESHCLAM_STATUS_FILE;
-
-    $conf[] = "Debug  " . (HV_DEBUG === 'true' ? "yes" : "no");
-
-#    $conf[] = "# Proxy settings";  # future
+	/*
+	* ------------------------------------------------------------------------------
+	* TODO: Proxy settings, GUI notifications...
+	* ------------------------------------------------------------------------------
+	$conf[] = <<< EOF
+# Proxy settings
 #HTTPProxyServer myproxy.com
 #HTTPProxyPort 1234
 #HTTPProxyUsername myusername
 #HTTPProxyPassword mypass
 
-# MAKE GUI Errors display
+# Make GUI display errors
 # Run command when database update process fails.
 # Default: disabled
 #OnErrorExecute command
@@ -981,473 +1018,428 @@ function havp_config_freshclam()
 # In the command string %v will be replaced by the new version number.
 # Default: disabled
 #OnOutdatedExecute command
+EOF;
+	* ------------------------------------------------------------------------------
+	*/
 
-# Enable debug messages in libclamav.
-# Default: disabled
-#Debug yes
+	// Use Google Safebrowsing database
+	$conf[] = "SafeBrowsing yes";
 
-    # use google safesearch AV database
-    $conf[] = "SafeBrowsing     yes";
-
-    $conf[] = "";
-    return implode("\n", $conf);
+	$conf[] = "";
+	return implode("\n", $conf);
 }
-# ------------------------------------------------------------------------------
-# configure squid
-function havp_configure_squid()
-{
+/*
+* ------------------------------------------------------------------------------
+* Configure Squid
+* ------------------------------------------------------------------------------
+*/
+function havp_configure_squid() {
 	global $config, $havp_config;
 	$new_opt = array();
-    $on_configure = ($havp_config[F_PROXYMODE] === 'squid' ? true : false);
+	$on_configure = ($havp_config[F_PROXYMODE] === 'squid' ? true : false);
 
-    if (!isset($config['installedpackages']['squid']['config'][0]['custom_options'])) return;
+	if (!isset($config['installedpackages']['squid']['config'][0]['custom_options'])) {
+		return;
+	}
 
-    if ($on_configure === true) {
-        $new_opt[] = "never_direct allow all";
-        $new_opt[] = "cache_peer 127.0.0.1 parent {$havp_config[F_PROXYPORT]} 0 name=havp no-query no-digest no-netdb-exchange default";
-    }
+	if ($on_configure === true) {
+		$new_opt[] = "never_direct allow all";
+		$new_opt[] = "cache_peer 127.0.0.1 parent {$havp_config[F_PROXYPORT]} 0 name=havp no-query no-digest no-netdb-exchange default";
+	}
 
-    # copy options, but not 'cache_peer' option
-    $cust_opt = explode(";", $config['installedpackages']['squid']['config'][0]['custom_options']);
-    foreach($cust_opt as $key => $val) {
-        if (strpos($val, "never_direct") !== false) continue;
-        if (strpos($val, "cache_peer 127.0.0.1 parent") !== false) continue;
-        $new_opt[] = $val;
-    }
+	/* Copy options, but not 'cache_peer' option */
+	$cust_opt = explode(";", $config['installedpackages']['squid']['config'][0]['custom_options']);
+	foreach($cust_opt as $key => $val) {
+		if (strpos($val, "never_direct") !== false) {
+			continue;
+		}
+		if (strpos($val, "cache_peer 127.0.0.1 parent") !== false) {
+			continue;
+		}
+		$new_opt[] = $val;
+	}
 
-    $new_opt = implode(";", $new_opt);
-    if (/*is_package_installed('squid') &&  */file_exists('/usr/local/pkg/squid.inc')) {
-        # squid config update
-        $config['installedpackages']['squid']['config'][0]['custom_options'] = $new_opt;
+	$new_opt = implode(";", $new_opt);
+	if (file_exists('/usr/local/pkg/squid.inc')) {
+		// Squid config update
+		$config['installedpackages']['squid']['config'][0]['custom_options'] = $new_opt;
 
-        # disable upstream proxy
-        if ($on_configure === true)
-            $config['installedpackages']['squidupstream']['config'][0]['proxy_forwarding'] = '';
+		// Disable upstream proxy
+		if ($on_configure === true) {
+			$config['installedpackages']['squidupstream']['config'][0]['proxy_forwarding'] = '';
+		}
 
-        write_config('Update redirector options to squid config.');
-	    require_once('squid.inc');
-        squid_resync();
-	 }
+		write_config('HAVP: Updated redirector options in Squid config.');
+
+		require_once('squid.inc');
+		squid_resync();
+	}
 }
-# ------------------------------------------------------------------------------
-function havp_whitelist_def()
-{
-    $whitelist  = array();
+/*
+* ------------------------------------------------------------------------------
+* Default whitelist
+* ------------------------------------------------------------------------------
+*/
+function havp_whitelist_def() {
+	$whitelist = array();
 
-    $whitelist[] = "*sourceforge.net/*clamav-*";
-    $whitelist[] = "*pfsense.com/*";
-    $whitelist[] = "*.microsoft.com/*";
-    $whitelist[] = "*.windowsupdate.com/*";         # M$ & M$ update
-    # media and image extensions
-    $whitelist[] = "*/*.gif\n*/*.swf\n*/*.png\n*/*.jpg\n*/*.jpeg\n*/*.mov\n*/*.avi\n*/*.flv\n*/*.bmp\n*/*.ico\n*/*.pdf\n*/*.mp3\n*/*.wma\n*/*.wmv\n*/*.ogg";
+	$whitelist[] = "*sourceforge.net/*clamav-*";
+	$whitelist[] = "*pfsense.org/*";
+	// Microsoft & Windows Update
+	$whitelist[] = "*.microsoft.com/*";
+	$whitelist[] = "*.windowsupdate.com/*";
+	// Media and image extensions
+	$whitelist[] = "*/*.gif\n*/*.swf\n*/*.png\n*/*.jpg\n*/*.jpeg\n*/*.mov\n*/*.avi\n*/*.flv\n*/*.bmp\n*/*.ico\n*/*.pdf\n*/*.mp3\n*/*.wma\n*/*.wmv\n*/*.ogg";
 
-    return implode("\n", $whitelist);
+	return implode("\n", $whitelist);
 }
-# ==============================================================================
-# Utils
-# ==============================================================================
-function havp_set_file_access($dir, $owner, $mod)
-{
-    if ( file_exists($dir) ) {
-        mwexec("chgrp -R -v $owner $dir");
-        mwexec("chown -R -v $owner $dir");
-        if (!empty($mod)) {
-             mwexec( "chmod -R -v $mod $dir");
-        }
-    }
-}
-# ------------------------------------------------------------------------------
-# Src from squid.inc Copyright (C) 2006 Scott Ullrich, Fernando Lemos
-function get_real_interface_address($iface)
-{
-        global $config;
-
-        if ($iface === 'localhost') return array('127.0.0.1', '');
-
-        $iface = convert_friendly_interface_to_real_interface_name($iface);
-        $line = trim(shell_exec("ifconfig $iface | grep inet | grep -v inet6"));
-        list($dummy, $ip, $dummy2, $netmask) = explode(" ", $line);
-
-        return array($ip, long2ip(hexdec($netmask)));
-}
-#-------------------------------------------------------------------------------
-# *** check black/white list domain ***
-# Lines can hold URLs with wildcards with following rules:
-# Line must cointain Domain/Path
-# Domains can have a wildcard at begin.
-# Pages can hav a wildcard at begin and end.
-# URLs without wildcards are exact
-# Examples:
-# (1) www.server-side.de    (Only this URL is whitelisted)
-# (2) www.server-side.de/*  (Domain is completely whitelisted)
-# (3) *server-side.de/index.html
-# (4) */*.gif               (All .gif are whitelisted)
-# (5) www.server-side.de/novirus*
-# (6) www.server-side.de/*novirus*
-#-------------------------------------------------------------------------------
-function check_bw_domain($_dm)
-{
-    $domain = "";
-    $path = "";
-
-    if (!is_string($_dm)) return false;
-
-    $pos = strpos($_dm, "/");
-    if ($pos === false) {
-        $domain = $_dm;
-        $path = "";
-    }
-    else {
-        $domain = substr($_dm, 0, $pos);
-        $path   = substr($_dm, $pos+1);
-    }
-
-    # Domains can have a wildcard at begin '*domain.xx' - *my.domain.com
-    # Path can have a wildcard(*) at begin and end '*xxx*'
-    # Regex:  * - {0,}; + - {1,}; ? = {0,1}
-    $df     = "[a-zA-Z0-9\-]";
-    $dm_fmt = "^((\*)|(\*\.))?($df+\.)+$df{2,}$";        # d.com *d.com *.d.com
-    $ph_fmt = "^((\*)|((\*)?([^\*]+)(\*)?))$";           # *path*
-
-    if (empty($path)) {
-    	# d.com *d.com *.d.com
-        return eregi($dm_fmt, $domain);
-    }
-    else {
-        if (!empty($domain)) {
-            return (($domain === '*') || eregi($dm_fmt, $domain)) && eregi($ph_fmt, $path);
-        }
-    }
-
-    return false;
+/*
+* ==============================================================================
+* Utils
+* ==============================================================================
+*/
+function havp_set_file_access($dir, $owner, $mod) {
+	if (file_exists($dir)) {
+		mwexec("/usr/bin/chgrp -R -v $owner $dir");
+		mwexec("/usr/sbin/chown -R -v $owner $dir");
+		if (!empty($mod)) {
+			mwexec( "/bin/chmod -R -v $mod $dir");
+		}
+	}
 }
 
-# ------------------------------------------------------------------------------
-# cron
-# ------------------------------------------------------------------------------
-# $options: [0]='minute', [1]='hour', [2]='mday', [3]='month', [4]='wday', [5]='who', [6]='command'
-#
-function havp_setup_cron($task_key, $options, $on_off)
-{
-    global $config;
-	$cron_item = array();
+function get_real_interface_address($iface) {
+	global $config;
 
-    # $on_off = TRUE/FALSE - install/deinstall cron task:
-    # prepare new cron item
-	if (is_array($options)) {
-		$cron_item['minute']  =  $options[0];
-        $cron_item['hour']    =  $options[1];
-        $cron_item['mday']    =  $options[2];
-        $cron_item['month']   =  $options[3];
-        $cron_item['wday']    =  $options[4];
-        $cron_item['who']     = ($options[5]) ? $options[5] : 'nobody';
-        $cron_item['command'] =  $options[6];
-    }
+	if ($iface === 'localhost') {
+		return array('127.0.0.1', '');
+	}
 
-    # unset old cron task with $task_key
-    if (!empty($task_key)) {
-        $flag_cron_upd = false;
-        # delete old cron task if exists
-        if (is_array($config['cron']['item'])) {
-            foreach($config['cron']['item'] as $key => $val) {
-                if (strpos($config['cron']['item'][$key]['command'], $task_key) !== false) {
-                    unset($config['cron']['item'][$key]);
-                    $flag_cron_upd = true;
-                    break;
-                }
-            }
-        }
+	$iface = convert_friendly_interface_to_real_interface_name($iface);
+	$line = trim(shell_exec("/sbin/ifconfig $iface | /usr/bin/grep inet | /usr/bin/grep -v inet6"));
+	list($dummy, $ip, $dummy2, $netmask) = explode(" ", $line);
 
-        # set new cron task
-        if (($on_off === true) and !empty($cron_item)) {
-            $config['cron']['item'][] = $cron_item;
-            $flag_cron_upd = true;
-        }
-
-        # write config and configure cron only if cron task modified
-        if ($flag_cron_upd === true) {
-            write_config("Installed cron task '$task_key' for 'havp' package");
-            configure_cron();
-        }
-    }
-    else {
-        # ! error $name !
-        return;
-    }
+	return array($ip, long2ip(hexdec($netmask)));
 }
-# ------------------------------------------------------------------------------
-# filter rules
-# ------------------------------------------------------------------------------
-function havp_generate_rules($type = 'filter')
-{
-    # pfSense v.2.x - welcome !
+/*
+* -------------------------------------------------------------------------------
+* Check blacklist/whitelist domains
+* -------------------------------------------------------------------------------
+*/
+// Lines can hold URLs with wildcards with following rules:
+// Line must contain domain/path
+// Domains may begin with a wildcard
+// Paths may begin and/or end with a wildcard
+// URLs without wildcards are exact match
+// Examples:
+// (1) www.server-side.de	(Only this URL is whitelisted)
+// (2) www.server-side.de/*	(Domain is completely whitelisted)
+// (3) *server-side.de/index.html
+// (4) */*.gif			(All .gif files are whitelisted)
+// (5) www.server-side.de/novirus*
+// (6) www.server-side.de/*novirus*
+/*
+* -------------------------------------------------------------------------------
+*/
+function check_bw_domain($_dm) {
+	$domain = "";
+	$path = "";
 
-    # 'nat' 'filter'
-    global $config, $havp_config;
-    $rules = array();
+	if (!is_string($_dm)) {
+		return false;
+	}
 
-    # no rules if havp disabled
-    if ($havp_config[F_ENABLE] !== 'true') {
-        return '';
-    }
+	$pos = strpos($_dm, "/");
+	if ($pos === false) {
+		$domain = $_dm;
+		$path = "";
+	} else {
+		$domain = substr($_dm, 0, $pos);
+		$path = substr($_dm, $pos+1);
+	}
 
-    $proxymode = $havp_config[F_PROXYMODE];
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # =-= HAVP always listen 127.0.0.1:port =-=
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Proxy mode:
-    # Standard         - Filter: Rdr ifaces:port => 127.0.0.1:port
-    # Parent for Squid - Filter: No
-    # Transparent      - Filter: Rdr ifaces:port => 127.0.0.1:port;
-    #                    Rdr Any Http => 127.0.0.1:port + Allow Http traffic via iface
-    #                    If Squid transparent, then as Standard.
-    # Internal         - Filter: No
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// Domains may begin with a wildcard: '*domain.xx' - *my.domain.com
+	// Paths may begin and/or end with a wildcard: '*xxx*'
+	// Regex: * - {0,}; + - {1,}; ? = {0,1}
+	$df = "[a-zA-Z0-9\-]";
+	$dm_fmt = "/^((\*)|(\*\.))?($df+\.)+$df{2,}$/i"; // d.com *d.com *.d.com
+	$ph_fmt = "/^((\*)|((\*)?([^\*]+)(\*)?))$/i"; // *path*
 
-    $proxybindiface = 'lo0'; # 127.0.0.1
-    $ifaces    = array_map('convert_friendly_interface_to_real_interface_name', explode(',', $havp_config[F_PROXYINTERFACE]));
-    $proxyport = ( $havp_config[F_PROXYPORT] ? $havp_config[F_PROXYPORT] : HVDEF_PROXYPORT );
+	if (empty($path)) {
+		// d.com *d.com *.d.com
+		return preg_match($dm_fmt, $domain);
+	} else {
+		if (!empty($domain)) {
+			return (($domain === '*') || preg_match($dm_fmt, $domain)) && preg_match($ph_fmt, $path);
+		}
+	}
 
-    # squid already transparent
-    $squid_transparent_proxy = ($config['installedpackages']['squid']['config'][0]['transparent_proxy'] == 'on');
-    if (($proxymode === 'transparent') && $squid_transparent_proxy) {
-        $proxymode = 'standard';
-        log_error("Havp: Squid is already configured as transparent proxy. Use 'Standard' proxy mode.");
-    }
-
-    # nat
-    if ($type == 'nat') {
-        $rules[] = "";
-        $rules[] = "# havp proxy ifaces redirect";
-        foreach($ifaces as $iface) {
-            switch($proxymode) {
-                case 'transparent':
-                    # rdr any http => localhost:port
-                    $rules[] = "rdr on $iface proto tcp from any to !($iface) port 80 -> $proxybindiface port $proxyport";
-                case 'standard':
-                case 'squid':
-                    # rdr iface:port => localhost:port
-                    $rules[] = "rdr on $iface proto tcp from any to ($iface) port $proxyport -> $proxybindiface port $proxyport";
-                    break;
-                    # no more rdr
-                case 'internal':
-                    default: break;
-            }
-        }
-        $rules[] = "";
-    }
-
-    # filter
-    if ($type == 'filter' || $type == 'rule') {
-        $rules[] = "";
-        $rules[] = "# havp proxy ifaces rules";
-        foreach($ifaces as $iface) {
-            switch($proxymode) {
-                case 'transparent':
-                    # pass http on iface
-                    $rules[] = "pass in quick on $iface proto tcp from any to !($iface) port 80 flags S/SA keep state";
-                    break;
-                # no more rules
-                case 'standard':
-                case 'squid':
-                case 'internal':
-                    default: break;
-            }
-        }
-        $rules[] = "";
-    }
-
-    if ($type == 'pfearly') {
-
-    }
-
-    if ($type == 'pflate') {
-
-    }
-
-    # test
-    # file_put_contents("/tmp/havp_".$type, "state: $proxymode\n" . implode("\n", $rules));
-
-    return implode("\n", $rules);
+	return false;
 }
-# ------------------------------------------------------------------------------
-function havp_filter_update_3()
-{
-    # for 1.x only
-    if (pfsense_version_() != '1') return;
+/*
+* ------------------------------------------------------------------------------
+* Filter rules
+* ------------------------------------------------------------------------------
+*/
+function havp_generate_rules($type = 'filter') {
+
+	global $config, $havp_config;
+	$rules = array();
+
+	// Do not configure any rules if HAVP is disabled
+	if ($havp_config[F_ENABLE] !== 'true') {
+		return '';
+	}
+
+	$proxymode = $havp_config[F_PROXYMODE];
+	/*
+	* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	* HAVP always listens on 127.0.0.1:port
+	* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	* Proxy mode:
+	* Standard		- Filter: rdr ifaces:port => 127.0.0.1:port
+	* Parent for Squid	- Filter: No
+	* Transparent		- Filter: rdr ifaces:port => 127.0.0.1:port;
+	*			rdr any http => 127.0.0.1:port + allow http traffic via iface
+	*			If Squid transparent, then as Standard.
+	* Internal		- Filter: No
+	* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	*/
+
+	$proxybindiface = 'lo0'; // 127.0.0.1
+	$ifaces = array_map('convert_friendly_interface_to_real_interface_name', explode(',', $havp_config[F_PROXYINTERFACE]));
+	$proxyport = ($havp_config[F_PROXYPORT] ? $havp_config[F_PROXYPORT] : HVDEF_PROXYPORT);
+
+	// Squid already transparent
+	$squid_transparent_proxy = ($config['installedpackages']['squid']['config'][0]['transparent_proxy'] == 'on');
+	if (($proxymode === 'transparent') && $squid_transparent_proxy) {
+		$proxymode = 'standard';
+		log_error("HAVP: Squid is already configured as transparent proxy. Use 'Standard' proxy mode.");
+	}
+
+	// NAT
+	if ($type == 'nat') {
+		$rules[] = "";
+		$rules[] = "# havp proxy ifaces redirect";
+		foreach ($ifaces as $iface) {
+			switch ($proxymode) {
+				case 'transparent':
+					// rdr any http => localhost:port
+					$rules[] = "rdr on $iface proto tcp from any to !($iface) port 80 -> $proxybindiface port $proxyport";
+				case 'standard':
+				case 'squid':
+					// rdr iface:port => localhost:port
+					$rules[] = "rdr on $iface proto tcp from any to ($iface) port $proxyport -> $proxybindiface port $proxyport";
+					break;
+				// No more rdr
+				case 'internal':
+				default: break;
+			}
+		}
+		$rules[] = "";
+	}
+
+	// Filter
+	if ($type == 'filter' || $type == 'rule') {
+		$rules[] = "";
+		$rules[] = "# havp proxy ifaces rules";
+		foreach ($ifaces as $iface) {
+			switch ($proxymode) {
+				case 'transparent':
+					// Pass http on iface
+					$rules[] = "pass in quick on $iface proto tcp from any to !($iface) port 80 flags S/SA keep state";
+					break;
+				// No more rules
+				case 'standard':
+				case 'squid':
+				case 'internal':
+				default: break;
+			}
+		}
+		$rules[] = "";
+	}
+
+	if ($type == 'pfearly') {
+		return;
+	}
+
+	if ($type == 'pflate') {
+		return;
+	}
+
+	return implode("\n", $rules);
+}
+
+function havp_filter_update_3() {
 
 	$rules_file = '/tmp/rules.debug';
-    if (file_exists($rules_file)) {
-        $newrules = array();
-        $rules = file_get_contents($rules_file);
-        $rules = explode("\n", $rules);
+	if (file_exists($rules_file)) {
+		$newrules = array();
+		$rules = file_get_contents($rules_file);
+		$rules = explode("\n", $rules);
 
-        foreach($rules as $val) {
-        	$newrules[] = $val;
-            # rdr
-        	if (trim($val) === "rdr-anchor \"miniupnpd\"") {
-        	    $newrules[] = "# havp rdr";
-        	    $newrules[] = havp_generate_rules('nat');
-        	    $newrules[] = "";
-        	}
-        	# rules
-        	elseif(trim($val) === "anchor \"miniupnpd\"") {
-        	    $newrules[] = "# havp rules";
-        	    $newrules[] = havp_generate_rules('filter');
-        	    $newrules[] = "";
-        	}
-        	$rules = implode("\n", $newrules);
-        }
-        file_put_contents($rules_file, $rules);
-        mwexec("pfctl -f $rules_file");
-    }
+		foreach ($rules as $val) {
+			$newrules[] = $val;
+			// rdr
+			if (trim($val) === "rdr-anchor \"miniupnpd\"") {
+				$newrules[] = "# havp rdr";
+				$newrules[] = havp_generate_rules('nat');
+				$newrules[] = "";
+			} elseif (trim($val) === "anchor \"miniupnpd\"") {
+				// rules
+				$newrules[] = "# havp rules";
+				$newrules[] = havp_generate_rules('filter');
+				$newrules[] = "";
+			}
+			$rules = implode("\n", $newrules);
+		}
+	file_put_contents($rules_file, $rules);
+	mwexec("/sbin/pfctl -f $rules_file");
+	}
 }
 
-# ------------------------------------------------------------------------------
-function havp_update_AV()
-{
-    # AV update script
-    file_put_contents(HVDEF_AVUPD_SCRIPT, havp_AVupdate_script());
-    havp_set_file_access(HVDEF_AVUPD_SCRIPT, HVDEF_AVUSER, '0755');
-    mwexec_bg(HVDEF_AVUPD_SCRIPT); # run update background
+/* AV update script */
+function havp_update_AV() {
+	file_put_contents(HVDEF_AVUPD_SCRIPT, havp_AVupdate_script());
+	havp_set_file_access(HVDEF_AVUPD_SCRIPT, HVDEF_AVUSER, '0755');
+	// Run update in background
+	mwexec_bg(HVDEF_AVUPD_SCRIPT);
 }
-# ==============================================================================
-# Scripts
-# ==============================================================================
-# AV update script
-function havp_AVupdate_script()
-{
-$f = HVDEF_UPD_STATUS_FILE;
-$u = HVDEF_FRESHCLAM_STATUS_FILE;
-return <<<EOD
+/*
+* ==============================================================================
+* Scripts
+* ==============================================================================
+*/
+/* AV update script */
+function havp_AVupdate_script() {
+	$f = HVDEF_UPD_STATUS_FILE;
+	$u = HVDEF_FRESHCLAM_STATUS_FILE;
+	return <<< EOD
 #!/bin/sh
-date +"%Y.%m.%d %H:%M:%S Antivirus update started."  > $f
-date +"%Y.%m.%d %H:%M:%S Antivirus database already is updated." > $u
+/bin/date +"%Y.%m.%d %H:%M:%S Antivirus update started." > $f
+/bin/date +"%Y.%m.%d %H:%M:%S Antivirus database already is updated." > $u
 /usr/local/bin/freshclam
 wait
 cat $u >> $f
 /usr/local/bin/sigtool --unpack-current daily.cvd
 /usr/local/bin/sigtool --unpack-current main.cvd
 wait
-date +"%Y.%m.%d %H:%M:%S Antivirus update end." >> $f
+/bin/date +"%Y.%m.%d %H:%M:%S Antivirus update end." >> $f
 EOD;
 
 }
-# ------------------------------------------------------------------------------
-# HAVP service startup script
-function havp_startup_script()
-{
-    global $havp_config;
-    $pid = HVDEF_PID_FILE;
-    $havpchk  = "ps auxw | grep \"[h]avp -c\"|awk '{print $2}'";
-    $clamdchk = "ps auxw | grep \"[c]lamd -c\"|awk '{print $2}'";
 
-    # rc script
-    $rc = array();
-    $rc['file'] = basename(HVDEF_HAVP_STARTUP_SCRIPT);
+/* HAVP service startup script */
+function havp_startup_script() {
+	global $havp_config;
+	$pid = HVDEF_PID_FILE;
+	$havpchk = "/bin/ps auxw | /usr/bin/grep \"[h]avp -c\" | /usr/bin/awk '{print $2}'";
+	$clamdchk = "/bin/ps auxw | /usr/bin/grep \"[c]lamd -c\" | /usr/bin/awk '{print $2}'";
 
-    $s[] = "\t# init";
-    $s[] = "\techo 'Starting ..' > " . HVDEF_HAVP_STATUS_FILE;
+	/* Create rc script */
+	$rc = array();
+	$rc['file'] = basename(HVDEF_HAVP_STARTUP_SCRIPT);
 
-    $s[] = "\t# start";
-    $s[] = "\tif [ -z \"`{$havpchk}`\" ];then";
-    if ($havp_config[F_USECLAMD] === 'true') {
-        $clampid_dir = HVDEF_CLAM_RUNDIR;
-        $s[] = "\t\t# start clamd before (to be sure)";
-        $s[] = "\t\t" . HVDEF_CLAM_STARTUP_SCRIPT . " start";
-        $s[] = "\t\tsleep 2";
-        $s[] = "";
+	$s[] = "\t# init";
+	$s[] = "\techo 'Starting ..' > " . HVDEF_HAVP_STATUS_FILE;
 
-        $s[] = "\t\t# if clamd started";
-        $s[] = "\t\tif [ -n \"`{$clamdchk}`\" ];then";
-        $s[] = "\t\t\t# Waiting CLAMD";
-        $s[] = "\t\t\techo -n \"Waiting CLAMD \"";
-        $s[] = "\t\t\techo 'Waiting CLAMD' > " . HVDEF_HAVP_STATUS_FILE;
-        $s[] = "\t\t\twhile [ \"`{$clamdchk}`\" != \"`/bin/cat {$clampid_dir}/clamd.pid`\" ];do";
-        $s[] = "\t\t\t\techo -n '.'";
-        $s[] = "\t\t\t\tsleep 1";
-        $s[] = "\t\t\tdone";
-        $s[] = "\t\t\techo";
-        $s[] = "\t\tfi";
-        $s[] = "";
-    }
-    $s[] = "\t\t/usr/local/sbin/havp -c " . HVDEF_HAVP_CONFIG . " 2>/dev/null";
-    $s[] = "\t\twait";
-    $s[] = "\tfi";
+	$s[] = "\t# start";
+	$s[] = "\tif [ -z \"`{$havpchk}`\" ]; then";
+	if ($havp_config[F_USECLAMD] === 'true') {
+		$clampid_dir = HVDEF_CLAM_RUNDIR;
+		$s[] = "\t\t# start clamd before (to be sure)";
+		$s[] = "\t\t" . HVDEF_CLAM_STARTUP_SCRIPT . " start";
+		$s[] = "\t\tsleep 2";
+		$s[] = "";
 
-    $s[] = "\t# Status";
-    $s[] = "\tif [ -z \"`{$havpchk}`\" ];then";
-    $s[] = "\t\techo 'Stopped' > " . HVDEF_HAVP_STATUS_FILE;
-    $s[] = "\telse";
-    $s[] = "\t\techo 'Started' > " . HVDEF_HAVP_STATUS_FILE;
-    $s[] = "\tfi";
+		$s[] = "\t\t# if clamd started";
+		$s[] = "\t\tif [ -n \"`{$clamdchk}`\" ]; then";
+		$s[] = "\t\t\t# Waiting for ClamD";
+		$s[] = "\t\t\techo -n \"Waiting for ClamD \"";
+		$s[] = "\t\t\techo 'Waiting for ClamD' > " . HVDEF_HAVP_STATUS_FILE;
+		$s[] = "\t\t\twhile [ \"`{$clamdchk}`\" != \"`/bin/cat {$clampid_dir}/clamd.pid`\" ]; do";
+		$s[] = "\t\t\t\techo -n '.'";
+		$s[] = "\t\t\t\tsleep 1";
+		$s[] = "\t\t\tdone";
+		$s[] = "\t\t\techo";
+		$s[] = "\t\tfi";
+		$s[] = "";
+	}
+	$s[] = "\t\t/usr/local/sbin/havp -c " . HVDEF_HAVP_CONFIG . " 2>/dev/null";
+	$s[] = "\t\twait";
+	$s[] = "\tfi";
 
-    $s[] = "";
-    $rc['start'] = implode("\n", $s);
-    unset($s);
+	$s[] = "\t# Status";
+	$s[] = "\tif [ -z \"`{$havpchk}`\" ]; then";
+	$s[] = "\t\techo 'Stopped' > " . HVDEF_HAVP_STATUS_FILE;
+	$s[] = "\telse";
+	$s[] = "\t\techo 'Started' > " . HVDEF_HAVP_STATUS_FILE;
+	$s[] = "\tfi";
 
-    $s[] = "# stop";
-    $s[] = "\t killall havp 2>/dev/null";
-    $s[] = "\t sleep 2";
-    $s[] = "\t killall -9 havp 2>/dev/null";
-    $s[] = "\t wait";
-    $s[] = "\t echo 'Stopped' > " . HVDEF_HAVP_STATUS_FILE;
-    $s[] = "";
-    $rc['stop'] = implode("\n", $s);
-    unset($s);
+	$s[] = "";
+	$rc['start'] = implode("\n", $s);
+	unset($s);
 
-    # we don't use start if package disabled
-    if ($havp_config[F_ENABLE] !== 'true') {
-        $rc['start'] = "\t echo 'Disabled' > " . HVDEF_HAVP_STATUS_FILE;
-    }
+	$s[] = "# stop";
+	$s[] = "\t /usr/bin/killall havp 2>/dev/null";
+	$s[] = "\t sleep 2";
+	$s[] = "\t /usr/bin/killall -9 havp 2>/dev/null";
+	$s[] = "\t wait";
+	$s[] = "\t echo 'Stopped' > " . HVDEF_HAVP_STATUS_FILE;
+	$s[] = "";
+	$rc['stop'] = implode("\n", $s);
+	unset($s);
 
-    write_rcfile($rc);
-}
-# ------------------------------------------------------------------------------
-# clamd service startup script
-function hv_clamd_startup_script()
-{
-    global $havp_config;
-    $pid = HVDEF_CLAM_PID;
-    $clamdchk = "ps auxw | grep \"[c]lamd -c\"|awk '{print $2}'";
+	// We don't use start if HAVP is disabled
+	if ($havp_config[F_ENABLE] !== 'true') {
+		$rc['start'] = "\t echo 'Disabled' > " . HVDEF_HAVP_STATUS_FILE;
+	}
 
-    # rc script
-    $rc = array();
-    $rc['file'] = basename(HVDEF_CLAM_STARTUP_SCRIPT);
-    $s[] = "\t\techo 'Starting..' > " . HVDEF_CLAM_STATUS_FILE;
-
-    $s[] = "# start";
-    $s[] = "\tif [ -z \"`{$clamdchk}`\" ];then";
-    $s[] = "\t\t/usr/local/sbin/clamd -c " . HVDEF_CLAM_CONFIG . " 2>/dev/null";
-    $s[] = "\t\twait";
-    $s[] = "\tfi";
-    $s[] = "\techo 'Started' > " . HVDEF_CLAM_STATUS_FILE;
-    $s[] = "";
-    $rc['start'] = implode("\n", $s);
-    unset($s);
-
-    $s[] = "#stop";
-    $s[] = "\t killall clamd 2>/dev/null";
-    $s[] = "\t sleep 2";
-    $s[] = "\t killall -9 clamd 2>/dev/null";
-    $s[] = "\t wait";
-    $s[] = "\t\techo 'Stopped' > " . HVDEF_CLAM_STATUS_FILE;
-    $s[] = "";
-    $rc['stop'] = implode("\n", $s);
-    unset($s);
-
-    write_rcfile($rc);
+	write_rcfile($rc);
 }
 
-# ------------------------------------------------------------------------------
-# HAVP filter resync script
-function havp_filter_resync_script()
-{
+/* ClamD service startup script */
+function hv_clamd_startup_script() {
+	global $havp_config;
+	$pid = HVDEF_CLAM_PID;
+	$clamdchk = "/bin/ps auxw | /usr/bin/grep \"[c]lamd -c\" | /usr/bin/awk '{print $2}'";
 
-return <<<EOD
+	/* Create rc script */
+	$rc = array();
+	$rc['file'] = basename(HVDEF_CLAM_STARTUP_SCRIPT);
+	$s[] = "\t\techo 'Starting..' > " . HVDEF_CLAM_STATUS_FILE;
+
+	$s[] = "# start";
+	$s[] = "\tif [ -z \"`{$clamdchk}`\" ]; then";
+	$s[] = "\t\t/usr/local/sbin/clamd -c " . HVDEF_CLAM_CONFIG . " 2>/dev/null";
+	$s[] = "\t\twait";
+	$s[] = "\tfi";
+	$s[] = "\techo 'Started' > " . HVDEF_CLAM_STATUS_FILE;
+	$s[] = "";
+	$rc['start'] = implode("\n", $s);
+	unset($s);
+
+	$s[] = "#stop";
+	$s[] = "\t /usr/bin/killall clamd 2>/dev/null";
+	$s[] = "\t sleep 2";
+	$s[] = "\t /usr/bin/killall -9 clamd 2>/dev/null";
+	$s[] = "\t wait";
+	$s[] = "\t\techo 'Stopped' > " . HVDEF_CLAM_STATUS_FILE;
+	$s[] = "";
+	$rc['stop'] = implode("\n", $s);
+	unset($s);
+
+	write_rcfile($rc);
+}
+
+
+/* HAVP filter resync script */
+function havp_filter_resync_script() {
+
+	return <<<EOD
 #!/usr/local/bin/php -f
 <?php
-# havp filter hook
+// havp filter hook
 if (file_exists('/usr/local/pkg/havp.inc')) {
 	require_once('havp.inc');
 	havp_filter_update_3();
@@ -1457,290 +1449,223 @@ EOD;
 
 }
 
-# ==============================================================================
-# RAM Disk
-# ==============================================================================
-function mountRAMdisk($free_and_mount = true)
-{
-    global $havp_config;
-    $mnt_point = HVDEF_RAMTEMP_DIR;
-    $mnt_flag_file = "$mnt_point/.mnt";
+/*
+* ==============================================================================
+* RAM Disk
+* ==============================================================================
+*/
+function mountRAMdisk($free_and_mount = true) {
+	global $havp_config;
+	$mnt_point = HVDEF_RAMTEMP_DIR;
+	$mnt_flag_file = "$mnt_point/.mnt";
 
-    # RAM Disk disabled
-    if (HV_USE_TMPRAMDISK !== 'true') {
-        umountRAMDisk();
-        return;
-    }
+	/* RAM Disk disabled */
+	if (HV_USE_TMPRAMDISK !== 'true') {
+		umountRAMDisk();
+		return;
+	}
 
-    # RAM Disk on VM disabled
-    if ((HV_VM_TMPRAMDISK  !== 'true') && VMWare_detect()) {
-        umountRAMDisk();
-   	    log_error("havp: RAMDisk on VM disabled.");
-        return;
-    }
+	/* RAM Disk on VM disabled */
+	if ((HV_VM_TMPRAMDISK !== 'true') && VMWare_detect()) {
+		umountRAMDisk();
+		log_error("havp: RAMDisk on VM disabled.");
+		return;
+	}
 
-    # free RAMDisk only
-    if ($free_and_mount !== true) {
-        umountRAMDisk();
-        return;
-    }
+	/* Free RAMDisk only */
+	if ($free_and_mount !== true) {
+		umountRAMDisk();
+		return;
+	}
 
-    # =-= Temp RAMDisk =-=
-    # note: use 1/4 of system memory capacity
-    $ramdisk_capacity = get_memory();
-    $ramdisk_capacity = intval(intval($ramdisk_capacity[0]) / 4); # [Mb]
+	/* Temp RAMDisk */
+	// Note: Use 1/4 of system memory capacity
+	$ramdisk_capacity = get_memory();
+	$ramdisk_capacity = intval(intval($ramdisk_capacity[0]) / 4); // [MB]
 
-    # RAMDisk already exists?
-    if (file_exists("/dev/md10")) return;
-    # umount old RAMDisk
-#    umountRAMDisk();
+	/* RAMDisk already exists? */
+	if (file_exists("/dev/md10")) {
+		return;
+	}
 
-    # create and mount a swap backed file system on /var/tmp/havp by /dev/md10:
-# SWAP
-#    mwexec("mdconfig -a -t swap -s {$ramdisk_capacity}M -u 10");
-#    mwexec("newfs -U /dev/md10");
-#    mwexec("mount /dev/md10 $mnt_point");
-# RAM - more quickly, used physical RAM
-    mwexec("/sbin/mdmfs -s {$ramdisk_capacity}M md10 {$mnt_point}");
-    mwexec("chmod 1777 {$mnt_point}");
+	/* Create and mount a swap backed file system on /var/tmp/havp by /dev/md10: */
+	// mwexec("mdconfig -a -t swap -s {$ramdisk_capacity}M -u 10");
+	// mwexec("newfs -U /dev/md10");
+	// mwexec("mount /dev/md10 $mnt_point");
+	/* RAM - faster, uses physical RAM */
+	mwexec("/sbin/mdmfs -s {$ramdisk_capacity}M md10 {$mnt_point}");
+	mwexec("/bin/chmod 1777 {$mnt_point}");
 
-    # create flag file
-    file_put_contents($mnt_flag_file, "{$ramdisk_capacity}");
-    # syslog
-    if (HV_DEBUG === 'true')
-        log_error("havp: Create RAMDisk {$ramdisk_capacity}Mb.");
-}
-# ------------------------------------------------------------------------------
-function umountRAMDisk()
-{
-    global $havp_config;
-
-    # detach and free all resources used by /dev/md10:
-    mwexec("umount -f " . HVDEF_RAMTEMP_DIR);
-    mwexec("mdconfig -d -u 10");
+	/* Create flag file */
+	file_put_contents($mnt_flag_file, "{$ramdisk_capacity}");
+	/* syslog */
+	if (HV_DEBUG === 'true') {
+		log_error("HAVP: Create RAMDisk {$ramdisk_capacity}Mb.");
+	}
 }
 
-# ==============================================================================
-# Utilites
-# ==============================================================================
-function VMWare_detect()
-{
-    global $g;
-    $fc = '';
 
-    if (file_exists("{$g['varlog_path']}/dmesg.boot") !== false)
-        $fc = file_get_contents("{$g['varlog_path']}/dmesg.boot");
+function umountRAMDisk() {
+	global $havp_config;
 
-    return (strpos($fc, "<VMware Virtual") !== false);
+	/* Detach and free all resources used by /dev/md10 */
+	mwexec("/sbin/umount -f " . HVDEF_RAMTEMP_DIR);
+	mwexec("/sbin/mdconfig -d -u 10");
 }
 
-function pfsense_version_()
-{
-    $ver = '1';
+/*
+* ==============================================================================
+* Utilites
+* ==============================================================================
+*/
+function VMWare_detect() {
+	global $g;
+	$fc = '';
 
-    if (file_exists('/etc/version')) {
-        $s = file_get_contents('/etc/version');
-        $s = str_replace('-', '.', $s); # '2.0-Beta' > '2.0.Beta'
-        $s = explode(".", $s);
-        $ver = $s ? $s[0] : '1';
-    }
+	if (file_exists("{$g['varlog_path']}/dmesg.boot") !== false) {
+		$fc = file_get_contents("{$g['varlog_path']}/dmesg.boot");
+	}
 
-    return intval($ver);
+	return (strpos($fc, "<VMware Virtual") !== false);
 }
 
-# ------------------------------------------------------------------------------
-function start_antivirus_scanner($filename)
-{
-    $param = array();
-#   $param[] = "-v";                                                            # verbose
-    if (HV_DEBUG === 'true')
-         $param[] = "--debug";                                                  # debug option
-    else $param[] = "--quiet";                                                  # output only errors
-    $param[] = "--stdout";                                                      # Write to stdout instead of stderr
-#   $param[] = "--no-summary";                                                  # Disable summary at end of scanning
-    $param[] = "-i";                                                            # Only print infected files
-    $param[] = "--tempdir=" . HVDEF_TEMP_DIR;                                   # Create temporary files in DIRECTORY
-#   $param[] = "-d FILE/DIR";                                                   # Load virus database from FILE or load all .cvd and .db[2] files from DIR
-    $param[] = "-l " . HVDEF_CLAMSCAN_LOG;                                      # Save scan report to FILE
-    $param[] = "-r";                                                            # Scan subdirectories recursively
-    $param[] = "--remove";                                                      # Remove infected files. Be careful!
-    $param[] = "--detect-broken";                                               # Try to detect broken executable files
-    $param[] = "--max-filesize=10000000";                                       # Files larger than this will be skipped and assumed clean
-    $param[] = "--max-scansize=5000000";                                        # The maximum amount of data to scan for each container file (*)
-    $param[] = "--max-files=10000";                                             # The maximum number of files to scan for each container file (*)
-    $param[] = "--max-recursion=255";                                           # Maximum archive recursion level for container file (*)
-    $param[] = "--max-dir-recursion=255";                                       # Maximum directory recursion level
+/* ------------------------------------------------------------------------------ */
+function start_antivirus_scanner($filename) {
+	$param = array();
+	// $param[] = "-v"; // verbose
+	if (HV_DEBUG === 'true') {
+		$param[] = "--debug";			// debug option
+	} else {
+		$param[] = "--quiet";			// output only errors
+	}
+	$param[] = "--stdout";				// Write to stdout instead of stderr
+	// $param[] = "--no-summary";			// Disable summary at end of scanning
+	$param[] = "-i";				// Only print infected files
+	$param[] = "--tempdir=" . HVDEF_TEMP_DIR;	// Create temporary files in DIRECTORY
+	// $param[] = "-d FILE/DIR";			// Load virus database from FILE or load all .cvd and .db[2] files from DIR
+	$param[] = "-l " . HVDEF_CLAMSCAN_LOG;		// Save scan report to FILE
+	$param[] = "-r";				// Scan subdirectories recursively
+	$param[] = "--remove";				// Remove infected files. Be careful!
+	$param[] = "--detect-broken";			// Try to detect broken executable files
+	$param[] = "--max-filesize=10000000";		// Files larger than this will be skipped and assumed clean
+	$param[] = "--max-scansize=5000000";		// The maximum amount of data to scan for each container file (*)
+	$param[] = "--max-files=10000";			// The maximum number of files to scan for each container file (*)
+	$param[] = "--max-recursion=255";		// Maximum archive recursion level for container file (*)
+	$param[] = "--max-dir-recursion=255";		// Maximum directory recursion level
 
-    $param = implode(" ", $param);
-    if ($havp_config[F_USECLAMD] === 'true')
-         $param = "clamdscan $param $filename"; # use clamd daemon (more quickly)
-    else $param = "clamscan  $param $filename";
+	$param = implode(" ", $param);
+	if ($havp_config[F_USECLAMD] === 'true') {
+		$param = "clamdscan $param $filename";	// use clamd daemon (faster)
+	} else {
+		$param = "clamscan $param $filename";
+	}
 
-    # debug clamscan cmd
-    if (HV_DEBUG === 'true') file_put_contents("/tmp/clamscan.cmd", $param);
+	// debug clamscan cmd
+	if (HV_DEBUG === 'true') {
+		file_put_contents("/tmp/clamscan.cmd", $param);
+	}
 
-    if (file_exists($filename)) {
-    	 log_error("Antivirus: Starting file '$filename' scanner. Log file is '" . HVDEF_CLAMSCAN_LOG . "'. Wait 5-10 minutes.");
+	if (file_exists($filename)) {
+		log_error("Antivirus: Starting file '$filename' scan. Log file is '" . HVDEF_CLAMSCAN_LOG . "'. Wait 5-10 minutes.");
 
-    	 # put to log scanning file
-    	 $cont="Starting scan file {$filename}\n";
-        file_put_contents(HVDEF_CLAMSCAN_LOG, $cont);
+		// Put file scan to log
+		$cont = "Starting scan file {$filename}\n";
+		file_put_contents(HVDEF_CLAMSCAN_LOG, $cont);
 
-        mwexec_bg("$param");
-        exec("date +\"%Y.%m.%d %H:%M:%S Starting scan file '$filename'.\" > " . HVDEF_CLAMSCAN_LOG);
-    }
-    else log_error("Antivirus: Can't starting file scanner. File '$filename' not exists.");
+		mwexec_bg("$param");
+		exec("/bin/date +\"%Y.%m.%d %H:%M:%S Starting scan of {$filename}.\" > " . HVDEF_CLAMSCAN_LOG);
+	} else {
+		log_error("Antivirus: Cannot scan file: {$filename} does not exist.");
+	}
 }
 
-# ------------------------------------------------------------------------------
-# HTML
-# ------------------------------------------------------------------------------
-function havp_fscan_html()
-{
-    global $g;
-    $clamscan_log = HVDEF_CLAMSCAN_LOG;
+/*
+* ------------------------------------------------------------------------------
+* HTML
+* ------------------------------------------------------------------------------
+*/
+function havp_fscan_html() {
+	global $g;
+	$clamscan_log = HVDEF_CLAMSCAN_LOG;
 
-    return <<<EOD
-<hr>
-<span onClick="document.getElementById('scanfilepath').value = '/var/squid';" style="cursor: pointer;">
-    <img src='./themes/{$g['theme']}/images/icons/icon_pass.gif' title='Click here'>
-        <font size='-1'><u>&nbsp;Squid cache path (scan your squid cache now).</u></font>
-    </img>
+	return <<< EOD
+<hr />
+<span onclick="document.getElementById('scanfilepath').value = '/var/squid';" style="cursor: pointer;">
+	<img src='./themes/{$g['theme']}/images/icons/icon_pass.gif' title='Click here' alt=''>
+		<span style='text-decoration: underline;'>&nbsp;Squid cache path (scan your Squid cache now).</span>
+	</img>
 </span>
-<br>
-<span onClick="document.getElementById('scanfilepath').value = '/var/db';" style="cursor: pointer;">
-    <img src='./themes/{$g['theme']}/images/icons/icon_pass.gif' title='Click here'>
-        <font size='-1'><u>&nbsp;Common DB path.</u></font>
-    </img>
+<br />
+<span onclick="document.getElementById('scanfilepath').value = '/var/db';" style="cursor: pointer;">
+	<img src='./themes/{$g['theme']}/images/icons/icon_pass.gif' title='Click here' alt=''>
+		<span style='text-decoration: underline;'>&nbsp;Common DB path.</span>
+	</img>
 </span>
-<br>
-<span onClick="document.getElementById('scanfilepath').value = '/tmp';" style="cursor: pointer;">
-    <img src='./themes/{$g['theme']}/images/icons/icon_pass.gif' title='Click here'>
-        <font size='-1'><u>&nbsp;Temp path.</u></font>
-    </img>
+<br />
+<span onclick="document.getElementById('scanfilepath').value = '/tmp';" style="cursor: pointer;">
+	<img src='./themes/{$g['theme']}/images/icons/icon_pass.gif' title='Click here' alt=''>
+		<span style='text-decoration: underline;'>&nbsp;Temp path.</span>
+	</img>
 </span>
-<hr>
-<input name='submit' type='submit' value='Start_scan'><br>
-Press button for start antivirus scanner now. After 5-10 minutes look log file '{$clamscan_log}'.<br>
-(Diagnostics: Execute Shell command: <b>'cat {$clamscan_log}'</b>)
+<hr />
+<input name='submit' type='submit' value='Start_scan' /><br />
+Press button to start AV scanner now. After 5-10 minutes look at the log file '{$clamscan_log}'.<br />
+In Diagnostics - Command Prompt - Execute Shell command: <strong>'/bin/cat {$clamscan_log}'</strong>)
 EOD;
 
 }
 
-/* Future - in next time */
-# blacklist, dns, down, error, invalid, maxsize, request, scanner, virus
-function havp_html_notification_page($type, $title, $notify, $message)
-{
-    $class = '';
-    switch($type) {
-        case 'blacklist': $class = 'notify-warn';     break;
-        case 'dns':       $class = 'notify-standart'; break;
-        case 'down':      $class = 'notify-standart'; break;
-        case 'error':     $class = 'notify-standart'; break;
-        case 'invalid':   $class = 'notify-standart'; break;
-        case 'maxsize':   $class = 'notify-warn';     break;
-        case 'request':   $class = 'notify-standart'; break;
-        case 'scanner':   $class = 'notify-warn';     break;
-        case 'virus':     $class = 'notify-danger';   break;
-   }
-
-    return <<<EOD
-<html>
- <head>
-  <meta http-equiv="content-type" content="text/html; ">
-  <style type="text/css">
-   <!--
-    .havp_scheme			{width: 100%; border: 0px; color: black; vertical-align: bottom; text-align: center; font-family: arial,helvetica; padding-bottom: 3%}
-    .havp_scheme.header 		{font-size: 10pt; font-weight: bold; background-color: #FFFFFF; color: #446699;}
-    .havp_scheme.notify		{font-size: 14pt; font-weight: bold; background-color: #E9E9E9; color: #446699;}
-    .havp_scheme.notify-standart	{font-size: 14pt; font-weight: bold; background-color: #E9E9E9; color: #446699;}
-    .havp_scheme.notify-strong  	{font-size: 14pt; font-weight: bold; background-color: #E9E9E9; color: #446699;}
-    .havp_scheme.notify-danger  	{font-size: 14pt; font-weight: bold; background-color: #FFEFEF; color: #FF6666;}
-    .havp_scheme.notify-warn    	{font-size: 14pt; font-weight: bold; background-color: #FFEFDF; color: #FF9966;}
-    .havp_scheme.message  		{font-size: 10pt; background-color: #FFFFFF; color: #000066;}
-    .havp_scheme.footer		{font-size: 10pt; background-color: #DDDDDD; color: #000066;}
-   -->
-  </style
-  <title>HTTP AntiVirus Proxy: $type</title>
- </head>
- <body>
-  <table class='havp_scheme' cellpadding='2' cellspacing='0' align='center'>
-   <tr class='header'><td>$title<br>HTTP AntiVirus Proxy: $type</td></tr>
-   <tr class='$class'><td>$notify</td></tr>
-   <tr class='message'><td>$message<br><!--message--></td></tr>
-   <tr class='footer' ><td>Powered by havp.</td></tr>
-  </table>
- </body>
-</html>
-EOD;
-
+/*
+* ==============================================================================
+* Status, widgets
+* ==============================================================================
+*/
+function havp_get_scan_log() {
+	$s = '';
+	$clamscanlog = "/var/log/clamscan.log";
+	if (file_exists($clamscanlog)) {
+		$s = file_get_contents("/var/log/clamscan.log");
+	}
+	if (empty($s)) {
+		$s = "Not found.";
+	}
+	return $s;
 }
 
-# ==============================================================================
-# Status, widgets
-# ==============================================================================
-function havp_get_scan_log()
-{
-    $s = '';
-    $clamscanlog = "/var/log/clamscan.log";
-    if (file_exists($clamscanlog)) {
-        $s = file_get_contents("/var/log/clamscan.log");
-    }
-    if (empty($s)) $s = "Not found.";
-    return $s;
+function havp_get_filescanlist() {
+	$slist = array();
+	$slist[0]['descr'] = 'Squid cache path (scan you Squid cache now).';
+	$slist[0]['path'] = '/var/squid';
+	$slist[1]['descr'] = 'Common DB path.';
+	$slist[1]['path'] = '/var/db';
+	$slist[2]['descr'] = 'Temp path.';
+	$slist[2]['path'] = '/tmp';
+	return $slist;
 }
 
-function havp_get_filescanlist()
-{
-    $slist = array();
-    $slist[0]['descr'] = 'Squid cache path (scan you squid cache now).';
-    $slist[0]['path']  = '/var/squid';
-    $slist[1]['descr'] = 'Common DB path.';
-    $slist[1]['path']  = '/var/db';
-    $slist[2]['descr'] = 'Temp path.';
-    $slist[2]['path']  = '/tmp';
-    return $slist;
+function havp_get_av_viruslog() {
+	$s = array();
+	if (file_exists(HVDEF_HAVP_ACCESSLOG)) {
+		$log = file_get_contents(HVDEF_HAVP_ACCESSLOG);
+		$log = explode("\n", $log);
+		$count = 0;
+		foreach($log as $ln) {
+			if (substr_count(strtolower($ln), "virus clam")) {
+				$s[] = $ln;
+			}
+		}
+	}
+	return $s;
 }
 
-function havp_get_av_viruslog()
-{
-    $s = array();
-    if (file_exists(HVDEF_HAVP_ACCESSLOG)) {
-        $log   = file_get_contents(HVDEF_HAVP_ACCESSLOG);
-
-        $log   = explode("\n", $log);
-        $count = 0;
-        foreach($log as $ln) {
-            if (substr_count(strtolower($ln), "virus clam"))
-                $s[] = $ln;
-        }
-    }
-
-    return $s;
-}
-
-function havp_get_av_statistic()
-{
-    $s = "Unknown.";
-    if (file_exists(HVDEF_HAVP_ACCESSLOG)) {
-        $log   = file_get_contents(HVDEF_HAVP_ACCESSLOG);
-
-        $count = substr_count(strtolower($log), "virus clam");
-        $s     = "Found $count viruses (total).";
-    }
-
-    return $s;
-}
-
-# ------------------------------------------------------------------------------
-# Fix
-# ------------------------------------------------------------------------------
-function havp_fix()
-{
-    # remove old named scripts
-    # now must exists 'havp.sh'/'clamd'
-    mwexec(HVDEF_SCRIPT_DIR . "/havp");
-    mwexec(HVDEF_SCRIPT_DIR . "/clamd.sh");
+function havp_get_av_statistic() {
+	$s = "Unknown.";
+	if (file_exists(HVDEF_HAVP_ACCESSLOG)) {
+		$log = file_get_contents(HVDEF_HAVP_ACCESSLOG);
+		$count = substr_count(strtolower($log), "virus clam");
+		$s = "Found $count viruses (total).";
+	}
+	return $s;
 }
 
 ?>

--- a/config/havp/havp.inc
+++ b/config/havp/havp.inc
@@ -524,18 +524,11 @@ function havp_reconfigure_cron() {
 	$on = ($opt[1] !== "");
 	$crontask = "/usr/bin/nice -n20 " . HVDEF_AVUPD_SCRIPT;
 
-	// Delete old cron task if it exists
-	if (is_array($config['cron']['item'])) {
-		foreach ($config['cron']['item'] as $item) {
-			if (strpos($item['command'], $crontask) !== false) {
-				install_cron_job($crontask, false);
-			}
-		}
-	}
-
-	// Set new cron task
+	// Set new cron task or remove it if inactive
 	if ($on === true) {
 		install_cron_job($crontask, $on, $opt);
+	} else {
+		install_cron_job($crontask, false);
 	}
 }
 /*

--- a/config/havp/havp.xml
+++ b/config/havp/havp.xml
@@ -1,324 +1,378 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-        <name>havp</name>
-        <title>Antivirus: HTTP proxy (havp + clamav)</title>
-        <category>Status</category>
-        <version>1.02</version>
-        <include_file>/usr/local/pkg/havp.inc</include_file>
-        <menu>
-                <name>Antivirus</name>
-                <tooltiptext>Antivirus service</tooltiptext>
-                <section>Services</section>
-                <url>/antivirus.php</url>
-        </menu>
-        <service>
+	<copyright>
+<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
+/*
+	havp.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2009-2010 Sergey Dvoriancev <dv_serg@mail.ru>
+	Copyright (C) 2014 Andrew Nikitin <andrey.b.nikitin@gmail.com>.
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
+	<name>havp</name>
+	<title>Antivirus: HTTP proxy (HAVP + ClamAV)</title>
+	<category>Status</category>
+	<version>1.06</version>
+	<include_file>/usr/local/pkg/havp.inc</include_file>
+	<menu>
+		<name>Antivirus</name>
+		<tooltiptext>Antivirus service</tooltiptext>
+		<section>Services</section>
+		<url>/antivirus.php</url>
+	</menu>
+	<service>
 		<name>havp</name>
 		<rcfile>havp.sh</rcfile>
 		<executable>havp</executable>
-		<description>Antivirus HTTP proxy Service</description>
-        </service>
-        <additional_files_needed>
-               <item>https://packages.pfsense.org/packages/config/havp/havp.inc</item>
-               <prefix>/usr/local/pkg/</prefix>
-               <chmod>0755</chmod>
-        </additional_files_needed>
-        <!--additional_files_needed>
-               <item>https://packages.pfsense.org/packages/config/havp/havp_fscan.xml</item>
-               <prefix>/usr/local/pkg/</prefix>
-               <chmod>0755</chmod>
-        </additional_files_needed-->
-        <additional_files_needed>
-               <item>https://packages.pfsense.org/packages/config/havp/havp_avset.xml</item>
-               <prefix>/usr/local/pkg/</prefix>
-               <chmod>0755</chmod>
-        </additional_files_needed>
-        <additional_files_needed>
-               <item>https://packages.pfsense.org/packages/config/havp/antivirus.php</item>
-               <prefix>/usr/local/www/</prefix>
-               <chmod>0755</chmod>
-        </additional_files_needed>
-        <tabs>
-                <tab>
-                        <text>General page</text>
-                        <url>/antivirus.php</url>
-                </tab>
-                <tab>
-                        <text>HTTP proxy</text>
-                        <url>/pkg_edit.php?xml=havp.xml&amp;id=0</url>
-                        <active/>
-                </tab>
-                <!--tab>
-                        <text>Files Scanner</text>
-                        <url>/pkg_edit.php?xml=havp_fscan.xml&amp;id=0</url>
-                </tab-->
-                <tab>
-                        <text>Settings</text>
-                        <url>/pkg_edit.php?xml=havp_avset.xml&amp;id=0</url>
-                </tab>
-                <tab>
-                        <text>HAVP Log</text>
-                        <url>/havp_log.php</url>
-                </tab>
-        </tabs>
-        <fields>
-                <field>
-                        <fielddescr>Enable</fielddescr>
-                        <fieldname>enable</fieldname>
-                        <description>Check this for enable proxy.</description>
-                        <type>checkbox</type>
-                </field>
-                <field>
-                        <fielddescr>ClamAV mode</fielddescr>
-                        <fieldname>useclamd</fieldname>
-                        <description>
-                            Select ClamAV running mode:&lt;br&gt;
-                            &lt;b&gt;Daemon&lt;/b&gt; - HAVP will use ClamAV as socket scanner daemon. Default option.&lt;br&gt;
-                            &lt;b&gt;Library&lt;/b&gt; - HAVP will use ClamAV as loaded library scanner. Note: this mode needs much more memory.&lt;br&gt;
-                        </description>
-                        <type>select</type>
-                        <default_value>true</default_value>
-                        <options>
-                                 <option><value>true</value><name>Daemon</name></option>
-                                 <option><value>false</value><name>Library</name></option>
-                        </options>
-                </field>
-                <field>
-                        <fielddescr>Proxy mode</fielddescr>
-                        <fieldname>proxymode</fieldname>
-                        <description>
-				Select interface mode: &lt;br&gt;
-				&lt;b&gt; standard &lt;/b&gt; - client(s) bind to the 'proxy port' on selected interface(s); &lt;br&gt;
-				&lt;b&gt; parent for squid &lt;/b&gt; - configure HAVP as parent for Squid proxy;&lt;br&gt;
-				&lt;b&gt; transparent &lt;/b&gt; - all HTTP requests on interface(s) will be directed to the HAVP proxy server without any client configuration necessary (works as parent for squid with transparent Squid proxy); &lt;br&gt;
-				&lt;b&gt; internal &lt;/b&gt; - HAVP will listen on the loopback (127.0.0.1) on configured 'proxy port.' Use you own traffic forwarding rules.&lt;br&gt;
+		<description>Antivirus HTTP Proxy Service</description>
+	</service>
+	<additional_files_needed>
+		<item>https://packages.pfsense.org/packages/config/havp/havp.inc</item>
+		<prefix>/usr/local/pkg/</prefix>
+	</additional_files_needed>
+	<!--
+	<additional_files_needed>
+		<item>https://packages.pfsense.org/packages/config/havp/havp_fscan.xml</item>
+		<prefix>/usr/local/pkg/</prefix>
+	</additional_files_needed>
+	-->
+	<additional_files_needed>
+		<item>https://packages.pfsense.org/packages/config/havp/havp_avset.xml</item>
+		<prefix>/usr/local/pkg/</prefix>
+	</additional_files_needed>
+	<additional_files_needed>
+		<item>https://packages.pfsense.org/packages/config/havp/antivirus.php</item>
+		<prefix>/usr/local/www/</prefix>
+	</additional_files_needed>
+	<tabs>
+		<tab>
+			<text>General Page</text>
+			<url>/antivirus.php</url>
+		</tab>
+		<tab>
+			<text>HTTP Proxy</text>
+			<url>/pkg_edit.php?xml=havp.xml</url>
+			<active/>
+		</tab>
+		<!--
+		<tab>
+			<text>Files Scanner</text>
+			<url>/pkg_edit.php?xml=havp_fscan.xml</url>
+		</tab>
+		-->
+		<tab>
+			<text>Settings</text>
+			<url>/pkg_edit.php?xml=havp_avset.xml</url>
+		</tab>
+		<tab>
+			<text>HAVP Log</text>
+			<url>/havp_log.php</url>
+		</tab>
+	</tabs>
+	<fields>
+		<field>
+			<fielddescr>Enable</fielddescr>
+			<fieldname>enable</fieldname>
+			<description>Check this to enable AV proxy.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>ClamAV Mode</fielddescr>
+			<fieldname>useclamd</fieldname>
+			<description>
+				<![CDATA[
+				Select ClamAV running mode:<br />
+				<strong>Daemon</strong> - HAVP will use ClamAV as socket scanner daemon. (Default option.)<br />
+				<strong>Library</strong> - HAVP will use ClamAV as loaded library scanner. Note: this mode needs <strong>much more</strong> memory.<br />
+				]]>
 			</description>
-                        <type>select</type>
-                        <default_value>standard</default_value>
-                        <options>
-                                 <option><value>standard</value><name>Standard</name></option>
-                                 <option><value>squid</value><name>Parent for Squid</name></option>
-                                 <option><value>transparent</value><name>Transparent</name></option>
-                                 <option><value>internal</value><name>Internal</name></option>
-                        </options>
-                </field>
-                <field>
-                        <fielddescr>Proxy interface(s)</fielddescr>
-                        <fieldname>proxyinterface</fieldname>
-                        <description>The interface(s) for client connections to the proxy. Use 'Ctrl' + L. Click for multiple selection.</description>
-                        <type>interfaces_selection</type>
-                        <required/>
-                        <multiple/>
-                        <default_value>lan</default_value>
-                </field>
-                <field>
-                        <fielddescr>Proxy port</fielddescr>
-                        <fieldname>proxyport</fieldname>
-                        <description>
-				This is the port the proxy server will listen on (for example: 8080). This port must be different from Squid proxy.
-                        </description>
-                        <type>input</type>
-                        <size>10</size>
-                        <required/>
-                        <default_value>3125</default_value>
-                </field>
-                <field>
-                        <fielddescr>Parent proxy</fielddescr>
-                        <fieldname>parentproxy</fieldname>
-                        <description>
-                                Enter the parent (upstream) proxy settings as PROXY:PORT format or leave empty.
-                        </description>
-                        <type>input</type>
-                        <size>90</size>
-                </field>
-                <field>
-                        <fielddescr>Enable X-Forwarded-For</fielddescr>
-                        <fieldname>enablexforwardedfor</fieldname>
-                        <description>
- 				If client sent this header, FORWARDED_IP setting defines the value, then it is passed on. You might want to keep this disabled for security reasons.
-				&lt;br&gt;Enable this if you use your own parent proxy after HAVP, so it will see the original client IP.
-				&lt;br&gt;Disabling this also disables Via: header generation.
-                        </description>
-                        <type>checkbox</type>
-                </field>
-                <field>
-                        <fielddescr>Enable Forwarded IP</fielddescr>
-                        <fieldname>enableforwardedip</fieldname>
-                        <description>
-				If HAVP is used as a parent proxy for some other proxy, this allows writing the real user's IP to log, instead of the proxy IP.
-                        </description>
-                        <type>checkbox</type>
-                </field>
-                <field>
-                        <fielddescr>Language</fielddescr>
-                        <fieldname>lang</fieldname>
-                        <description>Select the language in which the proxy server will display error messages to users.</description>
-                        <type>select</type>
-                        <value>en</value>
-                        <options>
-                                 <option><value>br</value><name>Brazil</name></option>
-                                 <option><value>de</value><name>Germany</name></option>
-                                 <option><value>en</value><name>English</name></option>
-                                 <option><value>es</value><name>Spain</name></option>
-                                 <option><value>fr</value><name>French</name></option>
-                                 <option><value>it</value><name>Italian</name></option>
-                                 <option><value>nf</value><name>Norfolk Island</name></option>
-                                 <option><value>pl</value><name>Poland</name></option>
-                                 <option><value>ru</value><name>Russian</name></option>
-                        </options>
-                </field>
-                <field>
-                        <fielddescr>Max download size, Bytes</fielddescr>
-                        <fieldname>maxdownloadsize</fieldname>
-                        <description>Enter value (in Bytes) or leave empty. Downloads larger than 'Max download size' will be blocked if not whitelisted.</description>
-                        <type>input</type>
-                        <size>10</size>
-                        <default_value></default_value>
-                </field>
-                <field>
-                        <fielddescr>HTTP Range requests</fielddescr>
-                        <fieldname>range</fieldname>
-                        <description>
-                        	Set this for allow HTTP Range requests, and broken downloads can be resumed.
-                        	Allowing HTTP Range is a security risk, because partial HTTP requests may not be properly scanned.
-                        	Whitelisted sites are allowed to use Range in any case.
-                        </description>
-                        <type>checkbox</type>
-                </field>
-                <field>
-                        <fielddescr>Whitelist</fielddescr>
-                        <fieldname>whitelist</fieldname>
-                        <description>
-                            Enter each destination URL on a new line that will be accessable to the users without scanning.
-                            Use '*' symbol for mask. Example: *.github.com/*, *sourceforge.net/*clamav-*, */*.xml, */*.inc
-                        </description>
-                        <type>textarea</type>
-                        <cols>60</cols>
-                        <rows>5</rows>
-                        <encoding>base64</encoding>
-                </field>
-                <field>
-                        <fielddescr>Blacklist</fielddescr>
-                        <fieldname>blacklist</fieldname>
-                        <description>Enter each destination domain on a new line that will be accessable to the users that are allowed to use the proxy.</description>
-                        <type>textarea</type>
-                        <cols>60</cols>
-                        <rows>5</rows>
-                        <encoding>base64</encoding>
-                </field>
-                <field>
-                        <fielddescr>Block file if error scanning</fielddescr>
-                        <fieldname>failscanerror</fieldname>
-                        <description>If set, the proxy will block the files on which an error scanning.</description>
-                        <type>checkbox</type>
-                </field>
-                <field>
-                        <fielddescr>Enable RAM Disk</fielddescr>
-                        <fieldname>enableramdisk</fieldname>
-                        <description>
-				This option allow use RAM disk for HAVP temp files for more quick traffic scan.
-				RAM disk size depends on 'ScanMax' file size and available memory.
-				This option can be ignored on systems with low memory.
-				( RAM disk size calculated as [1/4 available system memory] > [Scan max file size] * 100 )
-                        </description>
-                        <type>checkbox</type>
-                </field>
-                <field>
-                        <fielddescr>Scan max file size</fielddescr>
-                        <fieldname>scanmaxsize</fieldname>
-                        <description>
-                                Select this value for limit maximum file size or leave '---(5M)'.
-                                Files larger than this limit won't be scanned.
-                                Small values increace scan speed and maximum new connections per second and allow RAM disk use.
-                                &lt;br&gt;
-                                NOTE: Setting limit is a security risk, because some archives like
-                                ZIP need all the data to be scanned properly! Use this only if you
-                                can't afford temporary space for big files.
-                        </description>
-                        <type>select</type>
-                        <value>0</value>
-                        <options>
-                                 <option><value> 5000</value><name>--- (5M)</name></option>
-                                 <option><value>    1</value><name>     1 K</name></option>
-                                 <option><value>    2</value><name>     2 K</name></option>
-                                 <option><value>    3</value><name>     3 K</name></option>
-                                 <option><value>    5</value><name>     5 K</name></option>
-                                 <option><value>    7</value><name>     7 K</name></option>
-                                 <option><value>   10</value><name>    10 K</name></option>
-                                 <option><value>   20</value><name>    20 K</name></option>
-                                 <option><value>   30</value><name>    30 K</name></option>
-                                 <option><value>   50</value><name>    50 K</name></option>
-                                 <option><value>   70</value><name>    70 K</name></option>
-                                 <option><value>  100</value><name>   100 K</name></option>
-                                 <option><value>  200</value><name>   200 K</name></option>
-                                 <option><value>  300</value><name>   300 K</name></option>
-                                 <option><value>  500</value><name>   500 K</name></option>
-                                 <option><value>  700</value><name>   700 K</name></option>
-                                 <option><value> 1000</value><name>  1000 K</name></option>
-                                 <option><value> 1500</value><name>  1500 K</name></option>
-                                 <option><value> 2000</value><name>  2000 K</name></option>
-                                 <option><value> 2500</value><name>  2500 K</name></option>
-                                 <option><value> 3000</value><name>  3000 K</name></option>
-                                 <option><value> 3500</value><name>  3500 K</name></option>
-                                 <option><value> 4000</value><name>  4000 K</name></option>
-                                 <option><value> 4500</value><name>  4500 K</name></option>
-                                 <option><value> 5000</value><name>  5000 K</name></option>
-                                 <option><value> 5500</value><name>  5500 K</name></option>
-                                 <option><value> 6000</value><name>  6000 K</name></option>
-                                 <option><value> 7000</value><name>  7000 K</name></option>
-                                 <option><value> 8000</value><name>  8000 K</name></option>
-                                 <option><value> 9000</value><name>  9000 K</name></option>
-                                 <option><value>10000</value><name>10 000 K</name></option>
-                        </options>
-                </field>
-                <field>
-                        <fielddescr>Scan images</fielddescr>
-                        <fieldname>scanimg</fieldname>
-                        <description>
-                            Check this for scan image files. 
-                            This option allows you to increase reliability, but also slows down the scanning process.
-                        </description>
-                        <type>checkbox</type>
-                </field>
-                <field>
-                        <fielddescr>Scan media stream</fielddescr>
-                        <fieldname>scanstream</fieldname>
-                        <description>Check this for scan media (audio/video) stream. Use this for additional scan exploits for players.</description>
-                        <type>checkbox</type>
-                </field>
-                <field>
-                        <fielddescr>Scan Broken Executables</fielddescr>
-                        <fieldname>scanbrokenexe</fieldname>
-                        <description>Check this to enable the Heuristic Broken Executable scan.</description>
-                        <type>checkbox</type>
-						<default_value>on</default_value>
-                </field>				
-                <field>
-                        <fielddescr>HAVP Log</fielddescr>
-                        <fieldname>log</fieldname>
-                        <description>Check this for enable HAVP log.</description>
-                        <type>checkbox</type>
-                        <enablefields>syslog</enablefields>
-                </field>
-                <field>
-                        <fielddescr>HAVP Syslog</fielddescr>
-                        <fieldname>syslog</fieldname>
-                        <description>Check this for enable HAVP Syslog.</description>
-                        <type>checkbox</type>
-                </field>
-        </fields>
-        <custom_php_command_before_form>
-            havp_before_form($pkg);
-        </custom_php_command_before_form>
-        <custom_php_validation_command>
-            havp_validate_settings($_POST, $input_errors);
-        </custom_php_validation_command>
-        <custom_php_resync_config_command>
-            havp_resync();
-        </custom_php_resync_config_command>
-        <custom_php_install_command>
+			<type>select</type>
+			<default_value>true</default_value>
+			<options>
+				 <option><value>true</value><name>Daemon</name></option>
+				 <option><value>false</value><name>Library</name></option>
+			</options>
+		</field>
+		<field>
+			<fielddescr>Proxy Mode</fielddescr>
+			<fieldname>proxymode</fieldname>
+			<description>
+				<![CDATA[
+				Select proxy interface mode:<br />
+				<strong>Standard</strong> - clients bind to the 'proxy port' on selected interface(s)<br />
+				<strong>Parent for Squid</strong> - configure HAVP as parent for Squid proxy<br />
+				<strong>Transparent</strong> - all HTTP requests on interface(s) will be directed to the HAVP proxy server without any client configuration necessary. (Works as parent for Squid with transparent Squid proxy.)<br />
+				<strong>Internal</strong> - HAVP will listen on the loopback (127.0.0.1) on configured 'Proxy Port.' Use your own firewall forwarding rules.<br />
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>standard</default_value>
+			<options>
+				 <option><value>standard</value><name>Standard</name></option>
+				 <option><value>squid</value><name>Parent for Squid</name></option>
+				 <option><value>transparent</value><name>Transparent</name></option>
+				 <option><value>internal</value><name>Internal</name></option>
+			</options>
+		</field>
+		<field>
+			<fielddescr>Proxy Interface(s)</fielddescr>
+			<fieldname>proxyinterface</fieldname>
+			<description>The interface(s) for client connections to the proxy. Use 'Ctrl' + left click for multiple selection.</description>
+			<type>interfaces_selection</type>
+			<required/>
+			<multiple/>
+			<default_value>lan</default_value>
+		</field>
+		<field>
+			<fielddescr>Proxy Port</fielddescr>
+			<fieldname>proxyport</fieldname>
+			<description>
+				<![CDATA[
+				This is the port that HAVP proxy server will listen on. (Example: 8080)<br />
+				<strong>Note: This port must be different from Squid proxy.</strong>
+				]]>
+			</description>
+			<type>input</type>
+			<size>10</size>
+			<required/>
+			<default_value>3125</default_value>
+		</field>
+		<field>
+			<fielddescr>Parent Proxy</fielddescr>
+			<fieldname>parentproxy</fieldname>
+			<description>Enter the parent (upstream) proxy settings in PROXY:PORT format or leave empty.</description>
+			<type>input</type>
+			<size>90</size>
+		</field>
+		<field>
+			<fielddescr>Enable X-Forwarded-For</fielddescr>
+			<fieldname>enablexforwardedfor</fieldname>
+			<description>
+				<![CDATA[
+ 				If client sends this header, FORWARDED_IP setting defines the value, then it is passed on. You might want to keep this disabled for security reasons.<br />
+				Enable this if you use your own parent proxy after HAVP, so it will see the original client's IP.<br />
+				Note: Disabling this also disables <em>Via:</em> header generation.<br />
+				]]>
+			</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Enable Forwarded IP</fielddescr>
+			<fieldname>enableforwardedip</fieldname>
+			<description>If HAVP is used as a parent proxy for some other proxy, this allows writing the real user's IP to log, instead of the proxy IP.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Language</fielddescr>
+			<fieldname>lang</fieldname>
+			<description>Select the language in which the HAVP proxy server will display error messages to users.</description>
+			<type>select</type>
+			<value>en</value>
+			<options>
+				 <option><value>br</value><name>Brazilian Portuguese</name></option>
+				 <option><value>de</value><name>German</name></option>
+				 <option><value>en</value><name>English</name></option>
+				 <option><value>es</value><name>Spanish</name></option>
+				 <option><value>fr</value><name>French</name></option>
+				 <option><value>it</value><name>Italian</name></option>
+				 <option><value>nf</value><name>Norf'k</name></option>
+				 <option><value>pl</value><name>Polish</name></option>
+				 <option><value>ru</value><name>Russian</name></option>
+			</options>
+		</field>
+		<field>
+			<fielddescr>Max Download Size</fielddescr>
+			<fieldname>maxdownloadsize</fieldname>
+			<description>
+				<![CDATA[
+				Enter value <strong>(in bytes)</strong> or leave empty. Downloads larger than 'Max Download Size' will be blocked if not whitelisted.
+				]]>
+			</description>
+			<type>input</type>
+			<size>10</size>
+			<default_value></default_value>
+		</field>
+		<field>
+			<fielddescr>HTTP Range Requests</fielddescr>
+			<fieldname>range</fieldname>
+			<description>
+				<![CDATA[
+				Set this to allow HTTP Range requests, so that broken downloads can be resumed.<br />
+				Allowing HTTP Range is a security risk, because partial HTTP requests may not be properly scanned.<br />
+				Note: Whitelisted sites are allowed to use HTTP Range in any case, regardless of this setting.
+				]]>
+			</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Whitelist</fielddescr>
+			<fieldname>whitelist</fieldname>
+			<description>
+				<![CDATA[
+				Enter each destination URL on a <strong>separate line</strong>. The URLs will be accessible to users without AV scanning.<br />
+				Use '*' symbol as wildcard mask. URL examples: *.github.com/*, *sourceforge.net/*clamav-*, */*.xml, */*.inc
+				]]>
+			</description>
+			<type>textarea</type>
+			<cols>60</cols>
+			<rows>5</rows>
+			<encoding>base64</encoding>
+		</field>
+		<field>
+			<fielddescr>Blacklist</fielddescr>
+			<fieldname>blacklist</fieldname>
+			<description>
+				<![CDATA[
+				Enter each destination URL on a <strong>separate line</strong>, using the same syntax as 'Whitelist'.<br />
+				<strong>Access to these URLs will be blocked for HAVP proxy users.</strong>
+				]]>
+			</description>
+			<type>textarea</type>
+			<cols>60</cols>
+			<rows>5</rows>
+			<encoding>base64</encoding>
+		</field>
+		<field>
+			<fielddescr>Block File on Scanning Error</fielddescr>
+			<fieldname>failscanerror</fieldname>
+			<description>If enabled, the proxy will block the files if an error occurs while scanning.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Enable RAM Disk</fielddescr>
+			<fieldname>enableramdisk</fieldname>
+			<description>
+				<![CDATA[
+				This option allows to use RAM disk for HAVP temporary files for faster traffic scan.<br />
+				RAM disk size depends on 'Scan Max File Size' and available memory. <strong>This option should be ignored on systems with low memory.</strong><br />
+				Note: RAM disk size is calculated as [1/4 available system memory] > [Scan max file size] * 100 ).
+				]]>
+			</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Scan Max File Size</fielddescr>
+			<fieldname>scanmaxsize</fieldname>
+			<description>
+				<![CDATA[
+				Select the value to limit maximum scanned file size or leave at default (5 MB). Files larger than this limit will not be scanned.<br />
+				Small values increase scan speed and maximum new connections per second and allow RAM disk use.<br />
+				NOTE: Setting a low limit is a security risk, because some archives like ZIP need all the data to be scanned properly! Use this only if you
+				can't afford temporary space for large files.
+				]]>
+			</description>
+			<type>select</type>
+			<value>0</value>
+			<options>
+				 <option><value> 5000</value><name>--- (5M)</name></option>
+				 <option><value>    1</value><name>     1 K</name></option>
+				 <option><value>    2</value><name>     2 K</name></option>
+				 <option><value>    3</value><name>     3 K</name></option>
+				 <option><value>    5</value><name>     5 K</name></option>
+				 <option><value>    7</value><name>     7 K</name></option>
+				 <option><value>   10</value><name>    10 K</name></option>
+				 <option><value>   20</value><name>    20 K</name></option>
+				 <option><value>   30</value><name>    30 K</name></option>
+				 <option><value>   50</value><name>    50 K</name></option>
+				 <option><value>   70</value><name>    70 K</name></option>
+				 <option><value>  100</value><name>   100 K</name></option>
+				 <option><value>  200</value><name>   200 K</name></option>
+				 <option><value>  300</value><name>   300 K</name></option>
+				 <option><value>  500</value><name>   500 K</name></option>
+				 <option><value>  700</value><name>   700 K</name></option>
+				 <option><value> 1000</value><name>  1000 K</name></option>
+				 <option><value> 1500</value><name>  1500 K</name></option>
+				 <option><value> 2000</value><name>  2000 K</name></option>
+				 <option><value> 2500</value><name>  2500 K</name></option>
+				 <option><value> 3000</value><name>  3000 K</name></option>
+				 <option><value> 3500</value><name>  3500 K</name></option>
+				 <option><value> 4000</value><name>  4000 K</name></option>
+				 <option><value> 4500</value><name>  4500 K</name></option>
+				 <option><value> 5000</value><name>  5000 K</name></option>
+				 <option><value> 5500</value><name>  5500 K</name></option>
+				 <option><value> 6000</value><name>  6000 K</name></option>
+				 <option><value> 7000</value><name>  7000 K</name></option>
+				 <option><value> 8000</value><name>  8000 K</name></option>
+				 <option><value> 9000</value><name>  9000 K</name></option>
+				 <option><value>10000</value><name>10 000 K</name></option>
+			</options>
+		</field>
+		<field>
+			<fielddescr>Scan Images</fielddescr>
+			<fieldname>scanimg</fieldname>
+			<description>Check this option to scan image files. This option allows you to increase reliability, but also slows down the scanning process.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Scan Media Streams</fielddescr>
+			<fieldname>scanstream</fieldname>
+			<description>Check this option to scan media (audio/video) streams.</description>
+			<type>checkbox</type>
+		</field>
+		<field>
+			<fielddescr>Scan Broken Executables</fielddescr>
+			<fieldname>scanbrokenexe</fieldname>
+			<description>Check this to enable the Heuristic Broken Executable Scan.</description>
+			<type>checkbox</type>
+			<default_value>on</default_value>
+		</field>
+		<field>
+			<fielddescr>HAVP Log</fielddescr>
+			<fieldname>log</fieldname>
+			<description>Check this to enable HAVP logging.</description>
+			<type>checkbox</type>
+			<enablefields>syslog</enablefields>
+		</field>
+		<field>
+			<fielddescr>HAVP Syslog</fielddescr>
+			<fieldname>syslog</fieldname>
+			<description>Check this to enable HAVP logging to syslog.</description>
+			<type>checkbox</type>
+		</field>
+	</fields>
+	<custom_php_validation_command>
+		havp_validate_settings($_POST, $input_errors);
+	</custom_php_validation_command>
+	<custom_php_resync_config_command>
+		havp_resync();
+	</custom_php_resync_config_command>
+	<custom_php_install_command>
 		havp_install();
-        </custom_php_install_command>
-        <custom_php_deinstall_command>
+	</custom_php_install_command>
+	<custom_php_deinstall_command>
 		havp_deinstall();
-        </custom_php_deinstall_command>
+	</custom_php_deinstall_command>
 </packagegui>

--- a/config/havp/havp_avset.xml
+++ b/config/havp/havp_avset.xml
@@ -1,111 +1,154 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-        <name>havpavset</name>
-        <title>Antivirus: Settings</title>
-        <category>Status</category>
-        <version>none</version>
-        <include_file>/usr/local/pkg/havp.inc</include_file>
-        <tabs>
-                <tab>
-                        <text>General page</text>
-                        <url>/antivirus.php</url>
-                </tab>
-                <tab>
-                        <text>HTTP Proxy</text>
-                        <url>/pkg_edit.php?xml=havp.xml&amp;id=0</url>
-                </tab>
-                <!--tab>
-                        <text>Files Scanner</text>
-                        <url>/pkg_edit.php?xml=havp_fscan.xml&amp;id=0</url>
-                </tab-->
-                <tab>
-                        <text>Settings</text>
-                        <url>/pkg_edit.php?xml=havp_avset.xml&amp;id=0</url>
-                        <active/>
-                </tab>
-                <tab>
-                        <text>HAVP Log</text>
-                        <url>/havp_log.php</url>
-                </tab>
-        </tabs>
-        <fields>
-                <field>
-                        <fielddescr>AV base update</fielddescr>
-                        <fieldname>havpavupdate</fieldname>
-                        <description>
-                                &lt;input name='submit' type='submit' value='Update_AV'&gt;
-                                Press button for update AV database now.
-                        </description>
-                        <type>select</type>
-                        <value>hv_none</value>
-                        <options>
-                                <option><name>none          </name><value>0</value></option>
-                                <option><name>every 1  hours</name><value>1</value></option>
-                                <option><name>every 2  hours</name><value>2</value></option>
-                                <option><name>every 3  hours</name><value>3</value></option>
-                                <option><name>every 4  hours</name><value>4</value></option>
-                                <option><name>every 6  hours</name><value>5</value></option>
-                                <option><name>every 8  hours</name><value>6</value></option>
-                                <option><name>every 12 hours</name><value>7</value></option>
-                                <option><name>every 24 hours</name><value>8</value></option>
-                        </options>
-                </field>
-                <field>
-                        <fielddescr>Regional AV database update mirror</fielddescr>
-                        <fieldname>dbregion</fieldname>
-                        <description>Select regional database mirror.</description>
-                        <type>select</type>
-                        <value></value>
-                        <options>
-                                 <option><value></value><name>-----</name></option>
-                                 <option><value>au</value><name>Australia</name></option>
-                                 <option><value>eu</value><name>Europe</name></option>
-                                 <option><value>ca</value><name>Canada</name></option>
-                                 <option><value>cn</value><name>China</name></option>
-                                 <option><value>id</value><name>Indonesia</name></option>
-                                 <option><value>jp</value><name>Japan</name></option>
-                                 <option><value>kr</value><name>Korea</name></option>
-                                 <option><value>ml</value><name>Malaysia</name></option>
-                                 <option><value>ru</value><name>Russian</name></option>
-                                 <option><value>sa</value><name>South africa</name></option>
-                                 <option><value>tw</value><name>Taiwan</name></option>
-                                 <option><value>uk</value><name>United Kingdom</name></option>
-                                 <option><value>us</value><name>United States</name></option>
-                        </options>
-                </field>
-                <field>
-                        <fielddescr>Optional AV database update servers</fielddescr>
-                        <fieldname>avupdateserver</fieldname>
-                        <description>Enter here space separated AV update servers, or leave empty.</description>
-                        <type>textarea</type>
-                        <cols>60</cols>
-                        <rows>5</rows>
-                </field>
-                <field>
-                        <fielddescr>Log</fielddescr>
-                        <fieldname>avsetlog</fieldname>
-                        <description>Check this for enable log.</description>
-                        <type>checkbox</type>
-                        <enablefields>avsetsyslog</enablefields>
-                </field>
-                <field>
-                        <fielddescr>SysLog</fielddescr>
-                        <fieldname>avsetsyslog</fieldname>
-                        <description>Check this for enable SysLog.</description>
-                        <type>checkbox</type>
-                </field>
-        </fields>
-        <custom_php_command_before_form>
-		havp_before_form($pkg);
-        </custom_php_command_before_form>
-        <custom_php_validation_command>
+	<copyright>
+<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
+/*
+	havp_avset.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2009-2010 Sergey Dvoriancev <dv_serg@mail.ru>
+	Copyright (C) 2014 Andrew Nikitin <andrey.b.nikitin@gmail.com>.
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
+	<name>havpavset</name>
+	<title>Antivirus: Settings</title>
+	<category>Status</category>
+	<include_file>/usr/local/pkg/havp.inc</include_file>
+	<tabs>
+		<tab>
+			<text>General Page</text>
+			<url>/antivirus.php</url>
+		</tab>
+		<tab>
+			<text>HTTP Proxy</text>
+			<url>/pkg_edit.php?xml=havp.xml</url>
+		</tab>
+		<!--
+		<tab>
+			<text>Files Scanner</text>
+			<url>/pkg_edit.php?xml=havp_fscan.xml</url>
+		</tab>
+		-->
+		<tab>
+			<text>Settings</text>
+			<url>/pkg_edit.php?xml=havp_avset.xml</url>
+			<active/>
+		</tab>
+		<tab>
+			<text>HAVP Log</text>
+			<url>/havp_log.php</url>
+			</tab>
+		</tabs>
+	<fields>
+		<field>
+			<fielddescr>ClamAV Database Update</fielddescr>
+			<fieldname>havpavupdate</fieldname>
+			<description>
+				<![CDATA[
+				<input name='submit' type='submit' value='Update_AV' />
+				Press button to update AV databases now.
+				]]>
+			</description>
+			<type>select</type>
+			<value>hv_none</value>
+			<options>
+				<option><name>none	  </name><value>0</value></option>
+				<option><name>every 1  hours</name><value>1</value></option>
+				<option><name>every 2  hours</name><value>2</value></option>
+				<option><name>every 3  hours</name><value>3</value></option>
+				<option><name>every 4  hours</name><value>4</value></option>
+				<option><name>every 6  hours</name><value>5</value></option>
+				<option><name>every 8  hours</name><value>6</value></option>
+				<option><name>every 12 hours</name><value>7</value></option>
+				<option><name>every 24 hours</name><value>8</value></option>
+			</options>
+		</field>
+		<field>
+			<fielddescr>Regional AV Database Update Mirror</fielddescr>
+			<fieldname>dbregion</fieldname>
+			<description>Select regional database mirror.</description>
+			<type>select</type>
+			<value></value>
+			<options>
+				<option><value></value><name>-----</name></option>
+				<option><value>au</value><name>Australia</name></option>
+				<option><value>eu</value><name>Europe</name></option>
+				<option><value>ca</value><name>Canada</name></option>
+				<option><value>cn</value><name>China</name></option>
+				<option><value>id</value><name>Indonesia</name></option>
+				<option><value>jp</value><name>Japan</name></option>
+				<option><value>kr</value><name>Korea</name></option>
+				<option><value>ml</value><name>Malaysia</name></option>
+				<option><value>ru</value><name>Russian</name></option>
+				<option><value>sa</value><name>South Africa</name></option>
+				<option><value>tw</value><name>Taiwan</name></option>
+				<option><value>uk</value><name>United Kingdom</name></option>
+				<option><value>us</value><name>United States</name></option>
+			</options>
+		</field>
+		<field>
+			<fielddescr>Optional AV Database Update Servers</fielddescr>
+			<fieldname>avupdateserver</fieldname>
+			<description>
+				<![CDATA[
+				Enter space-separated ClamAV update servers here, or leave empty.<br />
+				Note: For official update mirrors, use db.XY.clamav.net format. (Replace XY with your <a href="http://www.iana.org/domains/root/db">country code</a>.)
+				]]>
+			</description>
+			<type>textarea</type>
+			<cols>60</cols>
+			<rows>5</rows>
+		</field>
+		<field>
+			<fielddescr>Log</fielddescr>
+			<fieldname>avsetlog</fieldname>
+			<description>Check this to enable AV logging.</description>
+			<type>checkbox</type>
+			<enablefields>avsetsyslog</enablefields>
+		</field>
+		<field>
+			<fielddescr>SysLog</fielddescr>
+			<fieldname>avsetsyslog</fieldname>
+			<description>Check this to enable AV logging to syslog.</description>
+			<type>checkbox</type>
+		</field>
+	</fields>
+	<custom_php_validation_command>
 		havp_validate_settings($_POST, $input_errors);
-        </custom_php_validation_command>
-        <custom_php_resync_config_command>
+	</custom_php_validation_command>
+	<custom_php_resync_config_command>
 		havp_avset_resync();
-        </custom_php_resync_config_command>
-        <custom_php_install_command>
-        </custom_php_install_command>
-        <custom_php_deinstall_command>
-        </custom_php_deinstall_command>
+	</custom_php_resync_config_command>
 </packagegui>

--- a/config/havp/havp_fscan.xml
+++ b/config/havp/havp_fscan.xml
@@ -1,50 +1,90 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-        <name>havpfscan</name>
-        <title>Antivirus: Files scanner</title>
-        <category>Status</category>
-        <version>none</version>
-        <include_file>/usr/local/pkg/havp.inc</include_file>
-        <tabs>
-                <tab>
-                        <text>General page</text>
-                        <url>/antivirus.php</url>
-                </tab>
-                <tab>
-                        <text>HTTP Proxy</text>
-                        <url>/pkg_edit.php?xml=havp.xml&amp;id=0</url>
-                </tab>
-                <!--tab>
-                        <text>Files Scanner</text>
-                        <url>/pkg_edit.php?xml=havp_fscan.xml&amp;id=0</url>
-                        <active/>
-                </tab-->
-                <tab>
-                        <text>Settings</text>
-                        <url>/pkg_edit.php?xml=havp_avset.xml&amp;id=0</url>
-                </tab>
-        </tabs>
-        <fields>
-                <field>
-                        <fielddescr>Scan file path</fielddescr>
-                        <fieldname>scanfilepath</fieldname>
-                        <description>
-				            Enter file path or catalog for scanning. &lt;br&gt;
-                        </description>
-                        <type>input</type>
-                        <size>90</size>
-                </field>
-        </fields>
-        <custom_php_command_before_form>
-            havp_fscan_before_form($pkg);
-        </custom_php_command_before_form>
-        <custom_php_validation_command>
-            havp_validate_settings($_POST, $input_errors);
-        </custom_php_validation_command>
-        <custom_php_resync_config_command>
-        </custom_php_resync_config_command>
-        <custom_php_install_command>
-        </custom_php_install_command>
-        <custom_php_deinstall_command>
-        </custom_php_deinstall_command>
+	<copyright>
+<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
+/*
+	havp_fscan.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2009-2010 Sergey Dvoriancev <dv_serg@mail.ru>
+	Copyright (C) 2014 Andrew Nikitin <andrey.b.nikitin@gmail.com>.
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
+/*
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
+	<name>havpfscan</name>
+	<title>Antivirus: Files Scanner</title>
+	<category>Status</category>
+	<version>none</version>
+	<include_file>/usr/local/pkg/havp.inc</include_file>
+	<tabs>
+		<tab>
+			<text>General Page</text>
+			<url>/antivirus.php</url>
+		</tab>
+		<tab>
+			<text>HTTP Proxy</text>
+			<url>/pkg_edit.php?xml=havp.xml</url>
+		</tab>
+		<!--
+		<tab>
+			<text>Files Scanner</text>
+			<url>/pkg_edit.php?xml=havp_fscan.xml</url>
+			<active/>
+		</tab>
+		-->
+		<tab>
+			<text>Settings</text>
+			<url>/pkg_edit.php?xml=havp_avset.xml</url>
+		</tab>
+	</tabs>
+	<fields>
+		<field>
+			<fielddescr>Scan File Path</fielddescr>
+			<fieldname>scanfilepath</fieldname>
+			<description>
+				<![CDATA[
+				Enter file path or catalog for scanning.<br />
+				]]>
+			</description>
+			<type>input</type>
+			<size>90</size>
+		</field>
+	</fields>
+	<custom_php_command_before_form>
+		havp_fscan_before_form($pkg);
+	</custom_php_command_before_form>
+	<custom_php_validation_command>
+		havp_validate_settings($_POST, $input_errors);
+	</custom_php_validation_command>
 </packagegui>

--- a/config/havp/havp_log.php
+++ b/config/havp/havp_log.php
@@ -1,10 +1,9 @@
 <?php
-/* $Id$ */
 /*
 	havp_log.php
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2014 Andrew Nikitin <andrey.b.nikitin@gmail.com>.
-	Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
-	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -28,19 +27,14 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require("guiconfig.inc");
+require_once("/usr/local/pkg/havp.inc");
 
-if (file_exists("/usr/local/pkg/havp.inc"))
-   require_once("/usr/local/pkg/havp.inc");
-else echo "No havp.inc found";
+$nentries = $config['syslog']['nentries'] ?: "50";
 
-$nentries = $config['syslog']['nentries'];
-if (!$nentries)
-	$nentries = 50;
-
-if ($_POST['clear']) 
+if ($_POST['clear']) {
 	file_put_contents(HVDEF_HAVP_ERRORLOG, '');
+}
 
 function dump_havp_errorlog($logfile, $tail) {
 	global $g, $config;
@@ -48,18 +42,18 @@ function dump_havp_errorlog($logfile, $tail) {
 	$logarr = "";
 	$grepline = "  ";
 	if (is_dir($logfile)) {
-		$logarr = array("File $logfile is a directory.");
-	} elseif(file_exists($logfile) && filesize($logfile) == 0) {
-		$logarr = array(" ... Log file is empty.");
+		$logarr = array("$logfile is a directory.");
+	} elseif (file_exists($logfile) && filesize($logfile) == 0) {
+		$logarr = array("Log file is empty.");
 	} else {
-		exec("cat " . escapeshellarg($logfile) . "{$grepline} | /usr/bin/tail {$sor} -n " . escapeshellarg($tail), $logarr);
+		exec("/bin/cat " . escapeshellarg($logfile) . "{$grepline} | /usr/bin/tail {$sor} -n " . escapeshellarg($tail), $logarr);
 	}
 	foreach ($logarr as $logent) {
 			$logent = preg_split("/\s+/", $logent, 3);
 			echo "<tr valign=\"top\">\n";
-			$entry_date_time = htmlspecialchars($logent[0] . " " .  $logent[1]);
+			$entry_date_time = htmlspecialchars($logent[0] . " " . $logent[1]);
 			$entry_text = htmlspecialchars($logent[2]);
-			echo "<td class=\"listlr nowrap\" width=\"130\">{$entry_date_time}</td>\n";
+			echo "<td class=\"listlr\" nowrap=\"nowrap\" width=\"130\">{$entry_date_time}</td>\n";
 			echo "<td class=\"listr\">{$entry_text}</td>\n";
 			echo "</tr>\n";
 	}
@@ -73,33 +67,36 @@ include("head.inc");
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 <?php include("fbegin.inc"); ?>
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tr><td>
+<tr><td>
 <?php
 	$tab_array = array();
-	$tab_array[] = array(gettext("General page"), false, "antivirus.php");
-	$tab_array[] = array(gettext("HTTP proxy"), false, "pkg_edit.php?xml=havp.xml&amp;id=0");
-	$tab_array[] = array(gettext("Settings"), false, "pkg_edit.php?xml=havp_avset.xml&amp;id=0");
+	$tab_array[] = array(gettext("General Page"), false, "antivirus.php");
+	$tab_array[] = array(gettext("HTTP Proxy"), false, "pkg_edit.php?xml=havp.xml");
+	$tab_array[] = array(gettext("Settings"), false, "pkg_edit.php?xml=havp_avset.xml");
 	$tab_array[] = array(gettext("HAVP Log"), true, "havp_log.php");
 	display_top_tabs($tab_array);
 ?>
-  </td></tr>
-  <tr>
-    <td>
+</td></tr>
+<tr><td>
 	<div id="mainarea">
 		<table class="tabcont" width="100%" border="0" cellspacing="0" cellpadding="0">
-		  <tr>
+		<tr>
 			<td colspan="2" class="listtopic">
-			  <?php printf(gettext("Last %s HAVP log entries"), $nentries);?></td>
-		  </tr>
-		  <?php dump_havp_errorlog(HVDEF_HAVP_ERRORLOG, $nentries); ?>
-		<tr><td><br/>
-		<form action="havp_log.php" method="post">
-			<input name="clear" type="submit" class="formbtn" value="<?=gettext("Clear log"); ?>" /></form></td></tr>
+			<?php printf(gettext("Last %s HAVP log entries"), $nentries);?></td>
+		</tr>
+		<?php dump_havp_errorlog(HVDEF_HAVP_ERRORLOG, $nentries); ?>
+		<tr>
+			<td><br/>
+				<form action="havp_log.php" method="post">
+					<input name="clear" type="submit" class="formbtn" value="<?=gettext("Clear log"); ?>" />
+				</form>
+			</td>
+		</tr>
 		</table>
 	</div>
-	</td>
-  </tr>
+</td></tr>
 </table>
+
 <?php include("fend.inc"); ?>
 </body>
 </html>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1201,7 +1201,7 @@
 			<ports_after>security/clamav</ports_after>
 		</build_pbi>
 		<build_options>CLAMAVUSER=havp;CLAMAVGROUP=havp</build_options>
-		<version>0.91_3 pkg v1.05_1</version>
+		<version>1.06</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/havp/havp.xml</config_file>


### PR DESCRIPTION
havp.xml, havp_avset.xml, havp_fscan.xml
- Add copyright header
- Fix indentation/whitespace
- Improve descriptions

havp.inc
- Update copyright header
- Loads of code style/indentation/whitespace fixes
- Replace deprecated eregi() with preg_match
- Use install_cron_job() instead of re-implementing it
- Nuke bunch of useless pfSense 1.2.x checks
- Fix lots of hardcoded ClamAV mirrors

havp_log.php, antivirus.php
- Update copyright header
- Fix indentation/whitespace
- XHTML fixes
