### PR TITLE
Replaced lookup_ca($server_cert['caref']) with ca_chain($server_cert)…

### DIFF
--- a/config/openvpn-client-export/openvpn-client-export.inc
+++ b/config/openvpn-client-export/openvpn-client-export.inc
@@ -127,7 +127,7 @@ function openvpn_client_export_validate_config($srvid, $usrid, $crtid) {
 	if (!$server_cert) {
 		$input_errors[] = "Could not locate server certificate.";
 	} else {
-		$server_ca = lookup_ca($server_cert['caref']);
+		$server_ca = ca_chain($server_cert);
 		if (!$server_ca) {
 			$input_errors[] = "Could not locate the CA reference for the server certificate.";
 		}
@@ -380,7 +380,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 			file_put_contents("{$tempdir}/{$prefix}.ovpn", $conf);
 
 			$cafile = "{$tempdir}/{$cafile}";
-			file_put_contents("{$cafile}", base64_decode($server_ca['crt']));
+			file_put_contents("{$cafile}", $server_ca);
 			if ($settings['tls']) {
 				$tlsfile = "{$tempdir}/{$prefix}-tls.key";
 				file_put_contents($tlsfile, base64_decode($settings['tls']));
@@ -414,7 +414,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 		case "inlinedroid":
 		case "inlineios":
 			// Inline CA
-			$conf .= "<ca>{$nl}" . trim(base64_decode($server_ca['crt'])) . "{$nl}</ca>{$nl}";
+			$conf .= "<ca>{$nl}" . trim($server_ca) . "{$nl}</ca>{$nl}";
 			if ($settings['mode'] != "server_user") {
 				// Inline Cert
 				$conf .= "<cert>{$nl}" . trim(base64_decode($cert['crt'])) . "{$nl}</cert>{$nl}";
@@ -442,7 +442,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 			file_put_contents("{$tempdir}/vpn.cnf", $conf);
 
 			$cafile = "{$keydir}/ca.crt";
-			file_put_contents("{$cafile}", base64_decode($server_ca['crt']));
+			file_put_contents("{$cafile}", $server_ca);
 			if ($settings['tls']) {
 				$tlsfile = "{$keydir}/ta.key";
 				file_put_contents($tlsfile, base64_decode($settings['tls']));
@@ -468,7 +468,7 @@ function openvpn_client_export_config($srvid, $usrid, $crtid, $useaddr, $verifys
 			file_put_contents("{$tempdir}/vpn.cnf", $conf);
 
 			$cafile = "{$tempdir}/ca.crt";
-			file_put_contents("{$cafile}", base64_decode($server_ca['crt']));
+			file_put_contents("{$cafile}", $server_ca);
 			if ($settings['tls']) {
 				$tlsfile = "{$tempdir}/ta.key";
 				file_put_contents($tlsfile, base64_decode($settings['tls']));
@@ -561,7 +561,7 @@ function openvpn_client_export_installer($srvid, $usrid, $crtid, $useaddr, $veri
 	file_put_contents($cfgfile, $conf);
 
 	$cafile = "{$tempdir}/config/{$prefix}-ca.crt";
-	file_put_contents($cafile, base64_decode($server_ca['crt']));
+	file_put_contents($cafile, $server_ca);
 	if ($settings['tls']) {
 		$tlsfile = "{$tempdir}/config/{$prefix}-tls.key";
 		file_put_contents($tlsfile, base64_decode($settings['tls']));
@@ -697,7 +697,7 @@ EOF;
 
 	// write ca
 	$cafile = "{$tempdir}/ca.crt";
-	file_put_contents($cafile, base64_decode($server_ca['crt']));
+	file_put_contents($cafile, $server_ca);
 
 	if ($settings['mode'] != "server_user") {
 

--- a/config/openvpn-client-export/openvpn-client-export.xml
+++ b/config/openvpn-client-export/openvpn-client-export.xml
@@ -44,7 +44,7 @@
 	]]>
 	</copyright>
 	<name>OpenVPN Client Export</name>
-	<version>1.2.19</version>
+	<version>1.2.20</version>
 	<title>OpenVPN Client Export</title>
 	<include_file>/usr/local/pkg/openvpn-client-export.inc</include_file>
 	<tabs>


### PR DESCRIPTION
…. Note that ca_chain returns a string of Base64 encoded certificates, not an array. Thus, all references to base64_decode($server_ca['crt']) have been replaced with simply $server_ca.

Additionally, incremented package version from 1.2.19 to 1.2.20.