### PR TITLE
stunnel - code style fixes

### DIFF
--- a/config/stunnel/stunnel.inc
+++ b/config/stunnel/stunnel.inc
@@ -1,45 +1,73 @@
 <?php
+/*
+	stunnel.inc
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2007-2009 Scott Ullrich
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+global $config;
+
+$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
 if ($pf_version == "2.1" || $pf_version == "2.2") {
 	define('STUNNEL_LOCALBASE', '/usr/pbi/stunnel-' . php_uname("m"));
 } else {
-	define('STUNNEL_LOCALBASE','/usr/local');
+	define('STUNNEL_LOCALBASE', '/usr/local');
 }
 define('STUNNEL_ETCDIR', STUNNEL_LOCALBASE . "/etc/stunnel");
 
-if(!isset($_GET['id']) and !isset($_POST['id'])) {
-	if($GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg']) {
-		$savemsg=$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg'];
+if (!isset($_GET['id']) and !isset($_POST['id'])) {
+	if ($GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg']) {
+		$savemsg = $GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg'];
 		unset($GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg']);
 		write_config();
 	}
-	
 }
 
-if(isset($_GET['id'])) {
-	$config['installedpackages']['stunnelcerts']['config'][$_GET['id']]['cert_chain']=
+if (isset($_GET['id'])) {
+	$config['installedpackages']['stunnelcerts']['config'][$_GET['id']]['cert_chain'] =
 		base64_decode($config['installedpackages']['stunnelcerts']['config'][$_GET['id']]['cert_chain']);
-	$config['installedpackages']['stunnelcerts']['config'][$_GET['id']]['cert_key']=
+	$config['installedpackages']['stunnelcerts']['config'][$_GET['id']]['cert_key'] =
 		base64_decode($config['installedpackages']['stunnelcerts']['config'][$_GET['id']]['cert_key']);
 }
 
-$certs=$config['installedpackages']['stunnelcerts']['config'];
-is_array($certs) ? $num_certs=count($certs) : $num_certs=0;
-if(!isset($_GET['id']) and !isset($_POST['id']) and $num_certs) {
-	for ($i=0;$i<$num_certs;$i++) {
-		$cert=$certs[$i];
-		$_info=openssl_x509_parse(base64_decode($cert['cert_chain']));
-		$valid=floor(($_info['validTo_time_t']-time())/86400);
-		if($cert['cert_chain']) {
-			if(!openssl_x509_check_private_key(base64_decode($cert['cert_chain']), base64_decode($cert['cert_key']))) {
-				$_status='<font color="#AA0000"><b>Invalid key/cert!</b></font>';
-			} elseif($valid<30) {
-				$_status='<font color="#B27D4B">Expires in '.$valid.' days!</font>';
+$certs = $config['installedpackages']['stunnelcerts']['config'];
+is_array($certs) ? $num_certs = count($certs) : $num_certs = 0;
+if (!isset($_GET['id']) and !isset($_POST['id']) and $num_certs) {
+	for ($i = 0; $i < $num_certs; $i++) {
+		$cert = $certs[$i];
+		$_info = openssl_x509_parse(base64_decode($cert['cert_chain']));
+		$valid = floor(($_info['validTo_time_t'] - time()) / 86400);
+		if ($cert['cert_chain']) {
+			if (!openssl_x509_check_private_key(base64_decode($cert['cert_chain']), base64_decode($cert['cert_key']))) {
+				$_status = '<font color="#AA0000"><strong>Invalid key/cert!</strong></font>';
+			} elseif ($valid < 30) {
+				$_status = '<font color="#B27D4B">Expires in ' . $valid . ' days!</font>';
 			} else {
-				$_status='<font color="#008800">OK ('.$valid.' days)</font>';
+				$_status = '<font color="#008800">OK (' . $valid . ' days)</font>';
 			}
-			$config['installedpackages']['stunnelcerts']['config'][$i]['status']=$_status;
+			$config['installedpackages']['stunnelcerts']['config'][$i]['status'] = $_status;
 		} else {
 			unset($config['installedpackages']['stunnelcerts']['config'][$i]);
 		}
@@ -47,18 +75,19 @@ if(!isset($_GET['id']) and !isset($_POST['id']) and $num_certs) {
 }
 
 
-$tunnels=$config['installedpackages']['stunnel']['config'];
-is_array($tunnels) ? $num_tunnels=count($tunnels) : $num_tunnels=0;
-if(!isset($_GET['id']) and $num_tunnels) {
-	for ($i=0;$i<$num_tunnels;$i++) {
-		$tunnel=$tunnels[$i];
-		if($tunnel['certificate']) {
-			$certid=0;
-			if(is_array($config['installedpackages']['stunnelcerts']['config'])) {
-				foreach($config['installedpackages']['stunnelcerts']['config'] as $cert) {
-					if($tunnel['certificate']==$cert['filename'])
+$tunnels = $config['installedpackages']['stunnel']['config'];
+is_array($tunnels) ? $num_tunnels = count($tunnels) : $num_tunnels = 0;
+if (!isset($_GET['id']) and $num_tunnels) {
+	for ($i = 0; $i < $num_tunnels; $i++) {
+		$tunnel = $tunnels[$i];
+		if ($tunnel['certificate']) {
+			$certid = 0;
+			if (is_array($config['installedpackages']['stunnelcerts']['config'])) {
+				foreach ($config['installedpackages']['stunnelcerts']['config'] as $cert) {
+					if ($tunnel['certificate'] == $cert['filename']) {
 						$config['installedpackages']['stunnel']['config'][$i]['certificatelink']=
-							'<a href="/pkg_edit.php?xml=stunnel_certs.xml&act=edit&id='.$certid.'">'.$cert['description'].'</a>';
+							'<a href="/pkg_edit.php?xml=stunnel_certs.xml&act=edit&id=' . $certid . '">' . $cert['description'] . '</a>';
+					}
 					$certid++;
 				}
 			}
@@ -67,7 +96,7 @@ if(!isset($_GET['id']) and $num_tunnels) {
 }
 
 function stunnel_printcsr() {
-#	$GLOBALS['savemsg']="<pre>" . print_r($GLOBALS['config']['installedpackages']['stunnelcerts']['config'],true) . "</pre>";
+//	$GLOBALS['savemsg'] = "<pre>" . print_r($GLOBALS['config']['installedpackages']['stunnelcerts']['config'], true) . "</pre>";
 }
 
 function stunnel_addcerts($config) {
@@ -75,13 +104,14 @@ function stunnel_addcerts($config) {
 	$tunnels=$config['installedpackages']['stunnel']['config'];
 	?>
 	<script type="text/javascript">
+	//<![CDATA[
 	function addcerts() {
 		<?php
-	
-		foreach($certs as $cert) {
+
+		foreach ($certs as $cert) {
 			echo("document.forms['iform'].certificate.appendChild(new Option('".$cert['description']."', '".$cert['filename']."'));");
 		}
-		
+
 		?>
 	}
 	addcerts();
@@ -93,9 +123,9 @@ function stunnel_addcerts($config) {
 			document.forms['iform'].certificate[i].selected = true;
 		} else {
 			document.forms['iform'].certificate[i].selected = false;
-		}	
+		}
 	}
-
+	//]]>
 	</script>
 	<?php
 }
@@ -103,105 +133,103 @@ function stunnel_addcerts($config) {
 function stunnel_disablefields() {
 	?>
 	<script type="text/javascript">
+	//<![CDATA[
 		document.forms['iform'].subject.readOnly=true;
 		document.forms['iform'].filename.readOnly=true;
 		document.forms['iform'].expiry.readOnly=true;
+	//]]>
 	</script>
 	<?php
 }
 
 function stunnel_delete($config) {
 	$cert=$config['installedpackages']['stunnelcerts']['config'][$_GET['id']];
-	if(isset($_GET['id'])) {
-		unlink_if_exists(STUNNEL_ETCDIR . '/'.$cert['filename'].'pem');
-		unlink_if_exists(STUNNEL_ETCDIR . '/'.$cert['filename'].'key');
-		unlink_if_exists(STUNNEL_ETCDIR . '/'.$cert['filename'].'chain');
+	if (isset($_GET['id'])) {
+		unlink_if_exists(STUNNEL_ETCDIR . '/' . $cert['filename'] . '.pem');
+		unlink_if_exists(STUNNEL_ETCDIR . '/' . $cert['filename'] . '.key');
+		unlink_if_exists(STUNNEL_ETCDIR . '/' . $cert['filename'] . '.chain');
 	}
 }
 
 function stunnel_save($config) {
-	$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg']='';
+	$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg'] = '';
 	conf_mount_rw();
-	if (!file_exists(STUNNEL_ETCDIR))
-		@mkdir(STUNNEL_ETCDIR, 0755, true);
-	$fout = fopen(STUNNEL_ETCDIR . "/stunnel.conf","w");
+	safe_mkdir(STUNNEL_ETCDIR, 0755);
+	$fout = fopen(STUNNEL_ETCDIR . "/stunnel.conf", "w");
 	fwrite($fout, "cert = " . STUNNEL_ETCDIR . "/stunnel.pem \n");
 	fwrite($fout, "chroot = /var/tmp/stunnel \n");
 	fwrite($fout, "setuid = stunnel \n");
 	fwrite($fout, "setgid = stunnel \n");
-	if(!is_array($config['installedpackages']['stunnel']['config'])) { $config['installedpackages']['stunnel']['config']=Array(); }
-	foreach($config['installedpackages']['stunnel']['config'] as $pkgconfig) {
+	if (!is_array($config['installedpackages']['stunnel']['config'])) {
+		$config['installedpackages']['stunnel']['config'] = array();
+	}
+	foreach ($config['installedpackages']['stunnel']['config'] as $pkgconfig) {
 		fwrite($fout, "\n[" . $pkgconfig['description'] . "]\n");
-		if($pkgconfig['client']) fwrite($fout, "client = yes" . "\n");
-		if($pkgconfig['certificate']) {
-			if(file_exists(STUNNEL_ETCDIR . '/'.$pkgconfig['certificate'].'.key') and
-			   file_exists(STUNNEL_ETCDIR . '/'.$pkgconfig['certificate'].'.chain')) {
+		if ($pkgconfig['client']) {
+			fwrite($fout, "client = yes" . "\n");
+		}
+		if ($pkgconfig['certificate']) {
+			if (file_exists(STUNNEL_ETCDIR . '/'.$pkgconfig['certificate'].'.key') and file_exists(STUNNEL_ETCDIR . '/'.$pkgconfig['certificate'].'.chain')) {
 				fwrite($fout, "key = " . STUNNEL_ETCDIR . "/" . $pkgconfig['certificate'] . ".key\n");
 				fwrite($fout, "cert = " . STUNNEL_ETCDIR . "/" . $pkgconfig['certificate'] . ".chain\n");
 			}
 		}
-		if($pkgconfig['sourceip']) fwrite($fout, "local = " . $pkgconfig['sourceip'] . "\n");
+		if ($pkgconfig['sourceip']) {
+			fwrite($fout, "local = " . $pkgconfig['sourceip'] . "\n");
+		}
 		fwrite($fout, "accept = " . $pkgconfig['localip'] . ":" . $pkgconfig['localport'] . "\n");
 		fwrite($fout, "connect = " . $pkgconfig['redirectip'] . ":" . $pkgconfig['redirectport'] . "\n");
 		fwrite($fout, "TIMEOUTclose = 0\n\n");
 	}
 	fclose($fout);
 	conf_mount_ro();
-	system("/usr/local/etc/rc.d/stunnel.sh stop 2>/dev/null");
-	system("/usr/local/etc/rc.d/stunnel.sh start 2>/dev/null");
+	stop_service("stunnel");
+	start_service("stunnel");
 }
+
 function stunnel_save_cert($config) {
-	$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg']='';
-	if(isset($_POST['id'])) {
-#		echo "<pre>";
-#		print_r($_POST);
-#		echo "</pre>";
-
-		if(!$_POST['cert_chain']) {
-			$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg'].="Certificate chain must be specified!<br>";
-		} if(!$_POST['cert_key']) {
-			$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg'].="RSA Key must be specified!<br>";
+	$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg'] = '';
+	if (isset($_POST['id'])) {
+		if (!$_POST['cert_chain']) {
+			$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg'] .= "Certificate chain must be specified!<br />";
 		}
-		if($_POST['cert_chain'] and $_POST['cert_key']) {
-			$_cert=openssl_x509_parse($_POST['cert_chain']);
-#			echo("<pre>");
-#			print_r($_cert);
-#			echo("</pre>");
-			if($_cert['hash']) {
-				if(openssl_x509_check_private_key($_POST['cert_chain'], $_POST['cert_key'])) {
-					file_put_contents(STUNNEL_ETCDIR . '/'.$_cert['hash'].'.key',
-						$_POST['cert_key']);
-					file_put_contents(STUNNEL_ETCDIR . '/'.$_cert['hash'].'.chain',
-						$_POST['cert_chain']);
-					file_put_contents(STUNNEL_ETCDIR . '/'.$_cert['hash'].'.pem',
-						$_POST['cert_key']."\n".$_POST['cert_chain']);
+		if (!$_POST['cert_key']) {
+			$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg'] .= "RSA Key must be specified!<br />";
+		}
+		if ($_POST['cert_chain'] and $_POST['cert_key']) {
+			$_cert = openssl_x509_parse($_POST['cert_chain']);
+			if ($_cert['hash']) {
+				if (openssl_x509_check_private_key($_POST['cert_chain'], $_POST['cert_key'])) {
+					file_put_contents(STUNNEL_ETCDIR . '/'. $_cert['hash'] . '.key', $_POST['cert_key']);
+					file_put_contents(STUNNEL_ETCDIR . '/' . $_cert['hash'] . '.chain', $_POST['cert_chain']);
+					file_put_contents(STUNNEL_ETCDIR . '/' . $_cert['hash'] . '.pem', $_POST['cert_key']."\n".$_POST['cert_chain']);
 					system('chown stunnel:stunnel ' . STUNNEL_ETCDIR . '/*');
-					chmod(STUNNEL_ETCDIR . '/'.$_cert['hash'].'.key', 0600);
-					chmod(STUNNEL_ETCDIR . '/'.$_cert['hash'].'.pem', 0600);
+					chmod(STUNNEL_ETCDIR . '/' . $_cert['hash'] . '.key', 0600);
+					chmod(STUNNEL_ETCDIR . '/' . $_cert['hash'] . '.pem', 0600);
 
-					$_POST['filename']=$_cert['hash'];
-					$_POST['expiry_raw']=$_cert['validTo_time_t'];
-					$_POST['expiry']=date('Y-m-d', $_cert['validTo_time_t']);
-					$_POST['subject']=$_cert['name'];
+					$_POST['filename'] = $_cert['hash'];
+					$_POST['expiry_raw'] = $_cert['validTo_time_t'];
+					$_POST['expiry'] = date('Y-m-d', $_cert['validTo_time_t']);
+					$_POST['subject'] = $_cert['name'];
 				} else {
-					$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg'].="Certificate and key do not match!<br>";
-					$_POST['filename']='';
+					$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg'] .= "Certificate and key do not match!<br />";
+					$_POST['filename'] = '';
 				}
 			} else {
-				$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg'].="Couldn't parse certificate!<br>";
-				$_POST['expiry_raw']='';
-				$_POST['expiry']='';
-				$_POST['subject']='';
-				$_POST['filename']='';
+				$GLOBALS['config']['installedpackages']['stunnelcerts']['savemsg'] .= "Couldn't parse certificate!<br />";
+				$_POST['expiry_raw'] = '';
+				$_POST['expiry'] = '';
+				$_POST['subject'] = '';
+				$_POST['filename'] = '';
 			}
 		}
-		$_POST['cert_key']=base64_encode($_POST['cert_key']);
-		$_POST['cert_chain']=base64_encode($_POST['cert_chain']);
-		$_fname=$GLOBALS['config']['installedpackages']['stunnelcerts']['config'][$_POST['id']]['filename'];
-		if($_fname and $_fname!=$_POST['filename']) {
-			unlink_if_exists(STUNNEL_ETCDIR . '/'.$_fname.'.chain');
-			unlink_if_exists(STUNNEL_ETCDIR . '/'.$_fname.'.key');
-			unlink_if_exists(STUNNEL_ETCDIR . '/'.$_fname.'.pem');
+		$_POST['cert_key'] = base64_encode($_POST['cert_key']);
+		$_POST['cert_chain'] = base64_encode($_POST['cert_chain']);
+		$_fname = $GLOBALS['config']['installedpackages']['stunnelcerts']['config'][$_POST['id']]['filename'];
+		if ($_fname and $_fname != $_POST['filename']) {
+			unlink_if_exists(STUNNEL_ETCDIR . '/' . $_fname . '.chain');
+			unlink_if_exists(STUNNEL_ETCDIR . '/' . $_fname . '.key');
+			unlink_if_exists(STUNNEL_ETCDIR . '/' . $_fname . '.pem');
 		}
 	}
 }
@@ -212,21 +240,23 @@ function stunnel_install() {
 	chmod(STUNNEL_ETCDIR . "/stunnel.pem", 0600);
 	@mkdir("/var/tmp/stunnel/var/tmp/run/stunnel", 0755, true);
 	system("/usr/sbin/chown -R stunnel:stunnel /var/tmp/stunnel");
-	$_rcfile['file']='stunnel.sh';
-	$_rcfile['start'].= STUNNEL_LOCALBASE . "/bin/stunnel " . STUNNEL_ETCDIR . "/stunnel.conf \n\t";
-	$_rcfile['stop'].="killall stunnel \n\t";
+	$_rcfile['file'] = 'stunnel.sh';
+	$_rcfile['start'] = STUNNEL_LOCALBASE . "/bin/stunnel " . STUNNEL_ETCDIR . "/stunnel.conf \n\t";
+	$_rcfile['stop'] = "/usr/bin/killall stunnel \n\t";
 	write_rcfile($_rcfile);
 	unlink_if_exists("/usr/local/etc/rc.d/stunnel");
-	
-	$fout = fopen(STUNNEL_ETCDIR . "/stunnel.conf","w");
+
+	$fout = fopen(STUNNEL_ETCDIR . "/stunnel.conf", "w");
 	fwrite($fout, "cert = " . STUNNEL_ETCDIR . "/stunnel.pem \n");
 	fwrite($fout, "chroot = /var/tmp/stunnel \n");
 	fwrite($fout, "setuid = stunnel \n");
 	fwrite($fout, "setgid = stunnel \n");
-	if($config['installedpackages']['stunnel']['config']) {
-		foreach($config['installedpackages']['stunnel']['config'] as $pkgconfig) {
+	if ($config['installedpackages']['stunnel']['config']) {
+		foreach ($config['installedpackages']['stunnel']['config'] as $pkgconfig) {
 			fwrite($fout, "\n[" . $pkgconfig['description'] . "]\n");
-			if($pkgconfig['sourceip']) fwrite($fout, "local = " . $pkgconfig['sourceip'] . "\n");
+			if ($pkgconfig['sourceip']) {
+				fwrite($fout, "local = " . $pkgconfig['sourceip'] . "\n");
+			}
 			fwrite($fout, "accept = " . $pkgconfig['localip'] . ":" . $pkgconfig['localport'] . "\n");
 			fwrite($fout, "connect = " . $pkgconfig['redirectip'] . ":" . $pkgconfig['redirectport'] . "\n");
 			fwrite($fout, "TIMEOUTclose = 0\n\n");
@@ -238,7 +268,6 @@ function stunnel_install() {
 function stunnel_deinstall() {
 	rmdir_recursive("/var/tmp/stunnel");
 	rmdir_recursive(STUNNEL_ETCDIR);
-	unlink_if_exists("/usr/local/etc/rc.d/stunnel.sh");
 }
 
 ?>

--- a/config/stunnel/stunnel.xml
+++ b/config/stunnel/stunnel.xml
@@ -1,71 +1,68 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-        <copyright>
-        <![CDATA[
+	<copyright>
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    stunnel.xml
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2007-2008 Scott Ullrich
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
+	stunnel.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2007-2008 Scott Ullrich
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
-        </copyright>
-    <description>Describe your package here</description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>stunnel</name>
-	<version>4.18</version>
+	<version>5.20.2</version>
 	<title>Services: Secure Tunnel</title>
-	<!-- Menu is where this packages menu will appear -->
 	<menu>
 		<name>STunnel</name>
-		<tooltiptext>The stunnel program is designed to work as an SSL encryption wrapper between remote client and local (inetd-startable) or remote server. It can be used to add SSL functionality to commonly used inetd daemons like POP2, POP3, and IMAP servers without any changes in the programs' code. It will negotiate an SSL connection using the OpenSSL or SSLeay libraries. It calls the underlying crypto libraries, so stunnel supports whatever cryptographic algorithms you compiled into your crypto package.</tooltiptext>
+		<tooltiptext>The stunnel program is designed to work as an SSL encryption wrapper between remote client and local (inetd-startable) or remote server.
+		It can be used to add SSL functionality to commonly used inetd daemons like POP2, POP3, and IMAP servers without any changes in the programs' code.
+		It will negotiate an SSL connection using the OpenSSL or SSLeay libraries.
+		It calls the underlying crypto libraries, so stunnel supports whatever cryptographic algorithms you compiled into your crypto package.</tooltiptext>
 		<section>Services</section>
 		<configfile>stunnel.xml</configfile>
 	</menu>
-	
+	<include_file>/usr/local/pkg/stunnel.inc</include_file>	
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0644</chmod>
 		<item>https://packages.pfsense.org/packages/config/stunnel/stunnel.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0644</chmod>
 		<item>https://packages.pfsense.org/packages/config/stunnel/stunnel_certs.xml</item>
 	</additional_files_needed>
-	<!-- configpath gets expanded out automatically and config items will be
-         stored in that location -->
 	<configpath>['installedpackages']['package']['$packagename']['configuration']</configpath>
-         
 	<tabs>
 		<tab>
 			<text>Tunnels</text>
@@ -77,9 +74,11 @@
 			<url>/pkg.php?xml=stunnel_certs.xml</url>
 		</tab>
 	</tabs>
-
-	<!-- adddeleteeditpagefields items will appear on the first page where you can add / delete or edit
-         items.  An example of this would be the nat page where you add new nat redirects -->         
+	<service>
+		<name>stunnel</name>
+		<rcfile>stunnel.sh</rcfile>
+		<executable>stunnel</executable>
+	</service>	
 	<adddeleteeditpagefields>
 		<columnitem>
 			<fielddescr>Description</fielddescr>
@@ -106,8 +105,6 @@
 			<fieldname>redirectport</fieldname>
 		</columnitem>
 	</adddeleteeditpagefields>
-	<!-- fields gets invoked when the user adds or edits a item.   the following items
-         will be parsed and rendered for the user as a gui with input, and selectboxes. -->
 	<fields>
 		<field>
 			<fielddescr>Description</fielddescr>
@@ -118,7 +115,7 @@
 		<field>
 			<fielddescr>Client Mode</fielddescr>
 			<fieldname>client</fieldname>
-			<description>Use client mode for this tunnel (i.e. connect to an SSL server, do not act as an SSL server)</description>
+			<description>Use client mode for this tunnel (i.e. connect to an SSL server, do not act as an SSL server).</description>
 			<type>checkbox</type>
 		</field>
 		<field>
@@ -128,7 +125,7 @@
 			<type>input</type>
 		</field>
 		<field>
-			<fielddescr>Listen on port</fielddescr>
+			<fielddescr>Listen on Port</fielddescr>
 			<fieldname>localport</fieldname>
 			<description>Enter the local port to bind this redirection to.</description>
 			<type>input</type>
@@ -156,18 +153,12 @@
 			<type>input</type>
 		</field>
 		<field>
-			<fielddescr>Outgoing source IP</fielddescr>
+			<fielddescr>Outgoing Source IP</fielddescr>
 			<fieldname>sourceip</fieldname>
 			<description>Enter the source IP address for outgoing connections.</description>
 			<type>input</type>
 		</field>
 	</fields>
-	<service>
-	  <name>stunnel</name>
-	  <rcfile>stunnel.sh</rcfile>
-	  <executable>stunnel</executable>
-	</service>
-	<include_file>/usr/local/pkg/stunnel.inc</include_file>
 	<custom_add_php_command_late>
 		stunnel_save($config);
 	</custom_add_php_command_late>

--- a/config/stunnel/stunnel_certs.xml
+++ b/config/stunnel/stunnel_certs.xml
@@ -1,53 +1,51 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-        <copyright>
-        <![CDATA[
+	<copyright>
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    stunnel.xml
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2007-2009 Scott Ullrich
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
+	stunnel_certs.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2007-2009 Scott Ullrich
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
-        </copyright>
-    <description>Stunnel certificates</description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>stunnelcerts</name>
-	<version>4.18</version>
+	<version>5.20.2</version>
 	<title>Services: Secure Tunnel - Certificates</title>
-	<!-- configpath gets expanded out automatically and config items will be
-         stored in that location -->
+	<include_file>/usr/local/pkg/stunnel.inc</include_file>
 	<configpath>['installedpackages']['package']['$packagename']['configuration']</configpath>
-
 	<tabs>
 		<tab>
 			<text>Tunnels</text>
@@ -59,9 +57,6 @@
 			<active/>
 		</tab>
 	</tabs>
-
-	<!-- adddeleteeditpagefields items will appear on the first page where you can add / delete or edit
-         items.  An example of this would be the nat page where you add new nat redirects -->
 	<adddeleteeditpagefields>
 		<columnitem>
 			<fielddescr>Description</fielddescr>
@@ -79,55 +74,59 @@
 			<fielddescr>Status</fielddescr>
 			<fieldname>status</fieldname>
 		</columnitem>
-
 	</adddeleteeditpagefields>
-	<!-- fields gets invoked when the user adds or edits a item.   the following items
-         will be parsed and rendered for the user as a gui with input, and selectboxes. -->
 	<fields>
 		<field>
 			<fielddescr>Description</fielddescr>
 			<fieldname>description</fieldname>
-			<description>Enter a (short) description for this certificate</description>
+			<description>Enter a (short) description for this certificate.</description>
 			<type>input</type>
 		</field>
 		<field>
-			<fielddescr>Certificate filename</fielddescr>
+			<fielddescr>Certificate Filename</fielddescr>
 			<fieldname>filename</fieldname>
 			<description>File name of certificate (read-only; updated on save). Extensions (.pem, .chain, .key) are added automatically.</description>
 			<type>input</type>
 		</field>
 		<field>
-			<fielddescr>Certificate subject</fielddescr>
+			<fielddescr>Certificate Subject</fielddescr>
 			<fieldname>subject</fieldname>
 			<description>Certificate subject (read-only; updated on save)</description>
 			<type>input</type>
 			<size>50</size>
 		</field>
 		<field>
-			<fielddescr>Certificate valid until</fielddescr>
+			<fielddescr>Certificate Valid Until</fielddescr>
 			<fieldname>expiry</fieldname>
 			<description>The certificate will expire on this date, and will no longer work.</description>
 			<type>input</type>
 		</field>
 		<field>
-			<fielddescr>RSA private key</fielddescr>
+			<fielddescr>RSA Private Key</fielddescr>
 			<fieldname>cert_key</fieldname>
-			<description>RSA private key used for certificate. Do not change for existing certificates!&lt;br&gt;</description>
+			<description>
+				<![CDATA[
+				RSA private key used for certificate. Do not change for existing certificates!<br />
+				]]>
+			</description>
 			<type>textarea</type>
 			<rows>7</rows>
-			<cols>65</cols>
+			<cols>70</cols>
 		</field>
 		<field>
-			<fielddescr>Certificate chain</fielddescr>
+			<fielddescr>Certificate Chain</fielddescr>
 			<fieldname>cert_chain</fieldname>
-			<description>Full certificate chain; root certificate on top, then any intermediates, server certificate at the end.&lt;br&gt;
-							&lt;b&gt;Full chain required for private or EV certificates!&lt;/b&gt;</description>
+			<description>
+				<![CDATA[
+				Full certificate chain; root certificate on top, then any intermediates, server certificate at the end.<br />
+				<strong>Full chain required for private or EV certificates!</strong>
+				]]>
+			</description>
 			<type>textarea</type>
 			<rows>7</rows>
-			<cols>65</cols>
+			<cols>70</cols>
 		</field>
 	</fields>	
-	<include_file>/usr/local/pkg/stunnel.inc</include_file>
 	<custom_add_php_command>
 		stunnel_save_cert($config);
 		stunnel_save($config);

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -951,7 +951,7 @@
 		<descr>SSL encryption wrapper between remote client and local or remote servers.</descr>
 		<category>Network Management</category>
 		<depends_on_package_pbi>stunnel-5.20-##ARCH##.pbi</depends_on_package_pbi>
-		<version>5.20.1</version>
+		<version>5.20.2</version>
 		<status>Stable</status>
 		<pkginfolink>https://doc.pfsense.org/index.php/Stunnel_package</pkginfolink>
 		<required_version>2.2</required_version>


### PR DESCRIPTION
stunnel.xml
- Update copyright header
- Indentation fixes
- Nuke useless chmods for default permissions and useless comments
- Descriptions cosmetics

stunnel_certs.xml
- Update copyright header
- Nuke useless comments
- Descriptions cosmetics

stunnel.inc
- Add missing copyright header
- Code style and indentation fixes
- Fix stunnel_delete() - missing dots after filename
- Use start_service() and stop_service()
- Put JS between CDATA
- No need to unlink service rc script manually on uninstall