### PR TITLE
sarg - code style cleanup and fixes

### DIFF
--- a/config/sarg/sarg.inc
+++ b/config/sarg/sarg.inc
@@ -1,540 +1,557 @@
 <?php
-/* ========================================================================== */
 /*
 	sarg.inc
-    part of pfSense (http://www.pfSense.com)
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2007 Joao Henrique F. Freitas
-    Copyright (C) 2012-2013 Marcello Coutinho
-    All rights reserved.
-                                                                              */
-/* ========================================================================== */
-/*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Copyright (C) 2012-2013 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version == "2.1" || $pf_version == "2.2"){
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+if ($pf_version == "2.1" || $pf_version == "2.2") {
 	// Function to get squidGuard directory
 	// each squidGuard version has a different directory
 	function getsqGuardDir() {
-		foreach (glob("/usr/pbi/*",GLOB_ONLYDIR) as $dirname) {
+		foreach (glob("/usr/pbi/*", GLOB_ONLYDIR) as $dirname) {
 			if (preg_match("/squidguard-/i", $dirname)) {
 				return trim($dirname);
 				break;
 			}
 		}
 	}
-
-        define('SARG_DIR', '/usr/pbi/sarg-' . php_uname("m"));
-        define('SQGARD_DIR', getsqGuardDir());
-        define('SQUID_DIR', '/usr/pbi/squid-' . php_uname("m"));
-        define('DANSG_DIR', '/usr/pbi/dansguardian-' . php_uname("m"));
-	}
-else{
-  define('SARG_DIR', '/usr/local');
-  define('SQGARD_DIR', '/usr/local');
-  define('SQUID_DIR', '/usr/local');
-  define('DANSG_DIR', '/usr/local');
+	define('SARG_DIR', '/usr/pbi/sarg-' . php_uname("m"));
+	define('SQGARD_DIR', getsqGuardDir());
+	define('SQUID_DIR', '/usr/pbi/squid-' . php_uname("m"));
+	define('DANSG_DIR', '/usr/pbi/dansguardian-' . php_uname("m"));
+} else {
+	define('SARG_DIR', '/usr/local');
+	define('SQGARD_DIR', '/usr/local');
+	define('SQUID_DIR', '/usr/local');
+	define('DANSG_DIR', '/usr/local');
 }
-  
-$uname=posix_uname();
-if ($uname['machine']=='amd64')
-        ini_set('memory_limit', '250M');
+
+$uname = posix_uname();
+if ($uname['machine']=='amd64') {
+	ini_set('memory_limit', '250M');
+}
 
 // STATIC VARS
-$sarg_proxy=array(	'squid_rc'=> SQUID_DIR . '/etc/rc.d/squid.sh',
-					'squid_config'=> '/var/squid/logs/access.log',
-					'squidguard_config'=> SQGARD_DIR . '/etc/squidGuard/squidGuard.conf',
-					'squidguard_block_log'=>'/var/squidGuard/log/block.log',
-					'dansguardian_config'=> DANSG_DIR . '/etc/dansguardian/dansguardian.conf',
-					'dansguardian_log'=>'/var/log/dansguardian/access.log');
-
+$sarg_proxy['squid_rc'] = SQUID_DIR . '/etc/rc.d/squid.sh';
+$sarg_proxy['squid_config'] = '/var/squid/logs/access.log';
+$sarg_proxy['squidguard_config'] = SQGARD_DIR . '/etc/squidGuard/squidGuard.conf';
+$sarg_proxy['squidguard_block_log'] = '/var/squidGuard/log/block.log';
+$sarg_proxy['dansguardian_config'] = DANSG_DIR . '/etc/dansguardian/dansguardian.conf';
+$sarg_proxy['dansguardian_log'] = '/var/log/dansguardian/access.log';
 // END STATIC VARS
 
-function sarg_start() {
-	global $g, $config;
-	
-	// reserved
-}
-
-function sarg_text_area_decode($text){
-	return preg_replace('/\r\n/', "\n",base64_decode($text));	
+function sarg_text_area_decode($text) {
+	return preg_replace('/\r\n/', "\n", base64_decode($text));
 }
 
 function sarg_resync() {
-        global $config;
-        if (($_POST['Submit'] == 'Save') || !isset($_POST['Submit']))
-        	sync_package_sarg();
-        if ($_POST['Submit'] == 'Force update now')
-        	run_sarg();
-
-}
-function log_rotate($log_file){
-	global $config, $g;
-	
-	#remove .10 rotate log file
-	unlink_if_exists("$log_file".".10");
-	#rotate logs from 9 to 0
-	$i=9;
-	while ($i>=0){
-		if (file_exists($log_file.".".$i))
-			rename ($log_file.".".$i,$log_file.".".($i+1));
-		$i=$i-1;
+	global $config;
+	if (($_POST['Submit'] == 'Save') || !isset($_POST['Submit'])) {
+		sync_package_sarg();
 	}
-	#rotate current log
-	if (file_exists("$log_file"))
-		rename ($log_file,$log_file.".0");	
+	if ($_POST['Submit'] == 'Force update now') {
+		run_sarg();
+	}
 }
-function run_sarg($id=-1) {
-	global $config, $g,$sarg_proxy;
-	#mount filesystem writeable
+
+function log_rotate($log_file) {
+	global $config, $g;
+
+	// remove .10 rotate log file
+	unlink_if_exists("{$log_file}.10");
+	// rotate logs from 9 to 0
+	$i = 9;
+	while ($i >= 0) {
+		if (file_exists("{$log_file}.{$i}")) {
+			rename("{$log_file}.{$i}", "{$log_file}" . ($i + 1));
+		}
+		$i = $i - 1;
+	}
+	// rotate current log
+	if (file_exists("$log_file")) {
+		rename("{$log_file}", "{$log_file}.0");
+	}
+}
+
+function run_sarg($id = -1) {
+	global $config, $g, $sarg_proxy;
+	// mount filesystem writeable
 	conf_mount_rw();
-	$cmd =  SARG_DIR . "/bin/sarg";
-	if ($id >= 0 && is_array($config['installedpackages']['sargschedule']['config'])){
-		$args=$config['installedpackages']['sargschedule']['config'][$id]['args'];
-		$action=$config['installedpackages']['sargschedule']['config'][$id]['action'];
-		$gzip=$config['installedpackages']['sargschedule']['config'][$id]['gzip'];
-		$find=$config['installedpackages']['sargschedule']['config'][$id]['find'];
-		$gziplevel=$config['installedpackages']['sargschedule']['config'][$id]['gziplevel'];
-		$daylimit=$config['installedpackages']['sargschedule']['config'][$id]['daylimit'];
-		}
-	else{
-		$args=$_POST['args'];
-		$action=$_POST['action'];
-		$gzip=$_POST['gzip'];
-		$find=$_POST['find'];
-		$gziplevel=$_POST['gziplevel'];
-		$daylimit="";
-		}
-	$find=(preg_match("/(\d+)/",$find,$find_matches) ? $find_matches[1] : "60");
+	$cmd = SARG_DIR . "/bin/sarg";
+	if ($id >= 0 && is_array($config['installedpackages']['sargschedule']['config'])) {
+		$args = $config['installedpackages']['sargschedule']['config'][$id]['args'];
+		$action = $config['installedpackages']['sargschedule']['config'][$id]['action'];
+		$gzip = $config['installedpackages']['sargschedule']['config'][$id]['gzip'];
+		$find = $config['installedpackages']['sargschedule']['config'][$id]['find'];
+		$gziplevel = $config['installedpackages']['sargschedule']['config'][$id]['gziplevel'];
+		$daylimit = $config['installedpackages']['sargschedule']['config'][$id]['daylimit'];
+	} else {
+		$args = $_POST['args'];
+		$action = $_POST['action'];
+		$gzip = $_POST['gzip'];
+		$find = $_POST['find'];
+		$gziplevel = $_POST['gziplevel'];
+		$daylimit = "";
+	}
+	$find = (preg_match("/(\d+)/", $find, $find_matches) ? $find_matches[1] : "60");
 	log_error("Sarg: force refresh now with {$args} args, compress({$gzip}) and {$action} action after sarg finish.");
-	$gzip_script="#!/bin/sh\n";
-	if ($gzip=="on"){
-		#remove old file if exists
+	$gzip_script = "#!/bin/sh\n";
+	if ($gzip == "on") {
+		// remove old file if exists
 		unlink_if_exists("/root/sarg_run_{$id}.sh");
-		$gzip_script.=<<<EOF
+		$gzip_script .= <<<EOF
 for a in `/usr/bin/find /usr/local/sarg-reports -cmin -{$find} -type d -mindepth 1 -maxdepth 1`
 do
 echo \$a
-/usr/bin/find \$a -name "*html" | xargs gzip {$gziplevel}
+/usr/bin/find \$a -name "*html" | /usr/bin/xargs gzip {$gziplevel}
 done
-		
+
 EOF;
 
-		}
-	if (preg_match("/(\d+)/",$daylimit,$day_matches)){
-		$gzip_script.=<<<EOF
+	}
+	if (preg_match("/(\d+)/", $daylimit, $day_matches)) {
+		$gzip_script .= <<<EOF
 for a in `/usr/bin/find /usr/local/sarg-reports -ctime +{$find} -type d -mindepth 1 -maxdepth 1`
 do
 echo \$a
-rm -rf \$a
+/bin/rm -rf \$a
 done
-		
+
 EOF;
 	}
-	#create a new file to speedup find search
-	file_put_contents("/root/sarg_run_{$id}.sh",$gzip_script,LOCK_EX);
-	mwexec("export LC_ALL=C && " .$cmd. " ".$args);
-	#check if there is a script to run after file save
-	if (is_array($config['installedpackages']['sarg']))
-		switch ($config['installedpackages']['sarg']['config'][0]['proxy_server']){
+	// create a new file to speedup find search
+	file_put_contents("/root/sarg_run_{$id}.sh", $gzip_script, LOCK_EX);
+	mwexec("export LC_ALL=C && " . $cmd . " " . $args);
+	// check if there is a script to run after file save
+	if (is_array($config['installedpackages']['sarg'])) {
+		switch ($config['installedpackages']['sarg']['config'][0]['proxy_server']) {
 			case "squidguard":
-				if ($action =="both" || $action=="rotate"){
-					log_error('executing squidguard log rotate after sarg.');
+				if ($action == "both" || $action == "rotate") {
+					log_error('Executing squidguard log rotate after sarg.');
 					log_rotate($sarg_proxy['squidguard_block_log']);
-					file_put_contents($sarg_proxy['squidguard_block_log'],"",LOCK_EX);
-					chown($sarg_proxy['squidguard_block_log'],'proxy');
-					chgrp($sarg_proxy['squidguard_block_log'],'proxy');
+					file_put_contents($sarg_proxy['squidguard_block_log'], "", LOCK_EX);
+					chown($sarg_proxy['squidguard_block_log'], 'proxy');
+					chgrp($sarg_proxy['squidguard_block_log'], 'proxy');
 					mwexec(SQUID_DIR . '/sbin/squid -k reconfigure');
-					}
-			#leave this case without break to run squid rotate too.
+				}
+			// leave this case without break to run squid rotate too.
 			case "squid":
-				if ($action =="both" || $action=="rotate"){
-					log_error('executing squid log rotate after sarg.');
+				if ($action == "both" || $action == "rotate") {
+					log_error('Executing squid log rotate after sarg.');
 					mwexec(SQUID_DIR . '/sbin/squid -k rotate');
+				}
+				if ($action == "both" || $action=="restart") {
+					if (file_exists($sarg_proxy['squid_rc'])) {
+						mwexec_bg($sarg_proxy['squid_rc'] . ' restart');
 					}
-				if ($action =="both" || $action=="restart"){
-					if (file_exists($sarg_proxy['squid_rc']))
-						mwexec_bg($sarg_proxy['squid_rc'].' restart');
-					}
+				}
 			break;
 			case "dansguardian":
-				if (preg_match('/\w+/',$action) && $action !="none"){
+				if (preg_match('/\w+/', $action) && $action != "none") {
 					log_rotate($sarg_proxy['dansguardian_log']);
-					log_error('restarting dansguardian after sarg and log rotate.');
+					log_error('Restarting dansguardian after sarg and log rotate.');
 					mwexec('/usr/bin/killall -HUP dansguardian');
-					}
+				}
 			break;
 		}
-	#check compress option
-	if ($gzip=="on")
+	}
+	// check compress option
+	if ($gzip == "on") {
 		mwexec_bg("/bin/sh /root/sarg_run_{$id}.sh");
-		
-	#mount filesystem readonly
+	}
+	// mount filesystem readonly
 	conf_mount_ro();
 }
 
 function sync_package_sarg() {
-	global $config, $g,$sarg_proxy;
-	
-	# detect boot process
-	if (is_array($_POST)){
-		if (!preg_match("/\w+/",$_POST['__csrf_magic']))
-			return;
+	global $config, $g, $sarg_proxy;
+
+	// detect boot process
+	if (platform_booting()) {
+		return;
 	}
-	#check pkg.php sent a sync request
-	
-	
-	$update_conf=0;
-	#mount filesystem writeable
+
+	// check pkg.php sent a sync request
+	$update_conf = 0;
+	// mount filesystem writeable
 	conf_mount_rw();
-	if (!is_array($config['installedpackages']['sarg']['config']))
-		$config['installedpackages']['sarg']['config'][0]=array('report_options'=>'use_graphs,remove_temp_files,main_index,use_comma,date_time_by_bytes',
-																'report_type'=>'topusers,topsites,sites_users,users_sites,date_time,denied,auth_failures,site_user_time_date,downloads',
-																'report_type'=>'u',
-																'report_charset'=>'UTF-8',
-																'topuser_num'=>'0',
-																'authfail_report_limit'=>'0',
-																'denied_report_limit'=>'0',
-																'user_report_limit' =>'0',
-																'lastlog'=> '0',
-																'max_elapsed'=> '0');
-	$sarg=$config['installedpackages']['sarg']['config'][0];
-	if (!is_array($config['installedpackages']['sarguser']['config']))
-		$config['installedpackages']['sarguser']['config'][0]=array('user_sort_field'=>'BYTES',
-																	'exclude_userlist'=> $sarg['exclude_userlist'],
-																	'include_userlist'=> $sarg['include_userlist'],
-																	'usertab'=>$sarg['usertab'],
-																	'ldap_filter_search'=> '(uid=%s)',
-																	'ldap_target_attr'=> 'cn',
-																	'ldap_port'=> '389',
-																	'ntlm_user_format'=>'domainname+username');
-	$sarguser=$config['installedpackages']['sarguser']['config'][0];
-	$access_log=$sarg['proxy_server'];
-	switch ($sarg['proxy_server']){
-		case 'dansguardian':
-			$access_log= $sarg_proxy['dansguardian_log'];
-			$dansguardian_conf=$sarg_proxy['dansguardian_config'];
-			$dansguardian_filter_out_date="dansguardian_filter_out_date on";
-			$squidguard_conf='squidguard_conf none';
-		break;
-		case 'squidguard':
-			$squidguard_conf='squidguard_conf '.$sarg_proxy['squidguard_config'];
-			$redirector_log_format='redirector_log_format #year#-#mon#-#day# #hour# #tmp#/#list#/#tmp#/#tmp#/#url#/#tmp# #ip#/#tmp# #user# #end#';
-			#Leve this case without break to include squid log file on squidguard option
-		case 'squid':
-			$access_log= $sarg_proxy['squid_config'];
-			if (is_array($config['installedpackages']['squid']['config']))
-				if (file_exists($config['installedpackages']['squid']['config'][0]['log_dir']. '/access.log'))
-					$access_log = $config['installedpackages']['squid']['config'][0]['log_dir']. '/access.log';
-		break;
+	if (!is_array($config['installedpackages']['sarg']['config'])) {
+		$config['installedpackages']['sarg']['config'][0]['report_options'] = 'use_graphs,remove_temp_files,main_index,use_comma,date_time_by_bytes';
+		$config['installedpackages']['sarg']['config'][0]['report_type'] = 'topusers,topsites,sites_users,users_sites,date_time,denied,auth_failures,site_user_time_date,downloads';
+		$config['installedpackages']['sarg']['config'][0]['report_date_format'] = 'u';
+		$config['installedpackages']['sarg']['config'][0]['report_charset'] = 'UTF-8';
+		$config['installedpackages']['sarg']['config'][0]['topuser_num'] = '0';
+		$config['installedpackages']['sarg']['config'][0]['authfail_report_limit'] = '0';
+		$config['installedpackages']['sarg']['config'][0]['denied_report_limit'] = '0';
+		$config['installedpackages']['sarg']['config'][0]['user_report_limit'] = '0';
+		$config['installedpackages']['sarg']['config'][0]['lastlog'] = '0';
+		$config['installedpackages']['sarg']['config'][0]['max_elapsed'] = '0';
 	}
-	if (!file_exists($access_log) && $access_log !=""){
-		$error="Sarg config error: ".$sarg['proxy_server']." log file ($access_log) does not exists";
+	$sarg = $config['installedpackages']['sarg']['config'][0];
+	if (!is_array($config['installedpackages']['sarguser']['config'])) {
+		$config['installedpackages']['sarguser']['config'][0]['user_sort_field'] = 'BYTES';
+		$config['installedpackages']['sarguser']['config'][0]['exclude_userlist'] = $sarg['exclude_userlist'];
+		$config['installedpackages']['sarguser']['config'][0]['include_userlist'] = $sarg['include_userlist'];
+		$config['installedpackages']['sarguser']['config'][0]['usertab'] = $sarg['usertab'];
+		$config['installedpackages']['sarguser']['config'][0]['ldap_filter_search'] = '(uid=%s)';
+		$config['installedpackages']['sarguser']['config'][0]['ldap_target_attr'] = 'cn';
+		$config['installedpackages']['sarguser']['config'][0]['ldap_port'] = '389';
+		$config['installedpackages']['sarguser']['config'][0]['ntlm_user_format'] = 'domainname+username';
+	}
+	$sarguser = $config['installedpackages']['sarguser']['config'][0];
+	$access_log = $sarg['proxy_server'];
+	switch ($sarg['proxy_server']) {
+		case 'dansguardian':
+			$access_log = $sarg_proxy['dansguardian_log'];
+			$dansguardian_conf = $sarg_proxy['dansguardian_config'];
+			$dansguardian_filter_out_date = "dansguardian_filter_out_date on";
+			$squidguard_conf = 'squidguard_conf none';
+			break;
+		case 'squidguard':
+			$squidguard_conf = 'squidguard_conf ' . $sarg_proxy['squidguard_config'];
+			$redirector_log_format = 'redirector_log_format #year#-#mon#-#day# #hour# #tmp#/#list#/#tmp#/#tmp#/#url#/#tmp# #ip#/#tmp# #user# #end#';
+			// leave this case without break to include squid log file on squidguard option
+		case 'squid':
+			$access_log = $sarg_proxy['squid_config'];
+			if (is_array($config['installedpackages']['squid']['config'])) {
+				if (file_exists($config['installedpackages']['squid']['config'][0]['log_dir'] . '/access.log')) {
+					$access_log = $config['installedpackages']['squid']['config'][0]['log_dir'] . '/access.log';
+				}
+			}
+			break;
+	}
+	if (!file_exists($access_log) && $access_log !="") {
+		$error = "Sarg config error: " . $sarg['proxy_server'] . " log file ($access_log) does not exists";
 		log_error($error);
 		file_notice("Sarg", $error, "Sarg Settings", "");
 	}
-	
-	#general tab	
-	$graphs=(preg_match('/use_graphs/',$sarg['report_options'])?"yes":"no");
-	$anonymous_output_files=(preg_match('/anonymous_output_files/',$sarg['report_options'])?"yes":"no");
-	$resolve_ip=(preg_match('/resolve_ip/',$sarg['report_options'])?"yes":"no");
-	$user_ip=(preg_match('/user_ip/',$sarg['report_options'])?"yes":"no");
-	$sort_order=(preg_match('/user_sort_field_order/',$sarg['report_options'])?"reverse":"normal");
-	$remove_temp_files=(preg_match('/remove_temp_files/',$sarg['report_options'])?"yes":"no");
-	$main_index=(preg_match('/main_index/',$sarg['report_options'])?"yes":"no");
-	$index_tree=(preg_match('/index_tree/',$sarg['report_options'])?"file":"date");
-	$overwrite_report=(preg_match('/overwrite_report/',$sarg['report_options'])?"yes":"no");
-	$use_comma=(preg_match('/use_comma/',$sarg['report_options'])?"yes":"no");
-	$long_url=(preg_match('/long_url/',$sarg['report_options'])?"yes":"no");
-	$privacy=(preg_match('/privacy/',$sarg['report_options'])?"yes":"no");
-	$displayed_values=(preg_match('/displayed_values/',$sarg['report_options'])?"abbreviation":"bytes");
-	$bytes_in_sites_users_report=(preg_match('/bytes_in_sites_users_report/',$sarg['report_options'])?"yes":"no");
-	$date_time_by=(preg_match('/date_time_by_bytes/',$sarg['report_options'])?"bytes":"");
-	$date_time_by.=(preg_match('/date_time_by_elap/',$sarg['report_options'])?" elap":"");
-	if(empty($date_time_by))
-		$date_time_by="bytes";
-	$date_format=(preg_match("/\w/",$sarg['report_date_format'])?$sarg['report_date_format']:"u");
-	$report_type=preg_replace('/,/',' ',$sarg['report_type']);
-	$report_charset=(empty($sarg['report_charset'])?"UTF-8":$sarg['report_charset']);
-	$exclude_string=(empty($sarg['exclude_string'])?"":'exclude_string "'.$sarg['exclude_string'].'"');
 
-	#limits
-	$max_elapsed=(empty($sarg['max_elapsed'])?"0":$sarg['max_elapsed']);
-	$lastlog=(empty($sarg['lastlog'])?"0":$sarg['lastlog']);
-	$topuser_num=(empty($sarg['topuser_num'])?"0":$sarg['topuser_num']);
-	$authfail_report_limit=(empty($sarg['authfail_report_limit'])?"0":$sarg['authfail_report_limit']);
-	$denied_report_limit=(empty($sarg['denied_report_limit'])?"0":$sarg['denied_report_limit']);
-	$report_limit=(empty($sarg['user_report_limit'])?"0":$sarg['user_report_limit']);
-	$user_report_limit = "siteusers_report_limit ".$report_limit."\n";
-	$user_report_limit .= "user_report_limit ".$report_limit."\n";
-	if(preg_match("/(squidguard|dansguardian)/",$sarg['proxy_server'])){
-		$user_report_limit .= $sarg['proxy_server']."_report_limit ".$report_limit."\n";
-		}
-	
-	#user tab
-	$ntlm_user_format=(empty($sarguser['ntlm_user_format'])?'domainname+username':$sarguser['ntlm_user_format']);
-	if(!empty($sarguser['include_userlist']))
-		$include_users="$include_users ".$sarguser['include_userlist'];
-		
-	if(empty($sarguser['usertab'])){
-		$usertab="none";
-		}
-	else{
-		$usertab=  SARG_DIR . "/etc/sarg/usertab.conf";
-		file_put_contents( SARG_DIR . '/etc/sarg/usertab.conf', sarg_text_area_decode($sarguser['usertab']),LOCK_EX);
-		}
-	if($sarguser['ldap_enable']){
-		$usertab="ldap";
-		$LDAPHost=(empty($sarguser['ldap_host'])?"":"LDAPHost ".$sarguser['ldap_host']);
-		$LDAPort=(empty($sarguser['ldap_port'])?"":"LDAPPort ".$sarguser['ldap_port']);
-		$LDAPBindDN=(empty($sarguser['ldap_bind_dn'])?"":"LDAPBindDN ".$sarguser['ldap_bind_dn']);
-		$LDAPBindPW=(empty($sarguser['ldap_bind_pw'])?"":"LDAPBindPW ".$sarguser['ldap_bind_pw']);
-		$LDAPBaseSearch=(empty($sarguser['ldap_base_search'])?"":"LDAPBaseSearch ".$sarguser['ldap_base_search']);
-		$LDAPTargetAttr=(empty($sarguser['ldap_target_Attr'])?"":"LDAPTargetAttr ".$sarguser['ldap_target_Attr']);
-		$LDAPFilterSearch=(empty($sarguser['ldap_filter_search'])?"":"LDAPFilterSearch ".$sarguser['ldap_filter_search']);
-		}
-		
-		
-	#move old reports
-	if (is_dir("/usr/local/www/sarg-reports") && !is_dir("/usr/local/sarg-reports"))
-		rename("/usr/local/www/sarg-reports","/usr/local/sarg-reports");
-
-	#check dirs
-	$dirs=array("/usr/local/sarg-reports","/usr/local/www/sarg-images","/usr/local/www/sarg-images/temp");
-		foreach ($dirs as $dir)
-		if (!is_dir($dir))
-			mkdir ($dir,0755,true);
-			
-	#images
-	$simages=array("datetime.png","graph.png","sarg-squidguard-block.png","sarg.png");
-	$simgdir1="/usr/local/www/sarg-images";
-	$simgdir2= SARG_DIR . "/etc/sarg/images";
-	foreach ($simages as $simage){
-		if (!file_exists("{$simgdir1}/{$simage}"))
-			copy("{$simgdir2}/{$simage}","{$simgdir1}/{$simage}");
+	// general tab
+	$graphs = (preg_match('/use_graphs/', $sarg['report_options']) ? "yes" : "no");
+	$anonymous_output_files = (preg_match('/anonymous_output_files/', $sarg['report_options']) ? "yes" : "no");
+	$resolve_ip = (preg_match('/resolve_ip/', $sarg['report_options']) ? "yes" : "no");
+	$user_ip = (preg_match('/user_ip/', $sarg['report_options']) ? "yes" : "no");
+	$sort_order = (preg_match('/user_sort_field_order/', $sarg['report_options']) ? "reverse" : "normal");
+	$remove_temp_files = (preg_match('/remove_temp_files/', $sarg['report_options']) ? "yes" : "no");
+	$main_index = (preg_match('/main_index/', $sarg['report_options']) ? "yes" : "no");
+	$index_tree = (preg_match('/index_tree/', $sarg['report_options']) ? "file" : "date");
+	$overwrite_report = (preg_match('/overwrite_report/', $sarg['report_options']) ? "yes" : "no");
+	$use_comma = (preg_match('/use_comma/', $sarg['report_options']) ? "yes" : "no");
+	$long_url = (preg_match('/long_url/', $sarg['report_options']) ? "yes" : "no");
+	$privacy = (preg_match('/privacy/', $sarg['report_options']) ? "yes" : "no");
+	$displayed_values = (preg_match('/displayed_values/', $sarg['report_options']) ? "abbreviation" : "bytes");
+	$bytes_in_sites_users_report = (preg_match('/bytes_in_sites_users_report/', $sarg['report_options']) ? "yes" : "no");
+	$date_time_by = (preg_match('/date_time_by_bytes/', $sarg['report_options']) ? "bytes" : "");
+	$date_time_by .= (preg_match('/date_time_by_elap/', $sarg['report_options']) ? " elap" : "");
+	if (empty($date_time_by)) {
+		$date_time_by = "bytes";
 	}
-			
-	//log_error($_POST['__csrf_magic']." sarg log:". $access_log);
-	#create sarg config files
-	$sarg_dir= SARG_DIR;
-	include("/usr/local/pkg/sarg.template");
-	file_put_contents( SARG_DIR . "/etc/sarg/sarg.conf", $sg, LOCK_EX);
-	file_put_contents( SARG_DIR . '/etc/sarg/exclude_hosts.conf', sarg_text_area_decode($sarg['exclude_hostlist']),LOCK_EX);
-	file_put_contents( SARG_DIR . '/etc/sarg/exclude_codes', sarg_text_area_decode($sarg['exclude_codelist']),LOCK_EX);
-	file_put_contents( SARG_DIR . '/etc/sarg/hostalias',sarg_text_area_decode($sarg['hostalias']),LOCK_EX);
-	file_put_contents( SARG_DIR . '/etc/sarg/exclude_users.conf', sarg_text_area_decode($sarguser['exclude_userlist']),LOCK_EX);
-	#check cron_tab
-	$new_cron=array();
-	$cron_found=0;
-	if (is_array($config['cron']['item']))
-		foreach($config['cron']['item'] as $cron){
-			if (preg_match("/usr.local.www.sarg.php/",$cron["command"]))
-				$cron_found++;
-			else
-				$new_cron['item'][]=$cron;
-			}
-		$cron_cmd="/usr/local/bin/php --no-header /usr/local/www/sarg.php";
-		$sarg_schedule_id=0;
-		if (is_array($config['installedpackages']['sargschedule']['config']))
-			foreach ($config['installedpackages']['sargschedule']['config'] as $sarg_schedule){
-	 			if(preg_match('/(\d+)m/',$sarg_schedule['frequency'],$matches) && $sarg_schedule['enable']){
-					$new_cron['item'][]=array(	"minute" =>	"*/".$matches[1],
-												"hour"	 =>	"*",
-												"mday" 	 =>	"*",
-												"month"  =>	"*",
-												"wday"	 =>	"*",
-												"who"	 =>	"root",
-												"command"=>	$cron_cmd." ".$sarg_schedule_id);
-					$config['cron']=$new_cron;
-					$cron_found++;
-					}
-			  	if(preg_match('/(\d+)h/',$sarg_schedule['frequency'],$matches) && $sarg_schedule['enable']){
-					$new_cron['item'][]=array(	"minute" =>	"0",
-												"hour"	 =>	"*/".$matches[1],
-												"mday" 	 =>	"*",
-												"month"  =>	"*",
-												"wday"	 =>	"*",
-												"who"	 =>	"root",
-												"command"=>	$cron_cmd." ".$sarg_schedule_id);
-					$config['cron']=$new_cron;
-					$cron_found++;
-		  			}
-		  		if(preg_match('/(\d+)d/',$sarg_schedule['frequency'],$matches) && $sarg_schedule['enable']){
-					$new_cron['item'][]=array(	"minute" =>	"0",
-												"hour"	 =>	"0",
-												"mday" 	 =>	"*/".$matches[1],
-												"month"  =>	"*",
-												"wday"	 =>	"*",
-												"who"	 =>	"root",
-												"command"=>	$cron_cmd." ".$sarg_schedule_id);
-					$config['cron']=$new_cron;
-					$cron_found++;
-			  		}
-			  	$sarg_schedule_id++;
-			 	}
+	$date_format = (preg_match("/\w/", $sarg['report_date_format']) ? $sarg['report_date_format'] : "u");
+	$report_type = preg_replace('/,/', ' ', $sarg['report_type']);
+	$report_charset = $sarg['report_charset'] ?: "UTF-8";
+	$exclude_string = (empty($sarg['exclude_string']) ? "" : 'exclude_string "' . $sarg['exclude_string'] . '"');
 
-	#update cron
-	if ($cron_found > 0){
-		$config['cron']=$new_cron;
-		write_config();
-		configure_cron();
+	// limits
+	$max_elapsed = $sarg['max_elapsed'] ?: "0";
+	$lastlog = $sarg['lastlog'] ?: "0";
+	$topuser_num = $sarg['topuser_num'] ?: "0";
+	$authfail_report_limit = $sarg['authfail_report_limit'] ?: "0";
+	$denied_report_limit = $sarg['denied_report_limit'] ?: "0";
+	$report_limit = $sarg['user_report_limit'] ?: "0";
+	$user_report_limit = "siteusers_report_limit " . $report_limit . "\n";
+	$user_report_limit .= "user_report_limit " . $report_limit . "\n";
+	if (preg_match("/(squidguard|dansguardian)/", $sarg['proxy_server'])) {
+		$user_report_limit .= $sarg['proxy_server'] . "_report_limit " . $report_limit . "\n";
+	}
+
+	// user tab
+	$ntlm_user_format = $sarguser['ntlm_user_format'] ?: 'domainname+username';
+	if (!empty($sarguser['include_userlist'])) {
+		$include_users = "$include_users " . $sarguser['include_userlist'];
+	}
+	if (empty($sarguser['usertab'])) {
+		$usertab="none";
+	} else {
+		$usertab = SARG_DIR . "/etc/sarg/usertab.conf";
+		file_put_contents(SARG_DIR . '/etc/sarg/usertab.conf', sarg_text_area_decode($sarguser['usertab']), LOCK_EX);
+	}
+	if ($sarguser['ldap_enable']) {
+		$usertab = "ldap";
+		$LDAPHost = (empty($sarguser['ldap_host']) ? "" : "LDAPHost " . $sarguser['ldap_host']);
+		$LDAPort = (empty($sarguser['ldap_port']) ? "" : "LDAPPort " . $sarguser['ldap_port']);
+		$LDAPBindDN = (empty($sarguser['ldap_bind_dn']) ? "" : "LDAPBindDN " . $sarguser['ldap_bind_dn']);
+		$LDAPBindPW = (empty($sarguser['ldap_bind_pw']) ? "" : "LDAPBindPW " . $sarguser['ldap_bind_pw']);
+		$LDAPBaseSearch = (empty($sarguser['ldap_base_search']) ? "" : "LDAPBaseSearch " . $sarguser['ldap_base_search']);
+		$LDAPTargetAttr = (empty($sarguser['ldap_target_Attr']) ? "" : "LDAPTargetAttr " . $sarguser['ldap_target_Attr']);
+		$LDAPFilterSearch = (empty($sarguser['ldap_filter_search']) ? "" : "LDAPFilterSearch " . $sarguser['ldap_filter_search']);
+	}
+
+	// move old reports
+	if (is_dir("/usr/local/www/sarg-reports") && !is_dir("/usr/local/sarg-reports")) {
+		rename("/usr/local/www/sarg-reports","/usr/local/sarg-reports");
+	}
+
+	// check dirs
+	$dirs = array("/usr/local/sarg-reports", "/usr/local/www/sarg-images", "/usr/local/www/sarg-images/temp");
+	foreach ($dirs as $dir) {
+		if (!is_dir($dir)) {
+			mkdir($dir, 0755, true);
 		}
-	#Write config if any file from filesystem was loaded
-	if ($update_conf > 0)
+	}
+
+	// images
+	$simages = array("datetime.png", "graph.png", "sarg-squidguard-block.png", "sarg.png");
+	$simgdir1 = "/usr/local/www/sarg-images";
+	$simgdir2 = SARG_DIR . "/etc/sarg/images";
+	foreach ($simages as $simage) {
+		if (!file_exists("{$simgdir1}/{$simage}")) {
+			copy("{$simgdir2}/{$simage}","{$simgdir1}/{$simage}");
+		}
+	}
+
+	// create sarg config files
+	$sarg_dir = SARG_DIR;
+	include("/usr/local/pkg/sarg.template");
+	file_put_contents(SARG_DIR . "/etc/sarg/sarg.conf", $sg, LOCK_EX);
+	file_put_contents(SARG_DIR . '/etc/sarg/exclude_hosts.conf', sarg_text_area_decode($sarg['exclude_hostlist']), LOCK_EX);
+	file_put_contents(SARG_DIR . '/etc/sarg/exclude_codes', sarg_text_area_decode($sarg['exclude_codelist']), LOCK_EX);
+	file_put_contents(SARG_DIR . '/etc/sarg/hostalias',sarg_text_area_decode($sarg['hostalias']), LOCK_EX);
+	file_put_contents(SARG_DIR . '/etc/sarg/exclude_users.conf', sarg_text_area_decode($sarguser['exclude_userlist']), LOCK_EX);
+
+	// check cron_tab
+	// TODO: Redo this mess to use install_cron_job() instead
+	$new_cron = array();
+	$cron_found = 0;
+	if (is_array($config['cron']['item'])) {
+		foreach($config['cron']['item'] as $cron) {
+			if (preg_match("/usr.local.www.sarg.php/", $cron["command"])) {
+				$cron_found++;
+			} else {
+				$new_cron['item'][] = $cron;
+			}
+		}
+		$cron_cmd="/usr/local/bin/php --no-header /usr/local/www/sarg.php";
+		$sarg_schedule_id = 0;
+		if (is_array($config['installedpackages']['sargschedule']['config'])) {
+			foreach ($config['installedpackages']['sargschedule']['config'] as $sarg_schedule) {
+	 			if (preg_match('/(\d+)m/', $sarg_schedule['frequency'], $matches) && $sarg_schedule['enable']) {
+					$new_cron['item'][] = array("minute" => "*/" . $matches[1],
+									"hour" => "*",
+									"mday" => "*",
+									"month" => "*",
+									"wday" => "*",
+									"who" => "root",
+									"command" => $cron_cmd . " " . $sarg_schedule_id);
+					$config['cron'] = $new_cron;
+					$cron_found++;
+				}
+				if (preg_match('/(\d+)h/', $sarg_schedule['frequency'], $matches) && $sarg_schedule['enable']) {
+					$new_cron['item'][] = array("minute" => "0",
+									"hour" => "*/" . $matches[1],
+									"mday" => "*",
+									"month" => "*",
+									"wday" => "*",
+									"who" => "root",
+									"command" => $cron_cmd . " " . $sarg_schedule_id);
+					$config['cron'] = $new_cron;
+					$cron_found++;
+				}
+				if (preg_match('/(\d+)d/', $sarg_schedule['frequency'], $matches) && $sarg_schedule['enable']) {
+					$new_cron['item'][] = array("minute" =>	"0",
+									"hour" => "0",
+									"mday" => "*/" . $matches[1],
+									"month" => "*",
+									"wday" => "*",
+									"who" => "root",
+									"command"=>	$cron_cmd . " " . $sarg_schedule_id);
+					$config['cron']=$new_cron;
+					$cron_found++;
+				}
+				$sarg_schedule_id++;
+			}
+		}
+
+		// update cron
+		if ($cron_found > 0) {
+			$config['cron'] = $new_cron;
+			write_config();
+			configure_cron();
+		}
+	}
+
+	// write config if any file from filesystem was loaded
+	if ($update_conf > 0) {
 		write_config();
-		
-	#mount filesystem readonly
+	}
+
+	// mount filesystem readonly
 	conf_mount_ro();
-	
+
 	sarg_sync_on_changes();
 }
 
 function sarg_validate_input($post, &$input_errors) {
-	global $config,$g;
+	global $config, $g;
 	foreach ($post as $key => $value) {
-		if (empty($value))
+		if (empty($value)) {
 			continue;
-		# check dansguardian
-		if (substr($key, 0, 12) == "proxy_server" && $value == "dansguardian"){
-			if (is_array($config['installedpackages']['dansguardianlog'])){
-				if ($config['installedpackages']['dansguardianlog']['config'][0]['logfileformat']!=3){
-					$input_errors[]='Sarg is only compatible with dansguardian log squid mode';
-					$input_errors[]='Please change it on service -> dansguarian -> report and log -> log file format';
+		}
+		// check dansguardian
+		if (substr($key, 0, 12) == "proxy_server" && $value == "dansguardian") {
+			if (is_array($config['installedpackages']['dansguardianlog'])) {
+				if ($config['installedpackages']['dansguardianlog']['config'][0]['logfileformat'] != 3) {
+					$input_errors[] = 'Sarg is only compatible with dansguardian squid mode log';
+					$input_errors[] = 'Please change it on Services -> Dansguardian -> Report and log -> Log file format';
 				}
-			}
-			else
+			} else {
 				$input_errors[]='dansguardian package not detected';
 			}
+		}
 
 		# check squidguard
 		if (substr($key, 0, 10) == "proxy_server" && $value == "squidguard")
 			if (!is_array($config['installedpackages']['squidguardgeneral']))
 				$input_errors[]='squidguard package not detected';
 
-		# check squid		
-		if (substr($key, 0, 5) == "proxy_server" && $value == "squid"){
-			if (is_array($config['installedpackages']['squid']))
-				if (!$config['installedpackages']['squid']['log_enabled'])
+		# check squid
+		if (substr($key, 0, 5) == "proxy_server" && $value == "squid") {
+			if (is_array($config['installedpackages']['squid'])) {
+				if (!$config['installedpackages']['squid']['log_enabled']) {
 					$input_errors[]='squidlogs not enabled';
-			else
-				$input_errors[]='squid package not installed';
 				}
-			
-		if (substr($key, 0, 11) == "description" && !preg_match("@^[a-zA-Z0-9 _/.-]+$@", $value))
-				$input_errors[] = "Do not use special characters on description";
-		if (substr($key, 0, 8) == "fullfile" && !preg_match("@^[a-zA-Z0-9_/.-]+$@", $value))
-				$input_errors[] = "Do not use special characters on filename";
-		#check cron option
-		if($key == "frequency" && (!preg_match("/^\d+(h|m|d)$/",$value) || $value == 0))
-				$input_errors[] = "A valid number with a time reference is required for the field 'Update Frequency'";		
+			} else {
+				$input_errors[]='squid package not installed';
+			}
+		}
+
+		if (substr($key, 0, 11) == "description" && !preg_match("@^[a-zA-Z0-9 _/.-]+$@", $value)) {
+			$input_errors[] = "Do not use special characters in description";
+		}
+		if (substr($key, 0, 8) == "fullfile" && !preg_match("@^[a-zA-Z0-9_/.-]+$@", $value)) {
+			$input_errors[] = "Do not use special characters in filename";
+		}
+		// check cron option
+		if ($key == "frequency" && (!preg_match("/^\d+(h|m|d)$/", $value) || $value == 0)) {
+			$input_errors[] = "A valid number with a time reference is required for the field 'Update Frequency'";
+		}
 	}
 }
 
 /* Uses XMLRPC to synchronize the changes to a remote node */
 function sarg_sync_on_changes() {
 	global $config, $g;
-	if (is_array($config['installedpackages']['sargsync']['config'])){
-		$sarg_sync=$config['installedpackages']['sargsync']['config'][0];
+	if (is_array($config['installedpackages']['sargsync']['config'])) {
+		$sarg_sync = $config['installedpackages']['sargsync']['config'][0];
 		$synconchanges = $sarg_sync['synconchanges'];
 		$synctimeout = $sarg_sync['synctimeout'];
-		switch ($synconchanges){
+		switch ($synconchanges) {
 			case "manual":
-				if (is_array($sarg_sync[row])){
-					$rs=$sarg_sync[row];
-					}
-				else{
+				if (is_array($sarg_sync[row])) {
+					$rs = $sarg_sync[row];
+				} else {
 					log_error("[sarg] xmlrpc sync is enabled but there is no hosts to push on sarg config.");
 					return;
-					}
+				}
 				break;
 			case "auto":
-					if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])){
-						$system_carp=$config['installedpackages']['carpsettings']['config'][0];
-						$rs[0]['ipaddress']=$system_carp['synchronizetoip'];
-						$rs[0]['username']=$system_carp['username'];
-						$rs[0]['password']=$system_carp['password'];
-						if ($system_carp['synchronizetoip'] =="" || $system_carp['username']==""){
-							log_error("[sarg] xmlrpc sync is enabled but there is no system backup hosts to push sarg config.");
-							return;
-						}
-						
-					}
-					else{
-						log_error("[sarg] xmlrpc sync is enabled but there is no system backup hosts to push sarg config.");
+				if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])) {
+					$system_carp = $config['installedpackages']['carpsettings']['config'][0];
+					$rs[0]['ipaddress'] = $system_carp['synchronizetoip'];
+					$rs[0]['username'] = $system_carp['username'];
+					$rs[0]['password'] = $system_carp['password'];
+					if ($system_carp['synchronizetoip'] == "" || $system_carp['username'] == "") {
+						log_error("[sarg] xmlrpc sync is enabled but there are no system backup hosts to push sarg config.");
 						return;
 					}
-				break;			
+
+				} else {
+					log_error("[sarg] xmlrpc sync is enabled but there are no system backup hosts to push sarg config.");
+					return;
+				}
+				break;
 			default:
 				return;
 			break;
 		}
-		if (is_array($rs)){
+		if (is_array($rs)) {
 			log_error("[sarg] xmlrpc sync is starting.");
-			foreach($rs as $sh){
+			foreach($rs as $sh) {
 				$sync_to_ip = $sh['ipaddress'];
 				$password = $sh['password'];
-				if($sh['username'])
+				if ($sh['username']) {
 					$username = $sh['username'];
-				else
+				} else {
 					$username = 'admin';
-				if($password && $sync_to_ip)
+				}
+				if ($password && $sync_to_ip) {
 					sarg_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout);
 				}
-			log_error("[sarg] xmlrpc sync is ending.");
 			}
- 		}
+			log_error("[sarg] xmlrpc sync is ending.");
+		}
+ 	}
 }
 
-/* Do the actual XMLRPC sync */
+/* do the actual XMLRPC sync */
 function sarg_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout) {
 	global $config, $g;
 
-	if(!$username)
+	if (!$username) {
 		return;
-		
-	if(!$password)
-		return;
+	}
 
-	if(!$sync_to_ip)
+	if (!$password) {
 		return;
-		
-	if(!$synctimeout)
-		$synctimeout="150";
-		
+	}
+
+	if (!$sync_to_ip) {
+		return;
+	}
+
+	if (!$synctimeout) {
+		$synctimeout="250";
+	}
+
 	$xmlrpc_sync_neighbor = $sync_to_ip;
-    if($config['system']['webgui']['protocol'] != "") {
+
+	if ($config['system']['webgui']['protocol'] != "") {
 		$synchronizetoip = $config['system']['webgui']['protocol'];
 		$synchronizetoip .= "://";
-    }
-    $port = $config['system']['webgui']['port'];
-    /* if port is empty lets rely on the protocol selection */
-    if($port == "") {
-		if($config['system']['webgui']['protocol'] == "http") 
+	}
+	$port = $config['system']['webgui']['port'];
+	/* if port is empty, let's rely on the protocol selection */
+	if ($port == "") {
+		if ($config['system']['webgui']['protocol'] == "http") {
 			$port = "80";
-		else 
+		} else {
 			$port = "443";
-    }
+		}
+	}
 	$synchronizetoip .= $sync_to_ip;
 
 	/* xml will hold the sections to sync */
@@ -547,22 +564,23 @@ function sarg_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout) {
 		XML_RPC_encode($xml)
 	);
 
-	/* set a few variables needed for sync code borrowed from filter.inc */
+	/* set a few variables needed for sync code */
 	$url = $synchronizetoip;
 	log_error("Beginning sarg XMLRPC sync to {$url}:{$port}.");
 	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
-	if($g['debug'])
+	if ($g['debug']) {
 		$cli->setDebug(1);
+	}
 	/* send our XMLRPC message and timeout after $synctimeout seconds */
 	$resp = $cli->send($msg, $synctimeout);
-	if(!$resp) {
+	if (!$resp) {
 		$error = "A communications error occurred while attempting sarg XMLRPC sync with {$url}:{$port}.";
 		log_error($error);
 		file_notice("sync_settings", $error, "sarg Settings Sync", "");
-	} elseif($resp->faultCode()) {
+	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, $synctimeout);
 		$error = "An error code was received while attempting sarg XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
@@ -571,27 +589,27 @@ function sarg_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout) {
 	} else {
 		log_error("sarg XMLRPC sync successfully completed with {$url}:{$port}.");
 	}
-	
+
 	/* tell sarg to reload our settings on the destionation sync host. */
 	$method = 'pfsense.exec_php';
-	$execcmd  = "require_once('/usr/local/pkg/sarg.inc');\n";
+	$execcmd = "require_once('/usr/local/pkg/sarg.inc');\n";
 	$execcmd .= "sync_package_sarg();";
 	/* assemble xmlrpc payload */
 	$params = array(
 		XML_RPC_encode($password),
 		XML_RPC_encode($execcmd)
 	);
-	
+
 	log_error("sarg XMLRPC reload data {$url}:{$port}.");
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
 	$resp = $cli->send($msg, $synctimeout);
-	if(!$resp) {
+	if (!$resp) {
 		$error = "A communications error occurred while attempting sarg XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
 		log_error($error);
 		file_notice("sync_settings", $error, "sarg Settings Sync", "");
-	} elseif($resp->faultCode()) {
+	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, $synctimeout);
 		$error = "An error code was received while attempting sarg XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
@@ -600,15 +618,6 @@ function sarg_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout) {
 	} else {
 		log_error("sarg XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
 	}
-	
-}
-
-function sarg_php_install_command() {
-	sync_package_sarg();
-}
-
-function sarg_php_deinstall_command() {
-	// reserved
 }
 
 ?>

--- a/config/sarg/sarg.php
+++ b/config/sarg/sarg.php
@@ -1,50 +1,45 @@
 <?php
-/* $Id$ */
-/* ========================================================================== */
 /*
-    sarg.php
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2012 Marcello Coutinho
-    
-    All rights reserved.                                                      
+	sarg.php
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
-/* ========================================================================== */
-/*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
-
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
-
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-
 require_once("/etc/inc/util.inc");
 require_once("/etc/inc/functions.inc");
 require_once("/etc/inc/pkg-utils.inc");
 require_once("/etc/inc/globals.inc");
 require_once("/usr/local/pkg/sarg.inc");
 
-$uname=posix_uname();
-if ($uname['machine']=='amd64')
-        ini_set('memory_limit', '250M');
+$uname = posix_uname();
+if ($uname['machine'] == 'amd64') {
+	ini_set('memory_limit', '250M');
+}
 
-if (preg_match ("/(\d+)/",$argv[1],$matches))
+if (preg_match("/(\d+)/", $argv[1], $matches)) {
 	run_sarg($matches[1]);
+}
 
-	
 ?>

--- a/config/sarg/sarg.priv.inc
+++ b/config/sarg/sarg.priv.inc
@@ -4,7 +4,7 @@ global $priv_list;
 
 $priv_list['page-status-sarg-reports'] = array();
 $priv_list['page-status-sarg-reports']['name'] = "WebCfg - Status: Sarg reports";
-$priv_list['page-status-sarg-reports']['descr'] = "Allow access to sarg reports page.";
+$priv_list['page-status-sarg-reports']['descr'] = "Allow access to Sarg reports page.";
 $priv_list['page-status-sarg-reports']['match'] = array();
 $priv_list['page-status-sarg-reports']['match'][] = "sarg_reports.php*";
 $priv_list['page-status-sarg-reports']['match'][] = "sarg_frame.php*";

--- a/config/sarg/sarg.template
+++ b/config/sarg/sarg.template
@@ -1,8 +1,9 @@
 <?php
 /*
-	sag.template
-	part of the Dansguardian package for pfSense
-	Copyright (C) 2012 Marcello Coutinho
+	sarg.template
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Marcello Coutinho <marcellocoutinho@gmail.com>
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -25,11 +26,9 @@
 	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
-
 */
-
-#create sarg.conf
-	$sg=<<<EOF
+// create sarg.conf
+	$sg = <<<EOF
 # sarg.conf
 #
 # TAG:  access_log file
@@ -39,7 +38,7 @@
 access_log {$access_log}
 
 # TAG: graphs yes|no
-#	Use graphics where is possible.
+#	Use graphics where possible.
 #           graph_days_bytes_bar_color blue|green|yellow|orange|brown|red
 #
 graphs {$graphs}
@@ -52,37 +51,37 @@ graphs {$graphs}
 #graph_font /usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf
 
 # TAG:	title
-# 	Especify the title for html page.
+# 	Specify the title for html page.
 #
 #title "Squid User Access Reports"
 
 # TAG:	font_face
-# 	Especify the font for html page.
+# 	Specify the font for html page.
 #
 #font_face Tahoma,Verdana,Arial
 
 # TAG:	header_color
-# 	Especify the header color
+# 	Specify the header color
 #
 #header_color darkblue
 
 # TAG:	header_bgcolor
-# 	Especify the header bgcolor
+# 	Specify the header bgcolor
 #
 #header_bgcolor blanchedalmond
 
 # TAG:	font_size
-# 	Especify the text font size
+# 	Specify the text font size
 #
 #font_size 9px
 
 # TAG:	header_font_size
-# 	Especify the header font size
+# 	Specify the header font size
 #
 #header_font_size 9px
 
 # TAG:	title_font_size
-# 	Especify the title font size
+# 	Specify the title font size
 #
 #title_font_size 11px
 
@@ -135,7 +134,7 @@ graphs {$graphs}
 
 # TAG:  password
 #       User password file used by Squid authentication scheme
-#       If used, generate reports just for that users.
+#       If used, generate reports just for those users.
 #
 #password none
 
@@ -153,7 +152,7 @@ output_dir /usr/local/sarg-reports
 
 # TAG:  anonymous_output_files yes/no
 #       Use anonymous file and directory names in the report. If it is set to
-#       no (the default), the user id/ip/name is slightly mangled to create a
+#       no (the default), the user ID/IP/name is slightly mangled to create a
 #       suitable file name to store the report of the user but the user's
 #       identity can easily be guessed from the mangled name. If this option is
 #       set, any file or directory belonging to the user is replaced by a short
@@ -169,12 +168,12 @@ anonymous_output_files {$anonymous_output_files}
 #output_email none
 
 # TAG:  resolve_ip yes/no
-#       Convert ip address to dns name
+#       Convert IP address to DNS name
 #       sarg -n
 resolve_ip {$resolve_ip}
 
 # TAG:  user_ip yes/no
-#       Use Ip Address instead userid in reports.
+#       Use IP address instead of userid in reports.
 #       sarg -p
 user_ip {$user_ip}
 
@@ -192,22 +191,22 @@ user_sort_field {$sarguser['user_sort_field']} {$sort_order}
 
 # TAG:  exclude_users file
 #       users within the file will be excluded from reports.
-#       you can use indexonly to have only index.html file.
+#       You can use indexonly to have only index.html file.
 #
 exclude_users {$sarg_dir}/etc/sarg/exclude_users.conf
 
 # TAG:  exclude_hosts file
 #       Hosts, domains or subnets will be excluded from reports.
 #
-#       Eg.: 192.168.10.10   - exclude ip address only
-#            192.168.10.0/24 - exclude full C class
-#            s1.acme.foo     - exclude hostname only
-#            *.acme.foo      - exclude full domain name
+#       Eg.: 192.168.10.10 - exclude this IP address only
+#            192.168.10.0/24 - exclude entire subnet
+#            host1.example.com - exclude this hostname only
+#            *.example.com - exclude entire domain
 #
 exclude_hosts {$sarg_dir}/etc/sarg/exclude_hosts.conf
 
 # TAG:  useragent_log file
-#       useragent.log file patch to generate useragent report.
+#       useragent.log file path to generate useragent report.
 #
 #useragent_log none
 
@@ -219,12 +218,12 @@ date_format {$date_format}
 
 # TAG:  per_user_limit file MB
 #       Saves userid on file if download exceed n MB.
-#       This option allow you to disable user access if user exceed a download limit.
+#       This option allows you to disable user access if user exceeds a download limit.
 #
 #per_user_limit none
 
 # TAG: lastlog n
-#      How many reports files must be kept in reports directory.
+#      How many reports files will be kept in reports directory.
 #      The oldest report file will be automatically removed.
 #      0 - no limit.
 #
@@ -232,7 +231,7 @@ date_format {$date_format}
 lastlog {$lastlog}
 
 # TAG: remove_temp_files yes
-#      Remove temporary files: geral, usuarios, top, periodo from root report directory.
+#      Remove temporary files from root report directory.
 #
 remove_temp_files {$remove_temp_files}
 
@@ -254,8 +253,8 @@ index_tree {$index_tree}
 #index_fields dirsize
 
 # TAG: overwrite_report yes|no
-#      yes - if report date already exist then will be overwrited.
-#       no - if report date already exist then will be renamed to filename.n, filename.n+1
+#      yes - if report date already exist it will be overwrited.
+#       no - if report date already exist it will be renamed to filename.n, filename.n+1
 #
 overwrite_report {$overwrite_report}
 
@@ -263,13 +262,13 @@ overwrite_report {$overwrite_report}
 #      What can I do with records without user id (no authentication) in access.log file ?
 #
 #      ignore - This record will be ignored.
-#          ip - Use ip address instead. (default)
+#          ip - Use IP address instead. (default)
 #   everybody - Use "everybody" instead.
 #
 #records_without_userid ip
 
 # TAG: use_comma no|yes
-#      Use comma instead point in reports.
+#      Use comma instead of dot in reports.
 #      Eg.: use_comma yes => 23,450,110
 #           use_comma no  => 23.450.110
 #
@@ -283,7 +282,7 @@ use_comma {$use_comma}
 #      here.
 #
 #      If you need too, you can use a shell script to process the content of /dev/stdin
-#      (/dev/stdin is the mail_content passed by sarg to the script) and call whatever
+#      (/dev/stdin is the mail_content passed by Sarg to the script) and call whatever
 #      command you like. It is not limited to mailing the report via SMTP.
 #
 #      Don't forget to quote the command if necessary (i.e. if the path contains
@@ -297,17 +296,17 @@ use_comma {$use_comma}
 #topsites_num 100
 
 # TAG: topsites_sort_order CONNECT|BYTES|TIME A|D
-#      Sort for topsites report, where A=Ascendent, D=Descendent
+#      Sort for topsites report, where A=Ascending, D=Descending
 #
 #topsites_sort_order CONNECT D
 
 # TAG: index_sort_order A/D
-#      Sort for index.html, where A=Ascendent, D=Descendent
+#      Sort for index.html, where A=Ascending, D=Descending
 #
 #index_sort_order D
 
 # TAG: exclude_codes file
-#      Ignore records with these codes. Eg.: NONE/400
+#      Ignore records with these Squid return codes. Eg.: NONE/400
 #      Write one code per line. Lines starting with a # are ignored.
 #      Only codes matching exactly one of the line is rejected. The
 #      comparison is not case sensitive.
@@ -316,12 +315,12 @@ exclude_codes {$sarg_dir}/etc/sarg/exclude_codes
 
 # TAG: replace_index string
 #      Replace "index.html" in the main index file with this string
-#      If null "index.html" is used
+#      If null, "index.html" is used
 #
 #replace_index <?php echo str_replace(".", "_", $REMOTE_ADDR); echo ".html"; ?>
 
 # TAG: max_elapsed milliseconds
-#      If elapsed time is recorded in log is greater than max_elapsed use 0 for elapsed time.
+#      If elapsed time recorded in log is greater than max_elapsed, use 0 for elapsed time.
 #      Use 0 for no checking
 #
 #max_elapsed 28800000
@@ -330,7 +329,7 @@ max_elapsed {$max_elapsed}
 
 # TAG: report_type type
 #      What kind of reports to generate.
-#      topusers            - users, sites, times, bytes, connects, links to accessed sites, etc
+#      topusers            - users, sites, times, bytes, connects, links to accessed sites, etc.
 #      topsites		   - site, connect and bytes report
 #      sites_users	   - users and sites report
 #      users_sites	   - accessed sites by the user report
@@ -346,12 +345,12 @@ max_elapsed {$max_elapsed}
 report_type {$report_type}
 
 # TAG: usertab filename
-#      You can change the "userid" or the "ip address" to be a real user name on the reports.
-#      If resolve_ip is active, the ip address is resolved before being looked up into this
-#      file. That is, if you want to map the ip address, be sure to set resolv_ip to no or
-#      the resolved name will be looked into the file instead of the ip address. Note that
-#      it can be used to resolve any ip address known to the dns and then map the unresolved
-#      ip addresses to a name found in the usertab file.
+#      You can change the "userid" or the "IP address" to be a real user name on the reports.
+#      If resolve_ip is active, the IP address is resolved before being looked up in this
+#      file. That is, if you want to map the ip address, be sure to set resolve_ip to no or
+#      the resolved name will be looked up in the file instead of the IP address. Note that
+#      it can be used to resolve any IP address known to the DNS and then map the unresolved
+#      IP addresses to a name found in the usertab file.
 #      Table syntax:
 # 		userid name   or   ip address name
 #      Eg:
@@ -360,9 +359,9 @@ report_type {$report_type}
 #		192.168.10.1 Karol Wojtyla
 #
 #      Each line must be terminated with '\ n'
-#      If usertab have value "ldap" (case ignoring), user names
-#      will be taken from LDAP server. This method as approaches for reception
-#      of usernames from Active Didectory
+#      If usertab is set to value "ldap" (case ignored), user names
+#      will be taken from LDAP server. Use this method to obtain usernames
+#      LDAP / Active Directory.
 #
 #usertab none
 usertab {$usertab}
@@ -380,34 +379,35 @@ usertab {$usertab}
 {$LDAPPort}
 
 # TAG: LDAPBindDN CN=username,OU=group,DC=mydomain,DC=com
-#	DN of LDAP user, who is authorized to read user's names from LDAP base
+#	DN of the LDAP user who is authorized to the search the LDAP database
 #	default is empty line
 #LDAPBindDN cn=proxy,dc=mydomain,dc=local
 {$LDAPBindDN}
 
 # TAG: LDAPBindPW secret
-#	Password of DN, who is authorized to read user's names from LDAP base
+#	Password for LDAPBindDN specified above.
 #	default is empty line
 #LDAPBindPW secret
 {$LDAPBindPW}
 
 # TAG: LDAPBaseSearch OU=users,DC=mydomain,DC=com
-#	LDAP search base
+#	LDAP search base DN. The search base is the place in the hierarchical LDAP structure
+#       where the search for user accounts starts.
 #	default is empty line
 #LDAPBaseSearch ou=users,dc=mydomain,dc=local
 {$LDAPBaseSearch}
 
 # TAG: LDAPFilterSearch (uid=%s)
-#	User search filter by user's logins in LDAP
+#	Use this to filter the user login entries to be returned for a search operation in LDAP.
 #	First founded record will be used
 #	%s - will be changed to userlogins from access.log file
-#       filter string can have up to 5 '%s' tags
+#       Search filter string can have up to 5 '%s' tags.
 #	default value is '(uid=%s)'
 #LDAPFilterSearch (uid=%s)
 {$LDAPFilterSearch}
 
 # TAG: LDAPTargetAttr attributename
-#	Name of the attribute containing a name of the user
+#	Name of the attribute containing the login name of the user.
 #	default value is 'cn'
 #LDAPTargetAttr cn
 {$LDAPTargetAttr}
@@ -431,15 +431,15 @@ date_time_by {$date_time_by}
 #      graphic character sets for writing in alphabetic languages
 #      You can use the following charsets:
 #		Latin1 		- West European
-#		Latin2 		- East European
-#		Latin3 		- South European
-#		Latin4 		- North European
+#		Latin2 		- Central and East European
+#		Latin3 		- Southeast European
+#		Latin4 		- Scandinavian/Baltic
 #		Cyrillic
 #		Arabic
 #		Greek
 #		Hebrew
 #		Latin5 		- Turkish
-#		Latin6
+#		Latin6          - Lappish/Nordic/Eskimo
 #		Windows-1251
 #		Japan
 #		Koi8-r
@@ -457,7 +457,7 @@ charset {$report_charset}
 #      privacy_string "***.***.***.***"
 #      privacy_string_color blue
 #      In some countries the sysadm cannot see the visited sites by a restrictive law.
-#      Using privacy yes the visited url will be changes by privacy_string and the link
+#      Using privacy 'yes', the visited url will be changes by privacy_string and the link
 #      will be removed from reports.
 #
 privacy {$privacy}
@@ -525,7 +525,7 @@ topuser_num {$topuser_num}
 {$datafile_fields}
 
 # TAG: datafile_url ip|name
-#      Saves the URL as ip or name in datafile
+#      Saves the URL as IP or name in datafile
 #
 #datafile_url ip
 
@@ -552,8 +552,8 @@ topuser_num {$topuser_num}
 dansguardian_conf {$dansguardian_conf}
 
 # TAG: dansguardian_filter_out_date on|off
-#      This option replaces dansguardian_ignore_date whose name was not appropriate with respect to its action.
-#      Note the change of parameter value compared with the old option.
+#      This option replaces dansguardian_ignore_date (its name was not appropriate with respect to its action).
+#      Note the change of parameter value compared to the old option.
 #      'off' use the record even if its date is outside of the range found in the input log file.
 #      'on'  use the record only if its date is in the range found in the input log file.
 #
@@ -569,7 +569,7 @@ dansguardian_conf {$dansguardian_conf}
 {$squidguard_conf}
 
 # TAG: redirector_log file
-#      the location of the web proxy redirector log such as one created by squidGuard or Rejik. The option
+#      The location of the web proxy redirector log, such as one created by squidGuard or Rejik. The option
 #      may be repeated up to 64 times to read multiple files.
 #      If this option is specified, it takes precedence over squidguard_conf.
 #      The command line option -L override this option.
@@ -577,9 +577,9 @@ dansguardian_conf {$dansguardian_conf}
 #redirector_log /usr/local/squidGuard/var/logs/urls.log
 
 # TAG: redirector_filter_out_date on|off
-#      This option replaces squidguard_ignore_date and redirector_ignore_date whose names were not
-#      appropriate with respect to their action.
-#      Note the change of parameter value compared with the old options.
+#      This option replaces squidguard_ignore_date and redirector_ignore_date (their names were not
+#      appropriate with respect to their actions).
+#      Note the change of parameter value compared to the old options.
 #      'off' use the record even if its date is outside of the range found in the input log file.
 #      'on'  use the record only if its date is in the range found in the input log file.
 #
@@ -587,23 +587,23 @@ dansguardian_conf {$dansguardian_conf}
 
 # TAG: redirector_log_format
 #      Format string for web proxy redirector logs.
-#      This option was named squidguard_log_format before sarg 2.3.
+#      This option was named squidguard_log_format before Sarg 2.3.
 #      REJIK       #year#-#mon#-#day# #hour# #list#:#tmp# #ip# #user# #tmp#/#tmp#/#url#/#end#
 #      SQUIDGUARD  #year#-#mon#-#day# #hour# #tmp#/#list#/#tmp#/#tmp#/#url#/#tmp# #ip#/#tmp# #user# #end#
 #redirector_log_format #year#-#mon#-#day# #hour# #tmp#/#list#/#tmp#/#tmp#/#url#/#tmp# #ip#/#tmp# #user# #end#
 {$redirector_log_format}
 # TAG: show_sarg_info yes|no
-#      shows sarg information and site path on each report bottom
+#      shows Sarg information and site path on each report bottom
 #
 show_sarg_info no
 
 # TAG: show_sarg_logo yes|no
-#      shows sarg logo
+#      shows Sarg logo
 #
 show_sarg_logo no
 
 # TAG: parsed_output_log directory
-#      Saves the processed log in a sarg format after parsing the squid log file.
+#      Saves the processed log in a Sarg format after parsing the squid log file.
 #      This is a way to dump all of the data structures out, after parsing from
 #      the logs (presumably this data will be much smaller than the log files themselves),
 #      and pull them back in for later processing and merging with data from previous logs.
@@ -657,27 +657,27 @@ denied_report_limit {$denied_report_limit}
 www_document_root /usr/local/www
 
 # TAG: block_it module_url
-#     This tag allow you to pass urls from user reports to a cgi or php module,
-#     to be blocked by some Squid acl
+#     This tag allows you to pass urls from user reports to a cgi or php module,
+#     to be blocked by some Squid acl.
 #
 #     Eg.: block_it /sarg-php/sarg-block-it.php
 #     sarg-block-it is a php that will append a url to a flat file.
 #     You must change /var/www/html/sarg-php/sarg-block-it to point to your file
-#     in $filename variable, and chown to a httpd owner.
+#     in $filename variable, and chown to the httpd owner.
 #
-#     sarg will pass http://module_url?url=url
+#     Sarg will pass http://module_url?url=url
 #
 #block_it none
 
 # TAG: external_css_file path
-#     Provide the path to an external css file to link into the HTML reports instead of
-#     the inline css written by sarg when this option is not set.
+#     Provide the path to an external CSS file to link into the HTML reports instead of
+#     the inline CSS written by sarg when this option is not set.
 #
 #     In versions prior to 2.3, this used to be an absolute file name to
 #     a file to include verbatim in each HTML page but, as it takes a lot of
-#     space, version 2.3 switched to a link to an external css file.
+#     space, version 2.3 switched to a link to an external CSS file.
 #     Therefore, this option must contain the HTTP server path on which a client
-#     browser may find the css file.
+#     browser may find the CSS file.
 #
 #     Sarg use theses style classes:
 #	.logo		logo class
@@ -692,7 +692,7 @@ www_document_root /usr/local/www
 #	.data3		table text class, align:center
 #	.link  		link class
 #
-#     Sarg can be instructed to output the internal css it inline
+#     Sarg can be instructed to output the internal CSS it inline
 #     into the reports with this command:
 #
 #        sarg --css
@@ -721,8 +721,8 @@ www_document_root /usr/local/www
 
 # TAG: ulimit n
 #    The maximum number of open file descriptors to avoid "Too many open files" error message.
-#    You need to run sarg as root to use ulimit tag.
-#    If you run sarg with a low privilege user, set to 'none' to disable ulimit
+#    You need to run Sarg as root to use ulimit tag.
+#    If you run Sarg with a low privilege user, set to 'none' to disable ulimit
 #
 #ulimit 20000
 
@@ -733,7 +733,7 @@ www_document_root /usr/local/www
 ntlm_user_format {$ntlm_user_format}
 
 # TAG: realtime_refresh_time num sec
-#      How many time to auto refresh the realtime report
+#      How many seconds between auto refresh of the realtime report.
 #      0 = disable
 #
 realtime_refresh_time 0
@@ -775,24 +775,24 @@ realtime_unauthenticated_records show
 #      is at the root of your web site.
 #
 #      If the path starts with "../" then it is assumed to be a relative
-#      path and sarg adds as many "../" as necessary to locate the js script from
+#      path and Sarg adds as many "../" as necessary to locate the js script from
 #      the output directory. Therefore, ../../sorttable.js links to the javascript
 #      one level above output_dir.
 #
 #      If this entry is set, each sortable table will have the "sortable" class set.
 #      You may have a look at http://www.kryogenix.org/code/browser/sorttable/
-#      for the implementation on which sarg is based.
+#      for the implementation on which Sarg is based.
 #
 sorttable /sarg_sorttable.js
 
 # TAG: hostalias
-#      The name of a text file containing the host names one per line and the
+#      The name of a text file containing the host names (one per line) and the
 #      optional alias to use in the report instead of that host name.
 #      Host names may contain up to one wildcard denoted by a *. The wildcard
-#      must not end the host name.
-#      The host name may be followed by an optional alias but if no alias is
-#      provided, the host name, including the wildcard, replaces any matching
-#      host name found in the log.
+#      must not be at the end of the host name.
+#      The host name may be followed by an optional alias; if no alias is provided,
+#      the host name, including the wildcard, replaces any matching host name found
+#      in the log.
 #      Host names replaced by identical aliases are grouped together in the
 #      reports.
 #      IP addresses are supported and accept the CIDR notation both for IPv4 and

--- a/config/sarg/sarg.xml
+++ b/config/sarg/sarg.xml
@@ -1,116 +1,103 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-	<![CDATA[
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    sarg.xml
-    part of the sarg for pfSense
-    Copyright (C) 2012-2013 Marcello Coutinho
-
-    All rights reserved.            
-			                                                                  */
-/* ========================================================================== */
+	sarg.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012-2013 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code MUST retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
 	]]>
 	</copyright>
-	<description>Describe your package here</description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>sarg</name>
-	<version>1.0</version>
+	<version>0.6.5</version>
 	<title>Status: Sarg Settings</title>
 	<include_file>/usr/local/pkg/sarg.inc</include_file>
 	<menu>
 		<name>Sarg Reports</name>
-		<tooltiptext>Configure sarg</tooltiptext>
+		<tooltiptext>Configure Sarg</tooltiptext>
 		<section>Status</section>
 		<url>/pkg_edit.php?xml=sarg.xml</url>
 	</menu>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/sarg/sarg.inc</item>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/sarg/sarg_schedule.xml</item>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/sarg/sarg_sync.xml</item>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/sarg/sarg_users.xml</item>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/sarg/sarg_realtime.php</item>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/sarg/sarg_about.php</item>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/sarg/sarg.php</item>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/sarg/sarg_reports.php</item>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/sarg/sarg_frame.php</item>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/sarg/sarg_sorttable.js</item>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/sarg/sarg.template</item>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<additional_files_needed>
 		<item>https://packages.pfsense.org/packages/config/sarg/sarg.priv.inc</item>
 		<prefix>/etc/inc/priv/</prefix>
-		<chmod>0755</chmod>
 	</additional_files_needed>
 	<tabs>
 		<tab>
@@ -142,120 +129,133 @@
 			<text>Help</text>
 			<url>/sarg_about.php</url>
 		</tab>
-</tabs>
+	</tabs>
 	<fields>
 		<field>
 			<name>Report Settings</name>
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Proxy server</fielddescr>
+			<fielddescr>Proxy Server</fielddescr>
 			<fieldname>proxy_server</fieldname>
-			<description><![CDATA[Select proxy server to read logs from]]></description>
-	    	<type>select</type>
- 				<options>
+			<description>Select proxy server type to read logs from.</description>
+			<type>select</type>
+ 			<options>
  				<option><name>Dansguardian</name><value>dansguardian</value></option>
  				<option><name>Squidguard</name><value>squidguard</value></option>
  				<option><name>Squid</name><value>squid</value></option>
- 				</options>
+ 			</options>
 		</field>
 		<field>
 			<fielddescr>Report Options</fielddescr>
 			<fieldname>report_options</fieldname>
-			<description><![CDATA[Sarg report options. Default values are in ( )<br>
-			If you select any option, it will be enabled on conf file.<br>
-			Use CTRL + click on this field]]></description>
-	    	<type>select</type>
- 				<options>
- 				<option><name>Use graphics where is possible. (yes)</name><value>use_graphs</value></option>
+			<description>
+				<![CDATA[
+				Select Sarg report options. Default values are in ( )<br />
+				Use CTRL + click to (de)select multiple values.
+				]]>
+			</description>
+			<type>select</type>
+ 			<options>
+ 				<option><name>Use graphs where is possible. (yes)</name><value>use_graphs</value></option>
  				<option><name>Use anonymous file and directory names in the report. (no)</name><value>anonymous_output_files </value></option>
- 				<option><name>Convert ip address to dns name (no)</name><value>resolve_ip</value></option>
- 				<option><name>Use Ip Address instead userid in reports. (no)</name><value>user_ip</value></option>
- 				<option><name>Sort Fields in Reverse order (no)</name><value>user_sort_field_order</value></option>
- 				<option><name>Remove temporary files from root report directory  (yes)</name><value>remove_temp_files</value></option>
+ 				<option><name>Convert IP address to DNS name (no)</name><value>resolve_ip</value></option>
+ 				<option><name>Use IP Address instead userid in reports. (no)</name><value>user_ip</value></option>
+ 				<option><name>Sort Fields in reverse order (no)</name><value>user_sort_field_order</value></option>
+ 				<option><name>Remove temporary files from root report directory (yes)</name><value>remove_temp_files</value></option>
  				<option><name>Generate the main index.html (yes)</name><value>main_index</value></option>
  				<option><name>Generate the index tree by file (yes)</name><value>index_tree</value></option>
  				<option><name>Overwrite report (no)</name><value>overwrite_report</value></option>
- 				<option><name>Use comma instead point in reports (yes)</name><value>use_comma</value></option>
- 				<option><name>Show full url in report (no)</name><value>long_url</value></option>
+ 				<option><name>Use comma instead of dot in reports (yes)</name><value>use_comma</value></option>
+ 				<option><name>Show full URL in report (no)</name><value>long_url</value></option>
  				<option><name>Privacy (no)</name><value>privacy</value></option>
- 				<option><name>Show Bytes in sites users reports(no)</name><value>bytes_in_sites_users_report</value></option>
- 				<option><name>Show values in reports using abbreviation (no)</name><value>displayed_values</value></option>
+ 				<option><name>Show bytes in sites users reports (no)</name><value>bytes_in_sites_users_report</value></option>
+ 				<option><name>Show abbreviated values in reports (no)</name><value>displayed_values</value></option>
  				<option><name>Show the downloaded volume on Date/Time reports (yes)</name><value>date_time_by_bytes</value></option>
- 				<option><name>Show the downloaded elapsed time on Date/Time reports (no)</name><value>date_time_by_elap</value></option>
- 				</options>
- 				<multiple/>
- 				<size>17</size>
+ 				<option><name>Show the elapsed time on Date/Time reports (no)</name><value>date_time_by_elap</value></option>
+ 			</options>
+ 			<multiple/>
+ 			<size>16</size>
 		</field>
 		<field>
-			<fielddescr>Report to generate</fielddescr>
+			<fielddescr>Report To Generate</fielddescr>
 			<fieldname>report_type</fieldname>
-			<description><![CDATA[Sarg report type. All are enabled by default<br>
-			Use CTRL + click on this field]]></description>
-	    	<type>select</type>
- 				<options>
- 				<option><name>topusers            - users, sites, times, bytes, connects, links to accessed sites, etc</name><value>topusers</value></option>
- 				<option><name>topsites		   - site, connect and bytes report</name><value>topsites</value></option>
- 				<option><name>sites_users	   - users and sites report</name><value>sites_users</value></option>
- 				<option><name>users_sites	   - accessed sites by the user report</name><value>users_sites</value></option>
- 				<option><name>date_time	   - bytes used per day and hour report</name><value>date_time</value></option>
- 				<option><name>denied		   - denied sites with full URL report</name><value>denied</value></option>
- 				<option><name>auth_failures       - autentication failures report</name><value>auth_failures</value></option>
+			<description>
+				<![CDATA[
+				Sarg report type. All types are enabled by default.<br />
+				Use CTRL + click to (de)select multiple values.
+				]]>
+			</description>
+			<type>select</type>
+ 			<options>
+ 				<option><name>topusers - users, sites, times, bytes, connects, links to accessed sites, etc.</name><value>topusers</value></option>
+ 				<option><name>topsites	- site, connect and bytes report</name><value>topsites</value></option>
+ 				<option><name>sites_users - users and sites report</name><value>sites_users</value></option>
+ 				<option><name>users_sites - sites accessed by the user report</name><value>users_sites</value></option>
+ 				<option><name>date_time	- bytes used per day and hour report</name><value>date_time</value></option>
+ 				<option><name>denied - denied sites with full URL report</name><value>denied</value></option>
+ 				<option><name>auth_failures - autentication failures report</name><value>auth_failures</value></option>
  				<option><name>site_user_time_date - sites, dates, times and bytes report</name><value>site_user_time_date</value></option>
- 				<option><name>downloads           - downloads per user report</name><value>downloads</value></option>
- 				</options>
- 				<multiple/>
- 				<size>10</size>
+ 				<option><name>downloads - downloads per user report</name><value>downloads</value></option>
+ 			</options>
+ 			<multiple/>
+ 			<size>9</size>
 		</field>
 		 <field>
 		 	<fielddescr>Date Format</fielddescr>
 			<fieldname>report_date_format</fieldname>
-		 	<description><![CDATA[Date format to use in reports.]]></description>
+		 	<description>Date format to use in reports.</description>
 			<type>select</type>
 			<options>
-			<option><name>American mm/dd/yy (default)</name><value>u</value></option>
-			<option><name>European dd/mm/yy</name><value>e</value></option>
-			<option><name>Weekly yy.ww</name><value>w</value></option>
+				<option><name>American mm/dd/yy (default)</name><value>u</value></option>
+				<option><name>European dd/mm/yy</name><value>e</value></option>
+				<option><name>Weekly yy.ww</name><value>w</value></option>
 			</options>
+			<default_value>u</default_value>
 		</field>
 		 <field>
-		 	<fielddescr>Report charset</fielddescr>
+		 	<fielddescr>Report Charset</fielddescr>
 			<fieldname>report_charset</fieldname>
-		 	<description><![CDATA[ISO 8859 is a full series of 10 standardized multilingual single-byte coded (8bit) graphic character sets for writing in alphabetic languages]]></description>
+		 	<description>Select character set for the reports.</description>
 			<type>select</type>
 			<options>
-			<option><name>UTF-8 (Default)</name><value>UTF-8</value></option>
-			<option><name>Latin1 		- West European</name><value>Latin1</value></option>
-			<option><name>Latin2 		- East European</name><value>Latin2</value></option>
-			<option><name>Latin3 		- South European</name><value>Latin3</value></option>
-			<option><name>Latin4 		- North European</name><value>Latin4</value></option>
-			<option><name>Latin5 		- Turkish</name><value>Latin5</value></option>
-			<option><name>Latin6</name><value>Latin6</value></option>
-			<option><name>Cyrillic</name><value>Cyrillic</value></option>
-			<option><name>Arabic</name><value>Arabic</value></option>
-			<option><name>Greek</name><value>Greek</value></option>
-			<option><name>Hebrew</name><value>Hebrew</value></option>
-			<option><name>Windows-1251</name><value>Windows-1251</value></option>
-			<option><name>Japan</name><value>Japan</value></option>
-			<option><name>Koi8-r</name><value>Koi8-r</value></option>
+				<option><name>UTF-8 (default)</name><value>UTF-8</value></option>
+				<option><name>Latin1 - West European</name><value>Latin1</value></option>
+				<option><name>Latin2 - Central and East European</name><value>Latin2</value></option>
+				<option><name>Latin3 - Southeast European</name><value>Latin3</value></option>
+				<option><name>Latin4 - Scandinavian/Baltic</name><value>Latin4</value></option>
+				<option><name>Latin5 - Turkish</name><value>Latin5</value></option>
+				<option><name>Latin6 - Lappish/Nordic/Eskimo</name><value>Latin6</value></option>
+				<option><name>Cyrillic</name><value>Cyrillic</value></option>
+				<option><name>Arabic</name><value>Arabic</value></option>
+				<option><name>Greek</name><value>Greek</value></option>
+				<option><name>Hebrew</name><value>Hebrew</value></option>
+				<option><name>Windows-1251</name><value>Windows-1251</value></option>
+				<option><name>Japan</name><value>Japan</value></option>
+				<option><name>KOI8-R</name><value>Koi8-r</value></option>
 			</options>
+			<default_value>UTF-8</default_value>
 		</field>
 		<field>
 			<fielddescr>Host Aliases</fielddescr>
 			<fieldname>hostalias</fieldname>
-			<description><![CDATA[The name of a text file containing the host names one per line and the optional alias to use in the report instead of that host name.<br>
-							Host names may contain up to one wildcard denoted by a *. The wildcard must not end the host name.<br>
-							The host name may be followed by an optional alias but if no alias is provided, the host name, including the wildcard, replaces any matching host name found in the log.<br>
-							Host names replaced by identical aliases are grouped together in the reports.<br>
-							IP addresses are supported and accept the CIDR notation both for IPv4 and IPv6 addresses.<br>
-							Sample:<br>
-							*.gstatic.com<br>
-							mt*.google.com<br>
-							*.myphone.microsoft.com<br>
-							*.myphone.microsoft.com:443 *.myphone.microsoft.com:secure<br>
-							*.freeav.net antivirus:freeav<br>
-							*.mail.live.com<br>
-							65.52.00.00/14 *.mail.live.com]]></description>
+			<description>
+				<![CDATA[
+				Host names (one per line) and the optional alias to use in the report instead of that host name.<br />
+				Host names may contain up to one wildcard denoted by a *. The wildcard must not be at the end of the host name.<br />
+				The host name may be followed by an optional alias; if no alias is provided, the host name, including the wildcard, replaces any matching host name found in the log.<br />
+				Host names replaced by identical aliases are grouped together in the reports.<br />
+				IP addresses are supported and accept the CIDR notation both for IPv4 and IPv6 addresses.<br /><br />
+				<strong>Examples:</strong><br />
+				*.gstatic.com<br />
+				mt*.google.com<br />
+				*.myphone.microsoft.com<br />
+				*.myphone.microsoft.com:443 *.myphone.microsoft.com:secure<br />
+				*.freeav.net antivirus:freeav<br />
+				*.mail.live.com<br />
+				65.52.00.00/14 *.mail.live.com
+				]]>
+			</description>
 			<type>textarea</type>
 			<cols>70</cols>
 			<rows>10</rows>
@@ -268,77 +268,107 @@
 		<field>
 			<fielddescr>Max Elapsed</fielddescr>
 			<fieldname>max_elapsed</fieldname>
-			<description><![CDATA[If elapsed time is recorded in log is greater than max_elapsed use 0 for elapsed time.<br>
-								  Samples: 0 means no checking<br>
-								   28800000 means 08 hours ]]></description>
-	    	<type>input</type>
-	    	<size>10</size>
+			<description>
+				<![CDATA[
+				If elapsed time recorded in log is greater than specified limit in milliseconds, use 0 for elapsed time.<br />
+				<strong>Examples:</strong> 0 means no checking; 28800000 means 8 hours.
+				]]>
+			</description>
+			<type>input</type>
+			<size>10</size>
+			<default_value>0</default_value>
 		</field>
 		<field>
-			<fielddescr>Reports list limits</fielddescr>
+			<fielddescr>Files Limits</fielddescr>
 			<fieldname>lastlog</fieldname>
-			<description><![CDATA[How many reports files must be kept in reports directory.<br>
-								 The oldest report file will be automatically removed.0 means no limit.]]></description>
-	    	<type>input</type>
-	    	<size>10</size>
+			<description>
+				<![CDATA[
+				How many reports files will be be kept in reports directory. The oldest report file will be automatically removed.<br />
+				Default: 0 - means no limit.
+				]]>
+			</description>
+			<type>input</type>
+			<size>10</size>
+			<default_value>0</default_value>
 		</field>
 		<field>
-			<fielddescr>Reports days limits</fielddescr>
+			<fielddescr>Days Limits</fielddescr>
 			<fieldname>daylimit</fieldname>
-			<description><![CDATA[How many days reports files must be kept in reports directory.<br>
-								 Older report file will be automatically removed.<br>
-								 Leave empty to do not remove old reports.]]></description>
-	    	<type>input</type>
-	    	<size>10</size>
+			<description>
+				<![CDATA[
+				Report files will be kept in reports directory for this many days. Report files older than limit will be automatically removed.<br />
+				Leave empty to not remove old reports.
+				]]>
+			</description>
+			<type>input</type>
+			<size>10</size>
 		</field>
 		<field>
 			<fielddescr>Top Users Limit</fielddescr>
 			<fieldname>topuser_num</fieldname>
-			<description><![CDATA[How many users in topsites report. 0 = no limit]]></description>
-	    	<type>input</type>
-	    	<size>10</size>
+			<description>
+				<![CDATA[
+				How many users appear in topsites report.
+				Default: 0 - means no limit.
+				]]>
+			</description>
+			<type>input</type>
+			<size>10</size>
+			<default_value>0</default_value>
 		</field>
 		<field>
 			<fielddescr>Denied Limit</fielddescr>
 			<fieldname>denied_report_limit</fieldname>
-			<description><![CDATA[0 means no limit.]]></description>
-	    	<type>input</type>
-	    	<size>10</size>
+			<description><![CDATA[Default: 0 - means no limit.]]></description>
+			<type>input</type>
+			<size>10</size>
+			<default_value>0</default_value>
 		</field>
 		<field>
 			<fielddescr>AuthFail Limit</fielddescr>
 			<fieldname>authfail_report_limit</fieldname>
-			<description><![CDATA[0 means no limit.]]></description>
-	    	<type>input</type>
-	    	<size>10</size>
+			<description><![CDATA[Default: 0 - means no limit.]]></description>
+			<type>input</type>
+			<size>10</size>
+			<default_value>0</default_value>
 		</field>
 		<field>
-			<fielddescr>User_report_limit</fielddescr>
+			<fielddescr>User Report Limit</fielddescr>
 			<fieldname>user_report_limit</fieldname>
-			<description><![CDATA[0 means no limit.]]></description>
-	    	<type>input</type>
-	    	<size>10</size>
+			<description><![CDATA[Default: 0 - means no limit.]]></description>
+			<type>input</type>
+			<size>10</size>
+			<default_value>0</default_value>
 		</field>
 		<field>
 			<name>Exclude Settings</name>
 			<type>listtopic</type>
 		</field>
-				<field>
+		<field>
 			<fielddescr>Exclude string</fielddescr>
 			<fieldname>exclude_string</fieldname>
-			<description><![CDATA[Records from access.log file that contain one of listed strings will be ignored.<br> 
-								<strong>Format: string1:string2:...:stringn</strong>]]></description>
+			<description>
+				<![CDATA[
+				Records from access.log file that contain one of listed strings will be ignored.<br />
+				<strong>Format: string1:string2:...:stringn</strong>
+				]]>
+			</description>
 			<type>input</type>
 			<size>70</size>
 		</field>
 		<field>
-			<fielddescr>Exclude hosts</fielddescr>
+			<fielddescr>Exclude Hosts</fielddescr>
 			<fieldname>exclude_hostlist</fieldname>
-			<description><![CDATA[Hosts, domains or subnets will be excluded from reports.<br>
-									Eg.: 192.168.10.10   - exclude ip address only<br>
-									192.168.10.0/24 - exclude full C class<br>
-									s1.acme.foo     - exclude hostname only<br>
-									*.acme.foo      - exclude full domain name]]></description>
+			<description>
+				<![CDATA[
+				Hosts, domains or subnets that will be excluded from reports.<br /><br />
+				<strong>Examples:</strong><br />
+				192.168.10.10 - exclude this IP address only.<br />
+				192.168.10.0/24 - exclude entire subnet.<br />
+				host1.example.com - exclude this hostname only.<br />
+				*.example.com - exclude entire domain.
+				]]>
+			</description>
 			<type>textarea</type>
 			<cols>70</cols>
 			<rows>10</rows>
@@ -347,24 +377,23 @@
 		<field>
 			<fielddescr>Exclude codes</fielddescr>
 			<fieldname>exclude_codelist</fieldname>
-			<description><![CDATA[Ignore records with these codes. Eg.: NONE/400<br>
-									Write one code per line. Lines starting with a # are ignored.<br>
-									Only codes matching exactly one of the line is rejected. The comparison is not case sensitive.]]></description>
+			<description>
+				<![CDATA[
+				Ignore records with these <a href="http://wiki.squid-cache.org/SquidFaq/SquidLogs#Squid_result_codes">Squid result codes</a>.<br />
+				Only codes matching exactly one of the line is rejected. The comparison is not case sensitive.<br />
+				<strong>Write one code per line. Lines starting with a # are ignored.</strong><br />
+				<strong>Example:</strong> NONE/400
+				]]>
+			</description>
 			<type>textarea</type>
 			<cols>70</cols>
 			<rows>10</rows>
 			<encoding>base64</encoding>
 		</field>
 	</fields>
-	<custom_php_install_command>
-		sarg_php_install_command();
-	</custom_php_install_command>
-	<custom_php_deinstall_command>
-		sarg_php_deinstall_command();
-	</custom_php_deinstall_command>
 	<custom_php_validation_command>
 		sarg_validate_input($_POST, $input_errors);
-	</custom_php_validation_command>	
+	</custom_php_validation_command>
 	<custom_php_resync_config_command>
 		sync_package_sarg();
 	</custom_php_resync_config_command>

--- a/config/sarg/sarg_about.php
+++ b/config/sarg/sarg_about.php
@@ -1,8 +1,9 @@
 <?php
 /*
 	sarg_about.php
-	part of pfSense (https://www.pfsense.org/)
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2012 Marcello Coutinho <marcellocoutinho@gmail.com>
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -26,77 +27,64 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require("guiconfig.inc");
-
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version < 2.0)
-	$one_two = true;
 
 $pgtitle = "About: Sarg Package";
 include("head.inc");
 
 ?>
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
-<?php include("fbegin.inc"); ?>
 
-<?php if($one_two): ?>
-<p class="pgtitle"><?=$pgtitle?></font></p>
-<?php endif; ?>
+<?php include("fbegin.inc"); ?>
 <?php if ($input_errors) print_input_errors($input_errors); ?>
 <?php if ($savemsg) print_info_box($savemsg); ?>
 
-
 <div id="mainlevel">
-	<table width="100%" border="0" cellpadding="0" cellspacing="0">
-		<tr><td>
+<table width="100%" border="0" cellpadding="0" cellspacing="0">
+	<tr><td>
 		<?php
-	$tab_array = array();
-	$tab_array[] = array(gettext("General"), false, "/pkg_edit.php?xml=sarg.xml&id=0");
-	$tab_array[] = array(gettext("Users"), false, "/pkg_edit.php?xml=sarg_users.xml&id=0");
-	$tab_array[] = array(gettext("Schedule"), false, "/pkg.php?xml=sarg_schedule.xml");
-	$tab_array[] = array(gettext("View Report"), false, "/sarg_reports.php");
-	$tab_array[] = array(gettext("Realtime"), false, "/sarg_realtime.php");
-	$tab_array[] = array(gettext("XMLRPC Sync"), false, "/pkg_edit.php?xml=sarg_sync.xml&id=0");
-	$tab_array[] = array(gettext("Help"), true, "/sarg_about.php");
-	display_top_tabs($tab_array);
-?>
-		</td></tr>
- 		<tr>
- 		
-    		<td>
-				<div id="mainarea">
-					<table class="tabcont" width="100%" border="0" cellpadding="8" cellspacing="0">
-					<tr><td></td></tr>
-						<tr>
-						<td colspan="2" valign="top" class="listtopic"><?=gettext("Help docs"); ?></td>
-						</tr>
-						<tr>
-                        <td width="22%" valign="top" class="vncell"><?=gettext("Sarg Site");?></td>
-						<td width="78%" class="vtable"><?=gettext("<a target=_new href='http://sarg.sourceforge.net/'>Squid Analysis Report Generator</a><br><br>");?>
-                        </tr>
-                        <tr>
-						<td colspan="2" valign="top" class="listtopic"><?=gettext("About sarg package"); ?></td>
-						</tr>
-						<tr>
-                        <td width="22%" valign="top" class="vncell"><?=gettext("Credits ");?></td>
-                        <td width="78%" class="vtable"><?=gettext("Package Created by <a target=_new href='https://forum.pfsense.org/index.php?action=profile;u=4710'>Marcello Coutinho</a><br><br>");?></td>
-                        </tr>
-						<tr>
-                        <td width="22%" valign="top" class="vncell"><?=gettext("Donations ");?></td>
-                        <td width="78%" class="vtable"><?=gettext("If you like this package, please <a target=_new href='https://www.pfsense.org/index.php?option=com_content&task=view&id=47&Itemid=77'>donate to pfSense project</a>.<br><br>
-								 If you want that your donation goes to this package developer, make a note on donation forwarding it to me.<br><br>");?></td>
-                        </tr>
-						</table>
-						
-				</div>
-			</td>
-		</tr>
-	
-
-	</table>
-	<br>
-	<div id="search_results"></div>
+		$tab_array = array();
+		$tab_array[] = array(gettext("General"), false, "/pkg_edit.php?xml=sarg.xml&id=0");
+		$tab_array[] = array(gettext("Users"), false, "/pkg_edit.php?xml=sarg_users.xml&id=0");
+		$tab_array[] = array(gettext("Schedule"), false, "/pkg.php?xml=sarg_schedule.xml");
+		$tab_array[] = array(gettext("View Report"), false, "/sarg_reports.php");
+		$tab_array[] = array(gettext("Realtime"), false, "/sarg_realtime.php");
+		$tab_array[] = array(gettext("XMLRPC Sync"), false, "/pkg_edit.php?xml=sarg_sync.xml&id=0");
+		$tab_array[] = array(gettext("Help"), true, "/sarg_about.php");
+		display_top_tabs($tab_array);
+		?>
+	</td></tr>
+ 	<tr><td>
+		<div id="mainarea">
+			<table class="tabcont" width="100%" border="0" cellpadding="8" cellspacing="0">
+				<tr><td></td></tr>
+				<tr>
+					<td colspan="2" valign="top" class="listtopic"><?=gettext("Help Docs"); ?></td>
+				</tr>
+				<tr>
+					<td width="22%" valign="top" class="vncell"><?=gettext("Sarg Site");?></td>
+					<td width="78%" class="vtable"><?=gettext("<a href='http://sarg.sourceforge.net/'>Squid Analysis Report Generator</a><br /><br />");?></td>
+				</tr>
+				<tr>
+					<td colspan="2" valign="top" class="listtopic"><?=gettext("About Sarg package"); ?></td>
+				</tr>
+				<tr>
+					<td width="22%" valign="top" class="vncell"><?=gettext("Credits ");?></td>
+					<td width="78%" class="vtable"><?=gettext("Package created by <a href='https://forum.pfsense.org/index.php?action=profile;u=4710'>Marcello Coutinho</a><br /><br />");?></td>
+				</tr>
+				<tr>
+					<td width="22%" valign="top" class="vncell"><?=gettext("Donations ");?></td>
+					<td width="78%" class="vtable">
+						<?=gettext("If you like this package, please <a href='https://www.pfsense.org/index.php?option=com_content&task=view&id=47&Itemid=77'>donate to pfSense project</a>.<br /><br />
+						If you want that your donation goes to this package developer, make a note on donation forwarding it to me.<br /><br />");?>
+					</td>
+				</tr>
+			</table>
+		</div>
+	</td></tr>
+</table>
+<br />
+<div id="search_results"></div>
 </div>
 <?php include("fend.inc"); ?>
 </body>

--- a/config/sarg/sarg_frame.php
+++ b/config/sarg/sarg_frame.php
@@ -1,9 +1,9 @@
 <?php
 /*
 	sarg_frame.php
-	part of pfSense (https://www.pfsense.org/)
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2012 Marcello Coutinho <marcellocoutinho@gmail.com>
-	based on varnish_view_config.
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -29,55 +29,55 @@
 */
 require_once("authgui.inc");
 
-$uname=posix_uname();
-if ($uname['machine']=='amd64')
-        ini_set('memory_limit', '250M');
-        
-if(preg_match("/(\S+)\W(\w+.html)/",$_REQUEST['file'],$matches)){
-	#https://192.168.1.1/sarg_reports.php?file=2012Mar30-2012Mar30/index.html
-	$url=$matches[2];
-	$prefix=$matches[1];
-	}
-else{
-	$url="index.html";
-	$prefix="";
-	}
-$url=($_REQUEST['file'] == ""?"index.html":$_REQUEST['file']);
-$dir="/usr/local/sarg-reports";
-$rand=rand(100000000000,999999999999);
-$report="";
-if (file_exists("{$dir}/{$url}"))
-	$report=file_get_contents("{$dir}/{$url}");
-else if (file_exists("{$dir}/{$url}.gz")) {
-		$data = gzfile("{$dir}/{$url}.gz");
-		$report = implode($data);
-		unset ($data);
-		}
-if ($report != "" )
-	{
-	$pattern[0]="/href=\W(\S+html)\W/";
-	$replace[0]="href=/sarg_frame.php?prevent=".$rand."&file=$prefix/$1";
-	$pattern[1]='/img src="\S+\W([a-zA-Z0-9.-]+.png)/';
-	$replace[1]='img src="/sarg-images/$1';
-	$pattern[2]='@img src="([.a-z/]+)/(\w+\.\w+)@';
-	$replace[2]='img src="/sarg-images'.$prefix.'/$1/$2';
-	$pattern[3]='/img src="([a-zA-Z0-9.-_]+).png/';
-	$replace[3]='img src="/sarg-images/temp/$1.'.$rand.'.png';
-	$pattern[4]='/<head>/';
-	$replace[4]='<head><META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"><META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">';
+$uname = posix_uname();
+if ($uname['machine'] == 'amd64') {
+	ini_set('memory_limit', '250M');
+}
 
-	#look for graph files inside reports. 
-	if (preg_match_all('/img src="([a-zA-Z0-9._-]+).png/',$report,$images)){
+if (preg_match("/(\S+)\W(\w+.html)/", $_REQUEST['file'], $matches)) {
+	// URL format
+	// https://192.168.1.1/sarg_reports.php?file=2012Mar30-2012Mar30/index.html
+	$url = $matches[2];
+	$prefix = $matches[1];
+} else {
+	$url = "index.html";
+	$prefix = "";
+}
+
+$url = ($_REQUEST['file'] == "" ? "index.html" : $_REQUEST['file']);
+$dir = "/usr/local/sarg-reports";
+$rand = rand(100000000000, 999999999999);
+$report = "";
+if (file_exists("{$dir}/{$url}")) {
+	$report = file_get_contents("{$dir}/{$url}");
+} elseif (file_exists("{$dir}/{$url}.gz")) {
+	$data = gzfile("{$dir}/{$url}.gz");
+	$report = implode($data);
+	unset ($data);
+}
+if ($report != "" ) {
+	$pattern[0] = "/href=\W(\S+html)\W/";
+	$replace[0] = "href=/sarg_frame.php?prevent=" . $rand . "&file=$prefix/$1";
+	$pattern[1] = '/img src="\S+\W([a-zA-Z0-9.-]+.png)/';
+	$replace[1] = 'img src="/sarg-images/$1';
+	$pattern[2] = '@img src="([.a-z/]+)/(\w+\.\w+)@';
+	$replace[2] = 'img src="/sarg-images' . $prefix . '/$1/$2';
+	$pattern[3] = '/img src="([a-zA-Z0-9.-_]+).png/';
+	$replace[3] = 'img src="/sarg-images/temp/$1.' . $rand . '.png';
+	$pattern[4] = '/<head>/';
+	$replace[4] = '<head><META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"><META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">';
+
+	// look for graph files inside reports. 
+	if (preg_match_all('/img src="([a-zA-Z0-9._-]+).png/', $report, $images)) {
 		conf_mount_rw();
-		for ($x=0;$x<count($images[1]);$x++){
-			copy("{$dir}/{$prefix}/{$images[1][$x]}.png","/usr/local/www/sarg-images/temp/{$images[1][$x]}.{$rand}.png");
-			}
-		conf_mount_ro();
+		for ($x = 0; $x < count($images[1]); $x++) {
+			copy("{$dir}/{$prefix}/{$images[1][$x]}.png", "/usr/local/www/sarg-images/temp/{$images[1][$x]}.{$rand}.png");
 		}
-	print preg_replace($pattern,$replace,$report);
+		conf_mount_ro();
 	}
-else{
-	print "<pre>Error: Could not find report index file.<br>Check and save sarg settings and try to force sarg schedule.";
-	}		
+	print preg_replace($pattern, $replace, $report);
+} else {
+	print "Error: Could not find report index file.<br />Check and save Sarg settings and try to force Sarg schedule.";
+}
 
 ?>

--- a/config/sarg/sarg_realtime.php
+++ b/config/sarg/sarg_realtime.php
@@ -1,8 +1,9 @@
 <?php
 /*
 	sarg_realtime.php
-	part of pfSense (https://www.pfsense.org/)
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2012 Marcello Coutinho <marcellocoutinho@gmail.com>
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -26,229 +27,227 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
-$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-if ($pf_version == "2.1" || $pf_version == "2.2")
-        define('SARG_DIR', '/usr/pbi/sarg-' . php_uname("m"));
-else
-  define('SARG_DIR', '/usr/local');
-  
-$uname=posix_uname();
-if ($uname['machine']=='amd64')
-        ini_set('memory_limit', '250M');
-        
+$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
+if ($pf_version == "2.1" || $pf_version == "2.2") {
+	define('SARG_DIR', '/usr/pbi/sarg-' . php_uname("m"));
+} else {
+	define('SARG_DIR', '/usr/local');
+}
+ 
+$uname = posix_uname();
+if ($uname['machine'] == 'amd64') {
+	ini_set('memory_limit', '250M');
+}
 
 function get_cmd(){
-	global $config,$g;
-	#print $_REQUEST['type'];
-	if ($_REQUEST['cmd'] =='sarg'){
-		$update_config=0;
-		#Check report xml info
-		if (!is_array($config['installedpackages']['sargrealtime'])){
-			$config['installedpackages']['sargrealtime']['config'][0]['realtime_types']= "";
-			$config['installedpackages']['sargrealtime']['config'][0]['realtime_users']= "";
+	global $config, $g;
+	// print $_REQUEST['type'];
+	if ($_REQUEST['cmd'] == 'sarg') {
+		$update_config = 0;
+		// Check report xml info
+		if (!is_array($config['installedpackages']['sargrealtime'])) {
+			$config['installedpackages']['sargrealtime']['config'][0]['realtime_types'] = "";
+			$config['installedpackages']['sargrealtime']['config'][0]['realtime_users'] = "";
 		}
-		#Check report http actions to show
-		if	($config['installedpackages']['sargrealtime']['config'][0]['realtime_types'] != $_REQUEST['qshape']){
-			$config['installedpackages']['sargrealtime']['config'][0]['realtime_types']= $_REQUEST['qshape'];
+		// Check report http actions to show
+		if ($config['installedpackages']['sargrealtime']['config'][0]['realtime_types'] != $_REQUEST['qshape']) {
+			$config['installedpackages']['sargrealtime']['config'][0]['realtime_types'] = $_REQUEST['qshape'];
 			$update_config++;
-			}
-
-		#Check report users show
-		if	($config['installedpackages']['sargrealtime']['config'][0]['realtime_users'] != $_REQUEST['type']){
+		}
+		// Check report users show
+		if ($config['installedpackages']['sargrealtime']['config'][0]['realtime_users'] != $_REQUEST['type']) {
 			$config['installedpackages']['sargrealtime']['config'][0]['realtime_users']= $_REQUEST['type'];
 			$update_config++;
-			}
-			
-		if($update_config > 0){
+		}
+		if ($update_config > 0) {
 			write_config();
-			#write changes to sarg_file
-			$sarg_config=file_get_contents(SARG_DIR . '/etc/sarg/sarg.conf');
-			$pattern[0]='/realtime_types\s+[A-Z,,]+/';
-			$replace[0]="realtime_types ".$_REQUEST['qshape'];
-			$pattern[1]='/realtime_unauthenticated_records\s+\w+/';
-			$replace[1]="realtime_unauthenticated_records ".$_REQUEST['type'];
-			file_put_contents(SARG_DIR . '/etc/sarg/sarg.conf', preg_replace($pattern,$replace,$sarg_config),LOCK_EX);
-			}
-		exec(SARG_DIR ."/bin/sarg -r",$sarg);
-		$pattern[0]="/<?(html|head|style)>/";
-		$replace[0]="";
-		$pattern[1]="/header_\w/";
-		$replace[1]="listtopic";
-		$pattern[2]="/class=.data./";
-		$replace[2]='class="listlr"';
-		$pattern[3]="/cellpadding=.\d./";
-		$replace[3]='cellpadding="0"';
-		$pattern[4]="/cellspacing=.\d./";
-		$replace[4]='cellspacing="0"';
-		$pattern[5]="/sarg/";
-		$replace[5]='cellspacing="0"';
-		foreach ($sarg as $line){
-			if (preg_match("/<.head>/",$line))
+			// write changes to sarg_file
+			$sarg_config = file_get_contents(SARG_DIR . '/etc/sarg/sarg.conf');
+			$pattern[0] = '/realtime_types\s+[A-Z,,]+/';
+			$replace[0] = "realtime_types " . $_REQUEST['qshape'];
+			$pattern[1] = '/realtime_unauthenticated_records\s+\w+/';
+			$replace[1] = "realtime_unauthenticated_records " . $_REQUEST['type'];
+			file_put_contents(SARG_DIR . '/etc/sarg/sarg.conf', preg_replace($pattern, $replace, $sarg_config), LOCK_EX);
+		}
+		exec(SARG_DIR . "/bin/sarg -r", $sarg);
+		$pattern[0] = "/<?(html|head|style)>/";
+		$replace[0] = "";
+		$pattern[1] = "/header_\w/";
+		$replace[1] = "listtopic";
+		$pattern[2] = "/class=.data./";
+		$replace[2] = 'class="listlr"';
+		$pattern[3] = "/cellpadding=.\d./";
+		$replace[3] = 'cellpadding="0"';
+		$pattern[4] = "/cellspacing=.\d./";
+		$replace[4] = 'cellspacing="0"';
+		$pattern[5] = "/sarg/";
+		$replace[5] = 'cellspacing="0"';
+		foreach ($sarg as $line) {
+			if (preg_match("/<.head>/", $line)) {
 				$print ="ok";
-			if ($print =="ok" && !preg_match("/(sarg realtime|Auto Refresh)/i",$line))
-				print preg_replace($pattern,$replace,$line);
+			}
+			if ($print == "ok" && !preg_match("/(sarg realtime|Auto Refresh)/i", $line)) {
+				print preg_replace($pattern, $replace, $line);
+			}
 		}
 	}
 }
 
-if ($_REQUEST['cmd']!=""){
+if ($_REQUEST['cmd'] != "") {
 	require_once("authgui.inc");
 	require_once("functions.inc");
 	get_cmd();
-	}
-else{
+} else {
 	require("guiconfig.inc");
-	$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-	if ($pf_version < 2.0)
-		$one_two = true;
-	
+
 	$pgtitle = "Status: Sarg Realtime";
 	include("head.inc");
-	
+
 	?>
 	<body link="#0000CC" vlink="#0000CC" alink="#0000CC">
 	<?php include("fbegin.inc"); ?>
-	
-	<?php if($one_two): ?>
-	<p class="pgtitle"><?=$pgtitle?></font></p>
-	<?php endif; ?>
-	
-	<?php if ($savemsg) print_info_box($savemsg); ?>
-	
-	<form action="sarg_realtime.php" method="post">
-		
-	<div id="mainlevel">
-		<table width="100%" border="0" cellpadding="0" cellspacing="0">
-			<tr><td>
-	<?php
-	$tab_array = array();
-	$tab_array[] = array(gettext("General"), false, "/pkg_edit.php?xml=sarg.xml&id=0");
-	$tab_array[] = array(gettext("Users"), false, "/pkg_edit.php?xml=sarg_users.xml&id=0");
-	$tab_array[] = array(gettext("Schedule"), false, "/pkg.php?xml=sarg_schedule.xml");
-	$tab_array[] = array(gettext("View Report"), false, "/sarg_reports.php");
-	$tab_array[] = array(gettext("Realtime"), true, "/sarg_realtime.php");
-	$tab_array[] = array(gettext("XMLRPC Sync"), false, "/pkg_edit.php?xml=sarg_sync.xml&id=0");
-	$tab_array[] = array(gettext("Help"), false, "/sarg_about.php");
-	display_top_tabs($tab_array);
-	?>
-			</td></tr>
-	 		<tr>
-	    		<td>
-					<div id="mainarea">
-						<table class="tabcont" width="100%" border="0" cellpadding="8" cellspacing="0">
-						<tr><td></td></tr>
-						<tr>
-						<td colspan="2" valign="top" class="listtopic"><?=gettext("Sarg Realtime"); ?></td></tr>
-					<tr>
-                        <td width="22%" valign="top" class="vncell"><?=gettext("Log command: ");?></td>
-                        <td width="78%" class="vtable">
-                        <select name="drop3" id="cmd">
-                        	<option value="sarg" selected="selected">Sarg Realtime</option>
-						</select><br><?=gettext("Select report command to run.");?></td>
-					</tr>
-					<tr>
-                        <td width="22%" valign="top" class="vncell"><?=gettext("update frequency: ");?></td>
-                        <td width="78%" class="vtable">
-                        <select name="drop3" id="updatef">
-                        	<option value="1">01 second</option>
-                            <option value="3" selected="selected">03 seconds</option>
-                        	<option value="5">05 seconds</option>
-                        	<option value="15">15 Seconds</option>
-							<option value="30">30 Seconds</option>
-							<option value="60">One minute</option>
-							<option value="1">Never</option>
-						</select><br><?=gettext("Select how often report will run.");?></td>
-					</tr>
-					<tr>					
-                        <td width="22%" valign="top" class="vncell"><?=gettext("Report Types: ");?></td>
-                        <td width="78%" class="vtable">
-                        <select name="drop3" id="qshape" multiple="multiple" size="5">
-                        	<option value="GET" selected="selected">GET</option>
-							<option value="PUT" selected="selected">PUT</option>
-							<option value="CONNECT" selected="selected">CONNECT</option>
-							<option value="ICP_QUERY">ICP_QUERY</option>
-							<option value="POST">POST</option>
-						</select><br><?=gettext("Which records must be in realtime report.");?></td>
-					</tr>
-					<tr>					
-                        <td width="22%" valign="top" class="vncell"><?=gettext("unauthenticated_records: ");?></td>
-                        <td width="78%" class="vtable">
-                        <select name="drop3" id="qtype">
-							<option value="show" selected>show</option>
-							<option value="hide">hide</option>
-						</select><br><?=gettext("What to do with unauthenticated records in realtime report.");?></td>
-					</tr>
 
-					<tr>
-							<td width="22%" valign="top"></td>
-                        <td width="78%"><input name="Submit" type="button" class="formbtn" id="run" value="<?=gettext("show log");?>" onclick="get_queue('mailq')"><div id="search_help"></div></td>
-				</table>
-				</div>
-				</td>
-			</tr>
-			</table>
-			<br>
-				<div>
+	<?php if ($savemsg) print_info_box($savemsg); ?>
+
+	<form action="sarg_realtime.php" method="post">
+
+	<div id="mainlevel">
+	<table width="100%" border="0" cellpadding="0" cellspacing="0">
+		<tr><td>
+			<?php
+			$tab_array = array();
+			$tab_array[] = array(gettext("General"), false, "/pkg_edit.php?xml=sarg.xml&id=0");
+			$tab_array[] = array(gettext("Users"), false, "/pkg_edit.php?xml=sarg_users.xml&id=0");
+			$tab_array[] = array(gettext("Schedule"), false, "/pkg.php?xml=sarg_schedule.xml");
+			$tab_array[] = array(gettext("View Report"), false, "/sarg_reports.php");
+			$tab_array[] = array(gettext("Realtime"), true, "/sarg_realtime.php");
+			$tab_array[] = array(gettext("XMLRPC Sync"), false, "/pkg_edit.php?xml=sarg_sync.xml&id=0");
+			$tab_array[] = array(gettext("Help"), false, "/sarg_about.php");
+			display_top_tabs($tab_array);
+			?>
+		</td></tr>
+	 	<tr><td>
+			<div id="mainarea">
 				<table class="tabcont" width="100%" border="0" cellpadding="8" cellspacing="0">
-								<tr>
-	     						<td class="tabcont" >
-	     						<div id="file_div"></div>
-									
-								</td>
-							</tr>
-						</table>
-					</div>
+					<tr><td></td></tr>
+					<tr><td colspan="2" valign="top" class="listtopic"><?=gettext("Sarg Realtime"); ?></td></tr>
+					<tr>
+						<td width="22%" valign="top" class="vncell"><?=gettext("Log command: ");?></td>
+						<td width="78%" class="vtable">
+							<select name="drop3" id="cmd">
+								<option value="sarg" selected="selected">Sarg Realtime</option>
+							</select>
+							<br /><?=gettext("Select report command to run.");?>
+						</td>
+					</tr>
+					<tr>
+						<td width="22%" valign="top" class="vncell"><?=gettext("update frequency: ");?></td>
+						<td width="78%" class="vtable">
+							<select name="drop3" id="updatef">
+								<option value="1">01 second</option>
+								<option value="3" selected="selected">03 seconds</option>
+								<option value="5">05 seconds</option>
+								<option value="15">15 Seconds</option>
+								<option value="30">30 Seconds</option>
+								<option value="60">One minute</option>
+								<option value="1">Never</option>
+							</select>
+							<br /><?=gettext("Select how often report will run.");?>
+						</td>
+					</tr>
+					<tr>
+						<td width="22%" valign="top" class="vncell"><?=gettext("Report Types: ");?></td>
+						<td width="78%" class="vtable">
+							<select name="drop3" id="qshape" multiple="multiple" size="5">
+								<option value="GET" selected="selected">GET</option>
+								<option value="PUT" selected="selected">PUT</option>
+								<option value="CONNECT" selected="selected">CONNECT</option>
+								<option value="ICP_QUERY">ICP_QUERY</option>
+								<option value="POST">POST</option>
+							</select>
+							<br /><?=gettext("Which records must be in realtime report.");?>
+						</td>
+					</tr>
+					<tr>
+						<td width="22%" valign="top" class="vncell"><?=gettext("unauthenticated_records: ");?></td>
+						<td width="78%" class="vtable">
+							<select name="drop3" id="qtype">
+								<option value="show" selected>show</option>
+								<option value="hide">hide</option>
+							</select>
+							<br /><?=gettext("What to do with unauthenticated records in realtime report.");?>
+						</td>
+					</tr>
+					<tr>
+						<td width="22%" valign="top"></td>
+						<td width="78%">
+							<input name="Submit" type="button" class="formbtn" id="run" value="<?=gettext("show log");?>" onclick="get_queue('mailq')" />
+							<div id="search_help"></div>
+						</td>
+					</tr>
+				</table>
+			</div>
+		</td></tr>
+	</table>
+	<br />
+	<div>
+		<table class="tabcont" width="100%" border="0" cellpadding="8" cellspacing="0">
+			<tr><td class="tabcont" >
+				<div id="file_div"></div>
+			</td></tr>
+		</table>
+	</div>
 	</div>
 	</form>
 	<script type="text/javascript">
-	function loopSelected(id)
-	{
-	  var selectedArray = new Array();
-	  var selObj = document.getElementById(id);
-	  var i;
-	  var count = 0;
-	  for (i=0; i<selObj.options.length; i++) {
-	    if (selObj.options[i].selected) {
-	      selectedArray[count] = selObj.options[i].value;
-	      count++;
-	    }
-	  }
-	  return(selectedArray);
-	}
-	function get_queue(loop) {
-			//prevent multiple instances
-			if ($('run').value=="show log" || loop== 'running'){
-				$('run').value="running...";
-				$('search_help').innerHTML ="<br><strong>You can change options while running.<br>To Stop search, change update frequency to Never.</strong>";
-				var axel = Math.random() + "";
-				var num = axel * 1000000000000000000;
-				var q_args=loopSelected('qshape');
-				var pars = 'cmd='+$('cmd').options[$('cmd').selectedIndex].value;
-				var pars = pars + '&qshape='+q_args;
-				var pars = pars + '&prevent='+num;
-				var pars = pars + '&type='+$('qtype').options[$('qtype').selectedIndex].value;
-				var url = "/sarg_realtime.php";
-				var myAjax = new Ajax.Request(
-					url,
-					{
-						method: 'post',
-						parameters: pars,
-						onComplete: activitycallback_queue_file
-					});
-				}
-			}
-		function activitycallback_queue_file(transport) {
-			$('file_div').innerHTML = transport.responseText;
-			var update=$('updatef').options[$('updatef').selectedIndex].value * 1000;
-			if (update > 999){
-				setTimeout('get_queue("running")', update);
-				}
-			else{
-				$('run').value="show log";
-				$('search_help').innerHTML ="";
+	//<![CDATA[
+	function loopSelected(id) {
+		var selectedArray = new Array();
+		var selObj = document.getElementById(id);
+		var i;
+		var count = 0;
+		for (i = 0; i < selObj.options.length; i++) {
+			if (selObj.options[i].selected) {
+				selectedArray[count] = selObj.options[i].value;
+				count++;
 			}
 		}
+		return (selectedArray);
+	}
+
+	function get_queue(loop) {
+		//prevent multiple instances
+		if ($('run').value == "show log" || loop == 'running') {
+			$('run').value = "running...";
+			$('search_help').innerHTML = "<br /><strong>You can change options while running.<br />To stop search, change update frequency to Never.</strong>";
+			var axel = Math.random() + "";
+			var num = axel * 1000000000000000000;
+			var q_args = loopSelected('qshape');
+			var pars = 'cmd=' + $('cmd').options[$('cmd').selectedIndex].value;
+			var pars = pars + '&qshape=' + q_args;
+			var pars = pars + '&prevent=' + num;
+			var pars = pars + '&type=' + $('qtype').options[$('qtype').selectedIndex].value;
+			var url = "/sarg_realtime.php";
+			var myAjax = new Ajax.Request(
+				url, {
+					method: 'post',
+					parameters: pars,
+					onComplete: activitycallback_queue_file
+				});
+		}
+	}
+
+	function activitycallback_queue_file(transport) {
+		$('file_div').innerHTML = transport.responseText;
+		var update = $('updatef').options[$('updatef').selectedIndex].value * 1000;
+		if (update > 999) {
+			setTimeout('get_queue("running")', update);
+		} else {
+			$('run').value = "show log";
+			$('search_help').innerHTML = "";
+		}
+	}
+	//]]>
 	</script>
 	<?php 
 	include("fend.inc");

--- a/config/sarg/sarg_reports.php
+++ b/config/sarg/sarg_reports.php
@@ -1,8 +1,9 @@
 <?php
 /*
 	sarg_reports.php
-	part of pfSense (https://www.pfsense.org/)
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2012 Marcello Coutinho <marcellocoutinho@gmail.com>
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -26,70 +27,58 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require("guiconfig.inc");
 
-	$pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
-	if ($pf_version < 2.0)
-		$one_two = true;
+$pgtitle = "Status: Sarg Reports";
+include("head.inc");
 	
-	$pgtitle = "Status: Sarg Reports";
-	include("head.inc");
+?>
+<body link="#0000CC" vlink="#0000CC" alink="#0000CC">
+<?php include("fbegin.inc"); ?>
 	
-	?>
-	<body link="#0000CC" vlink="#0000CC" alink="#0000CC">
-	<?php include("fbegin.inc"); ?>
+<?php if ($savemsg) print_info_box($savemsg); ?>
 	
-	<?php if($one_two): ?>
-	<p class="pgtitle"><?=$pgtitle?></font></p>
-	<?php endif; ?>
-	
-	<?php if ($savemsg) print_info_box($savemsg); ?>
-	
-	<form>
-		
-	<div id="mainlevel">
-		<table width="100%" border="0" cellpadding="0" cellspacing="0">
-			<tr><td>
-	<?php
-	$tab_array = array();
-	$tab_array[] = array(gettext("General"), false, "/pkg_edit.php?xml=sarg.xml&id=0");
-	$tab_array[] = array(gettext("Users"), false, "/pkg_edit.php?xml=sarg_users.xml&id=0");
-	$tab_array[] = array(gettext("Schedule"), false, "/pkg.php?xml=sarg_schedule.xml");
-	$tab_array[] = array(gettext("View Report"), true, "/sarg_reports.php");
-	$tab_array[] = array(gettext("Realtime"), false, "/sarg_realtime.php");
-	$tab_array[] = array(gettext("XMLRPC Sync"), false, "/pkg_edit.php?xml=sarg_sync.xml&id=0");
-	$tab_array[] = array(gettext("Help"), false, "/pkg_edit.php?xml=sarg_about.php");
-	display_top_tabs($tab_array);
-	conf_mount_rw();
-	exec('rm -f /usr/local/www/sarg-images/temp/*');
-	conf_mount_ro();
-	?>
-			</td></tr>
-	 		<tr>
-	    		<td>
-					<div id="mainarea">
-						<table class="tabcont" width="100%" border="0" cellpadding="8" cellspacing="0">
-						<tr><td></td></tr>
-						<tr>
-						<td colspan="2" valign="top" class="listtopic"><?=gettext("Sarg Reports"); ?></td></tr>
-				</table>
-				</div>
-				<br>
-				<script language="JavaScript">
-					var axel = Math.random() + "";
-					var num = axel * 1000000000000000000;
-					document.writeln('<IFRAME SRC="/sarg_frame.php?prevent='+ num +'?"  frameborder=0 width="100%" height="600"></IFRAME>');
-				</script>
-				<div id="file_div"></div>
-				
-				</td>
-			</tr>
+<form>
+<div id="mainlevel">
+<table width="100%" border="0" cellpadding="0" cellspacing="0">
+	<tr><td>
+		<?php
+		$tab_array = array();
+		$tab_array[] = array(gettext("General"), false, "/pkg_edit.php?xml=sarg.xml&id=0");
+		$tab_array[] = array(gettext("Users"), false, "/pkg_edit.php?xml=sarg_users.xml&id=0");
+		$tab_array[] = array(gettext("Schedule"), false, "/pkg.php?xml=sarg_schedule.xml");
+		$tab_array[] = array(gettext("View Report"), true, "/sarg_reports.php");
+		$tab_array[] = array(gettext("Realtime"), false, "/sarg_realtime.php");
+		$tab_array[] = array(gettext("XMLRPC Sync"), false, "/pkg_edit.php?xml=sarg_sync.xml&id=0");
+		$tab_array[] = array(gettext("Help"), false, "/pkg_edit.php?xml=sarg_about.php");
+		display_top_tabs($tab_array);
+		conf_mount_rw();
+		mwexec('/bin/rm -f /usr/local/www/sarg-images/temp/*');
+		conf_mount_ro();
+		?>
+	</td></tr>
+	<tr><td>
+		<div id="mainarea">
+			<table class="tabcont" width="100%" border="0" cellpadding="8" cellspacing="0">
+				<tr><td></td></tr>
+				<tr><td colspan="2" valign="top" class="listtopic"><?=gettext("Sarg Reports"); ?></td></tr>
 			</table>
-	</div>
-	</form>
-	<?php 
-	include("fend.inc");
-	?>
-	</body>
-	</html>
+		</div>
+		<br />
+		<script type="text/javascript">
+		//<![CDATA[
+		var axel = Math.random() + "";
+		var num = axel * 1000000000000000000;
+		document.writeln('<iframe src="/sarg_frame.php?prevent='+ num +'?"  frameborder="0" width="100%" height="600"></iframe>');
+		//]]>
+		</script>
+		<div id="file_div"></div>
+	</td></tr>
+</table>
+</div>
+</form>
+<?php 
+include("fend.inc");
+?>
+</body>
+</html>

--- a/config/sarg/sarg_schedule.xml
+++ b/config/sarg/sarg_schedule.xml
@@ -1,65 +1,50 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-        <copyright>
-        <![CDATA[
-/* ========================================================================== */
+	<copyright>
+<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
 /*
-    sarg_schedule.xml
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2012 Marcello Coutinho
-    All rights reserved.                                                      
+	sarg_schedule.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
-        ]]>
-        </copyright>
-    <description>Describe your package here</description>
-    <requirements>Describe your package requirements here</requirements>
-    <faq>Currently there are no FAQ items provided.</faq>
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>sargschedule</name>
-	<version>0.5</version>
+	<version>0.6.5</version>
 	<title>Status: Sarg Schedules</title>
 	<include_file>/usr/local/pkg/sarg.inc</include_file>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/sarg/sarg.inc</item>
-	</additional_files_needed>
-	<additional_files_needed>
-		<prefix>/usr/local/pkg/</prefix>
-		<chmod>0755</chmod>
-		<item>https://packages.pfsense.org/packages/config/sarg/sarg_sync.xml</item>
-	</additional_files_needed>
-	<menu>
-		<name>sarg</name>
-		<tooltiptext>sarg</tooltiptext>
-		<section>Diagnostics</section>
-		<configfile>sarg.xml</configfile>
-	</menu>
 	<tabs>
 		<tab>
 			<text>General</text>
@@ -101,7 +86,7 @@
 			<fieldname>frequency</fieldname>
 		</columnitem>
 		<columnitem>
-			<fielddescr>Aditional Args</fielddescr>
+			<fielddescr>Additional Args</fielddescr>
 			<fieldname>args</fieldname>
 		</columnitem>
 		<columnitem>
@@ -116,7 +101,7 @@
 			<fielddescr>Description</fielddescr>
 			<fieldname>description</fieldname>
 		</columnitem>
-		<movable>arrow</movable>	
+		<movable>on</movable>
 	</adddeleteeditpagefields>
 	<fields>
 		<field>
@@ -128,48 +113,58 @@
 			<fielddescr>Enable</fielddescr>
 			<fieldname>enable</fieldname>
 			<type>checkbox</type>
-			<description>Enable this schedule</description>
-		</field>	
+			<description>Enable this schedule.</description>
+		</field>
 		<field>
 			<fielddescr>Description</fielddescr>
 			<fieldname>description</fieldname>
-			<description>Enter a description for this file.</description>
+			<description>Enter a description for this schedule.</description>
 			<type>input</type>
 			<size>50</size>
 		</field>
 		<field>
-			<fielddescr>Sarg args</fielddescr>
+			<fielddescr>Sarg Args</fielddescr>
 			<fieldname>args</fieldname>
-			<description><![CDATA[Enter sarg extra args to run on this schedule.<br>
-						To force sarg to create a report only for specific days, use:<br>
-						<b>TODAY:</b>&nbsp;&nbsp;-d `date +%d/%m/%Y`<br>
-						<b>YESTERDAY:</b>&nbsp;&nbsp;-d `date -v-1d +%d/%m/%Y`<br>
-						<b>WEEKAGO:</b>&nbsp;&nbsp;-d `date -v-1w +%d/%m/%Y`-`date -v-1d +%d/%m/%Y`<br>
-						<b>MONTHAGO:</b>&nbsp;&nbsp;-d `date -v-1m +01/%m/%Y`-`date -v-1m +31/%m/%Y`]]></description>
+			<description>
+				<![CDATA[
+				Enter Sarg extra arguments to run on this schedule.<br />
+				To force Sarg to create a report only for specific days, use:<br /><br />
+				<strong>TODAY:</strong>&nbsp;&nbsp;-d `date +%d/%m/%Y`<br />
+				<strong>YESTERDAY:</strong>&nbsp;&nbsp;-d `date -v-1d +%d/%m/%Y`<br />
+				<strong>WEEKAGO:</strong>&nbsp;&nbsp;-d `date -v-1w +%d/%m/%Y`-`date -v-1d +%d/%m/%Y`<br />
+				<strong>MONTHAGO:</strong>&nbsp;&nbsp;-d `date -v-1m +01/%m/%Y`-`date -v-1m +31/%m/%Y`
+				]]>
+			</description>
 			<type>input</type>
 			<size>50</size>
 		</field>
 		<field>
-			<fielddescr>frequency</fielddescr>
+			<fielddescr>Frequency</fielddescr>
 			<fieldname>frequency</fieldname>
 			<type>input</type>
 			<size>5</size>
-			<description><![CDATA[How often extract users from active directory and verify changes<br>
-							Valid options are minutes(m), hours(h), days(d)<br>
-							Sample: To update every hour, use 1h<br><br>]]>&lt;input type=&quot;submit&quot; name=&quot;Submit&quot; value=&quot;Force update now&quot;&gt;&lt;br&gt;</description>
+			<description>
+				<![CDATA[
+				How often should this report be updated.<br />
+				Valid options are: minutes(m), hours(h), days(d)<br />
+				<strong>Example:</strong> To update every hour, use 1h<br /><br />
+				<input type="submit" name="Submit" value="Force update now" /><br />
+				]]>
+			</description>
 			<required/>
 		</field>
 		<field>
-			<fielddescr>Action after sarg</fielddescr>
+			<fielddescr>Action After Sarg</fielddescr>
 			<fieldname>action</fieldname>
+			<description>Choose an action to run after Sarg finishes.</description>
 			<type>select</type>
- 				<options>
- 				<option><name>None(default)</name><value>none</value></option>
-				<option><name>rotate logs</name><value>rotate</value></option>
+ 			<options>
+				<option><name>None (default)</name><value>none</value></option>
+				<option><name>Rotate logs</name><value>rotate</value></option>
 				<option><name>Restart proxy daemon</name><value>restart</value></option>
 				<option><name>Rotate log and restart proxy daemon</name><value>both</value></option>
-				</options>
-			<description>Choose an action after sarg finishes</description>
+			</options>
+			<default_value>none</default_value>
 		</field>
 		<field>
 			<type>listtopic</type>
@@ -179,14 +174,14 @@
 		<field>
 			<fielddescr>Enable Compression</fielddescr>
 			<fieldname>gzip</fieldname>
-			<description><![CDATA[Enable this option to compress sarg report html files using gzip and reduce 4 times sarg reports data.]]></description>
+			<description>Enable this option to compress Sarg HTML report files using gzip. Reduces reports size.</description>
 			<type>checkbox</type>
 		</field>
 		<field>
-			<fielddescr>Compression level</fielddescr>
+			<fielddescr>Compression Level</fielddescr>
 			<fieldname>gziplevel</fieldname>
 			<type>select</type>
- 				<options>
+ 			<options>
  				<option><name>Default gzip compression (Recommended)</name><value></value></option>
 				<option><name>1 (fast)</name><value>--fast</value></option>
 				<option><name>2</name><value>-2</value></option>
@@ -197,7 +192,7 @@
 				<option><name>7</name><value>-7</value></option>
 				<option><name>8</name><value>-8</value></option>
 				<option><name>9 (best)</name><value>--best</value></option>
-				</options>
+			</options>
 			<description>Choose gzip compression level.</description>
 		</field>
 		<field>
@@ -206,21 +201,21 @@
 			<type>input</type>
 			<default_value>60</default_value>
 			<size>5</size>
-			<description><![CDATA[To speed up find process, restrict find search to report files created/changed n minutes ago.<br>
-							Default is to 60 minutes. If your reports take longer to be created, increase this value.]]></description>
+			<description>
+				<![CDATA[
+				To speed up find process, restrict search to report files created/changed specified number of minutes ago.<br />
+				If your reports take long time to be created, increase this value.<br />
+				Default: 60 (minutes).
+				]]>
+			</description>
 		</field>
 	</fields>
-	<custom_php_install_command>
-		sarg_php_install_command();
-	</custom_php_install_command>
-	<custom_php_command_before_form>
-	</custom_php_command_before_form>
 	<custom_php_validation_command>
 		sarg_validate_input($_POST, $input_errors);
 	</custom_php_validation_command>
 	<custom_delete_php_command>
 		sync_package_sarg();
-	</custom_delete_php_command>	
+	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		sarg_resync();
 	</custom_php_resync_config_command>

--- a/config/sarg/sarg_sorttable.js
+++ b/config/sarg/sarg_sorttable.js
@@ -14,321 +14,333 @@
   Licenced as X11: http://www.kryogenix.org/code/browser/licence.html
   This basically means: do what you want with it.
 */
-
- 
-var stIsIE = /*@cc_on!@*/false;
+var stIsIE = /*@cc_on!@*/ false;
 
 sorttable = {
-  init: function() {
-    // quit if this function has already been called
-    if (arguments.callee.done) return;
-    // flag this function so we don't do the same thing twice
-    arguments.callee.done = true;
-    // kill the timer
-    if (_timer) clearInterval(_timer);
-    
-    if (!document.createElement || !document.getElementsByTagName) return;
-    
-    sorttable.DATE_RE = /^(\d\d?)[\/\.-](\d\d?)[\/\.-]((\d\d)?\d\d)$/;
-    
-    forEach(document.getElementsByTagName('table'), function(table) {
-      if (table.className.search(/\bsortable\b/) != -1) {
-        sorttable.makeSortable(table);
-      }
-    });
-    
-  },
-  
-  makeSortable: function(table) {
-    if (table.getElementsByTagName('thead').length == 0) {
-      // table doesn't have a tHead. Since it should have, create one and
-      // put the first table row in it.
-      the = document.createElement('thead');
-      the.appendChild(table.rows[0]);
-      table.insertBefore(the,table.firstChild);
-    }
-    // Safari doesn't support table.tHead, sigh
-    if (table.tHead == null) table.tHead = table.getElementsByTagName('thead')[0];
-    
-    if (table.tHead.rows.length != 1) return; // can't cope with two header rows
-    
-    // Sorttable v1 put rows with a class of "sortbottom" at the bottom (as
-    // "total" rows, for example). This is B&R, since what you're supposed
-    // to do is put them in a tfoot. So, if there are sortbottom rows,
-    // for backwards compatibility, move them to tfoot (creating it if needed).
-    sortbottomrows = [];
-    for (var i=0; i<table.rows.length; i++) {
-      if (table.rows[i].className.search(/\bsortbottom\b/) != -1) {
-        sortbottomrows[sortbottomrows.length] = table.rows[i];
-      }
-    }
-    if (sortbottomrows) {
-      if (table.tFoot == null) {
-        // table doesn't have a tfoot. Create one.
-        tfo = document.createElement('tfoot');
-        table.appendChild(tfo);
-      }
-      for (var i=0; i<sortbottomrows.length; i++) {
-        tfo.appendChild(sortbottomrows[i]);
-      }
-      delete sortbottomrows;
-    }
-    
-    // work through each column and calculate its type
-    headrow = table.tHead.rows[0].cells;
-    for (var i=0; i<headrow.length; i++) {
-      // manually override the type with a sorttable_type attribute
-      if (!headrow[i].className.match(/\bsorttable_nosort\b/)) { // skip this col
-        mtch = headrow[i].className.match(/\bsorttable_([a-z0-9]+)\b/);
-        if (mtch) { override = mtch[1]; }
-	      if (mtch && typeof sorttable["sort_"+override] == 'function') {
-	        headrow[i].sorttable_sortfunction = sorttable["sort_"+override];
-	      } else {
-	        headrow[i].sorttable_sortfunction = sorttable.guessType(table,i);
-	      }
-	      // make it clickable to sort
-	      headrow[i].sorttable_columnindex = i;
-	      headrow[i].sorttable_tbody = table.tBodies[0];
-	      dean_addEvent(headrow[i],"click", function(e) {
+	init: function() {
+		// quit if this function has already been called
+		if (arguments.callee.done) return;
+		// flag this function so we don't do the same thing twice
+		arguments.callee.done = true;
+		// kill the timer
+		if (_timer) clearInterval(_timer);
 
-          if (this.className.search(/\bsorttable_sorted\b/) != -1) {
-            // if we're already sorted by this column, just 
-            // reverse the table, which is quicker
-            sorttable.reverse(this.sorttable_tbody);
-            this.className = this.className.replace('sorttable_sorted',
-                                                    'sorttable_sorted_reverse');
-            this.removeChild(document.getElementById('sorttable_sortfwdind'));
-            sortrevind = document.createElement('span');
-            sortrevind.id = "sorttable_sortrevind";
-            sortrevind.innerHTML = stIsIE ? '&nbsp<font face="webdings">5</font>' : '&nbsp;&#x25B4;';
-            this.appendChild(sortrevind);
-            return;
-          }
-          if (this.className.search(/\bsorttable_sorted_reverse\b/) != -1) {
-            // if we're already sorted by this column in reverse, just 
-            // re-reverse the table, which is quicker
-            sorttable.reverse(this.sorttable_tbody);
-            this.className = this.className.replace('sorttable_sorted_reverse',
-                                                    'sorttable_sorted');
-            this.removeChild(document.getElementById('sorttable_sortrevind'));
-            sortfwdind = document.createElement('span');
-            sortfwdind.id = "sorttable_sortfwdind";
-            sortfwdind.innerHTML = stIsIE ? '&nbsp<font face="webdings">6</font>' : '&nbsp;&#x25BE;';
-            this.appendChild(sortfwdind);
-            return;
-          }
-          
-          // remove sorttable_sorted classes
-          theadrow = this.parentNode;
-          forEach(theadrow.childNodes, function(cell) {
-            if (cell.nodeType == 1) { // an element
-              cell.className = cell.className.replace('sorttable_sorted_reverse','');
-              cell.className = cell.className.replace('sorttable_sorted','');
-            }
-          });
-          sortfwdind = document.getElementById('sorttable_sortfwdind');
-          if (sortfwdind) { sortfwdind.parentNode.removeChild(sortfwdind); }
-          sortrevind = document.getElementById('sorttable_sortrevind');
-          if (sortrevind) { sortrevind.parentNode.removeChild(sortrevind); }
-          
-          this.className += ' sorttable_sorted';
-          sortfwdind = document.createElement('span');
-          sortfwdind.id = "sorttable_sortfwdind";
-          sortfwdind.innerHTML = stIsIE ? '&nbsp<font face="webdings">6</font>' : '&nbsp;&#x25BE;';
-          this.appendChild(sortfwdind);
+		if (!document.createElement || !document.getElementsByTagName) return;
 
-	        // build an array to sort. This is a Schwartzian transform thing,
-	        // i.e., we "decorate" each row with the actual sort key,
-	        // sort based on the sort keys, and then put the rows back in order
-	        // which is a lot faster because you only do getInnerText once per row
-	        row_array = [];
-	        col = this.sorttable_columnindex;
-	        rows = this.sorttable_tbody.rows;
-	        for (var j=0; j<rows.length; j++) {
-	          row_array[row_array.length] = [sorttable.getInnerText(rows[j].cells[col]), rows[j]];
-	        }
-	        /* If you want a stable sort, uncomment the following line */
-	        //sorttable.shaker_sort(row_array, this.sorttable_sortfunction);
-	        /* and comment out this one */
-	        row_array.sort(this.sorttable_sortfunction);
-	        
-	        tb = this.sorttable_tbody;
-	        for (var j=0; j<row_array.length; j++) {
-	          tb.appendChild(row_array[j][1]);
-	        }
-	        
-	        delete row_array;
-	      });
-	    }
-    }
-  },
-  
-  guessType: function(table, column) {
-    // guess the type of a column based on its first non-blank row
-    sortfn = sorttable.sort_alpha;
-    for (var i=0; i<table.tBodies[0].rows.length; i++) {
-      text = sorttable.getInnerText(table.tBodies[0].rows[i].cells[column]);
-      if (text != '') {
-        if (text.match(/^-?[£$¤]?[\d,.]+%?$/)) {
-          return sorttable.sort_numeric;
-        }
-        // check for a date: dd/mm/yyyy or dd/mm/yy 
-        // can have / or . or - as separator
-        // can be mm/dd as well
-        possdate = text.match(sorttable.DATE_RE)
-        if (possdate) {
-          // looks like a date
-          first = parseInt(possdate[1]);
-          second = parseInt(possdate[2]);
-          if (first > 12) {
-            // definitely dd/mm
-            return sorttable.sort_ddmm;
-          } else if (second > 12) {
-            return sorttable.sort_mmdd;
-          } else {
-            // looks like a date, but we can't tell which, so assume
-            // that it's dd/mm (English imperialism!) and keep looking
-            sortfn = sorttable.sort_ddmm;
-          }
-        }
-      }
-    }
-    return sortfn;
-  },
-  
-  getInnerText: function(node) {
-    // gets the text we want to use for sorting for a cell.
-    // strips leading and trailing whitespace.
-    // this is *not* a generic getInnerText function; it's special to sorttable.
-    // for example, you can override the cell text with a customkey attribute.
-    // it also gets .value for <input> fields.
-    
-    hasInputs = (typeof node.getElementsByTagName == 'function') &&
-                 node.getElementsByTagName('input').length;
-    
-    if (node.getAttribute("sorttable_customkey") != null) {
-      return node.getAttribute("sorttable_customkey");
-    }
-    else if (typeof node.textContent != 'undefined' && !hasInputs) {
-      return node.textContent.replace(/^\s+|\s+$/g, '');
-    }
-    else if (typeof node.innerText != 'undefined' && !hasInputs) {
-      return node.innerText.replace(/^\s+|\s+$/g, '');
-    }
-    else if (typeof node.text != 'undefined' && !hasInputs) {
-      return node.text.replace(/^\s+|\s+$/g, '');
-    }
-    else {
-      switch (node.nodeType) {
-        case 3:
-          if (node.nodeName.toLowerCase() == 'input') {
-            return node.value.replace(/^\s+|\s+$/g, '');
-          }
-        case 4:
-          return node.nodeValue.replace(/^\s+|\s+$/g, '');
-          break;
-        case 1:
-        case 11:
-          var innerText = '';
-          for (var i = 0; i < node.childNodes.length; i++) {
-            innerText += sorttable.getInnerText(node.childNodes[i]);
-          }
-          return innerText.replace(/^\s+|\s+$/g, '');
-          break;
-        default:
-          return '';
-      }
-    }
-  },
-  
-  reverse: function(tbody) {
-    // reverse the rows in a tbody
-    newrows = [];
-    for (var i=0; i<tbody.rows.length; i++) {
-      newrows[newrows.length] = tbody.rows[i];
-    }
-    for (var i=newrows.length-1; i>=0; i--) {
-       tbody.appendChild(newrows[i]);
-    }
-    delete newrows;
-  },
-  
-  /* sort functions
-     each sort function takes two parameters, a and b
-     you are comparing a[0] and b[0] */
-  sort_numeric: function(a,b) {
-    aa = parseFloat(a[0].replace(/[^0-9.-]/g,''));
-    if (isNaN(aa)) aa = 0;
-    bb = parseFloat(b[0].replace(/[^0-9.-]/g,'')); 
-    if (isNaN(bb)) bb = 0;
-    return aa-bb;
-  },
-  sort_alpha: function(a,b) {
-    if (a[0]==b[0]) return 0;
-    if (a[0]<b[0]) return -1;
-    return 1;
-  },
-  sort_ddmm: function(a,b) {
-    mtch = a[0].match(sorttable.DATE_RE);
-    y = mtch[3]; m = mtch[2]; d = mtch[1];
-    if (m.length == 1) m = '0'+m;
-    if (d.length == 1) d = '0'+d;
-    dt1 = y+m+d;
-    mtch = b[0].match(sorttable.DATE_RE);
-    y = mtch[3]; m = mtch[2]; d = mtch[1];
-    if (m.length == 1) m = '0'+m;
-    if (d.length == 1) d = '0'+d;
-    dt2 = y+m+d;
-    if (dt1==dt2) return 0;
-    if (dt1<dt2) return -1;
-    return 1;
-  },
-  sort_mmdd: function(a,b) {
-    mtch = a[0].match(sorttable.DATE_RE);
-    y = mtch[3]; d = mtch[2]; m = mtch[1];
-    if (m.length == 1) m = '0'+m;
-    if (d.length == 1) d = '0'+d;
-    dt1 = y+m+d;
-    mtch = b[0].match(sorttable.DATE_RE);
-    y = mtch[3]; d = mtch[2]; m = mtch[1];
-    if (m.length == 1) m = '0'+m;
-    if (d.length == 1) d = '0'+d;
-    dt2 = y+m+d;
-    if (dt1==dt2) return 0;
-    if (dt1<dt2) return -1;
-    return 1;
-  },
-  
-  shaker_sort: function(list, comp_func) {
-    // A stable sort function to allow multi-level sorting of data
-    // see: http://en.wikipedia.org/wiki/Cocktail_sort
-    // thanks to Joseph Nahmias
-    var b = 0;
-    var t = list.length - 1;
-    var swap = true;
+		sorttable.DATE_RE = /^(\d\d?)[\/\.-](\d\d?)[\/\.-]((\d\d)?\d\d)$/;
 
-    while(swap) {
-        swap = false;
-        for(var i = b; i < t; ++i) {
-            if ( comp_func(list[i], list[i+1]) > 0 ) {
-                var q = list[i]; list[i] = list[i+1]; list[i+1] = q;
-                swap = true;
-            }
-        } // for
-        t--;
+		forEach(document.getElementsByTagName('table'), function(table) {
+			if (table.className.search(/\bsortable\b/) != -1) {
+				sorttable.makeSortable(table);
+			}
+		});
 
-        if (!swap) break;
+	},
 
-        for(var i = t; i > b; --i) {
-            if ( comp_func(list[i], list[i-1]) < 0 ) {
-                var q = list[i]; list[i] = list[i-1]; list[i-1] = q;
-                swap = true;
-            }
-        } // for
-        b++;
+	makeSortable: function(table) {
+		if (table.getElementsByTagName('thead').length == 0) {
+			// table doesn't have a tHead. Since it should have, create one and
+			// put the first table row in it.
+			the = document.createElement('thead');
+			the.appendChild(table.rows[0]);
+			table.insertBefore(the, table.firstChild);
+		}
+		// Safari doesn't support table.tHead, sigh
+		if (table.tHead == null) table.tHead = table.getElementsByTagName('thead')[0];
 
-    } // while(swap)
-  }  
+		if (table.tHead.rows.length != 1) return; // can't cope with two header rows
+
+		// Sorttable v1 put rows with a class of "sortbottom" at the bottom (as
+		// "total" rows, for example). This is B&R, since what you're supposed
+		// to do is put them in a tfoot. So, if there are sortbottom rows,
+		// for backwards compatibility, move them to tfoot (creating it if needed).
+		sortbottomrows = [];
+		for (var i = 0; i < table.rows.length; i++) {
+			if (table.rows[i].className.search(/\bsortbottom\b/) != -1) {
+				sortbottomrows[sortbottomrows.length] = table.rows[i];
+			}
+		}
+		if (sortbottomrows) {
+			if (table.tFoot == null) {
+				// table doesn't have a tfoot. Create one.
+				tfo = document.createElement('tfoot');
+				table.appendChild(tfo);
+			}
+			for (var i = 0; i < sortbottomrows.length; i++) {
+				tfo.appendChild(sortbottomrows[i]);
+			}
+			delete sortbottomrows;
+		}
+
+		// work through each column and calculate its type
+		headrow = table.tHead.rows[0].cells;
+		for (var i = 0; i < headrow.length; i++) {
+			// manually override the type with a sorttable_type attribute
+			if (!headrow[i].className.match(/\bsorttable_nosort\b/)) { // skip this col
+				mtch = headrow[i].className.match(/\bsorttable_([a-z0-9]+)\b/);
+				if (mtch) {
+					override = mtch[1];
+				}
+				if (mtch && typeof sorttable["sort_" + override] == 'function') {
+					headrow[i].sorttable_sortfunction = sorttable["sort_" + override];
+				} else {
+					headrow[i].sorttable_sortfunction = sorttable.guessType(table, i);
+				}
+				// make it clickable to sort
+				headrow[i].sorttable_columnindex = i;
+				headrow[i].sorttable_tbody = table.tBodies[0];
+				dean_addEvent(headrow[i], "click", function(e) {
+
+					if (this.className.search(/\bsorttable_sorted\b/) != -1) {
+						// if we're already sorted by this column, just 
+						// reverse the table, which is quicker
+						sorttable.reverse(this.sorttable_tbody);
+						this.className = this.className.replace('sorttable_sorted',
+							'sorttable_sorted_reverse');
+						this.removeChild(document.getElementById('sorttable_sortfwdind'));
+						sortrevind = document.createElement('span');
+						sortrevind.id = "sorttable_sortrevind";
+						sortrevind.innerHTML = stIsIE ? '&nbsp<font face="webdings">5</font>' : '&nbsp;&#x25B4;';
+						this.appendChild(sortrevind);
+						return;
+					}
+					if (this.className.search(/\bsorttable_sorted_reverse\b/) != -1) {
+						// if we're already sorted by this column in reverse, just 
+						// re-reverse the table, which is quicker
+						sorttable.reverse(this.sorttable_tbody);
+						this.className = this.className.replace('sorttable_sorted_reverse',
+							'sorttable_sorted');
+						this.removeChild(document.getElementById('sorttable_sortrevind'));
+						sortfwdind = document.createElement('span');
+						sortfwdind.id = "sorttable_sortfwdind";
+						sortfwdind.innerHTML = stIsIE ? '&nbsp<font face="webdings">6</font>' : '&nbsp;&#x25BE;';
+						this.appendChild(sortfwdind);
+						return;
+					}
+
+					// remove sorttable_sorted classes
+					theadrow = this.parentNode;
+					forEach(theadrow.childNodes, function(cell) {
+						if (cell.nodeType == 1) { // an element
+							cell.className = cell.className.replace('sorttable_sorted_reverse', '');
+							cell.className = cell.className.replace('sorttable_sorted', '');
+						}
+					});
+					sortfwdind = document.getElementById('sorttable_sortfwdind');
+					if (sortfwdind) {
+						sortfwdind.parentNode.removeChild(sortfwdind);
+					}
+					sortrevind = document.getElementById('sorttable_sortrevind');
+					if (sortrevind) {
+						sortrevind.parentNode.removeChild(sortrevind);
+					}
+
+					this.className += ' sorttable_sorted';
+					sortfwdind = document.createElement('span');
+					sortfwdind.id = "sorttable_sortfwdind";
+					sortfwdind.innerHTML = stIsIE ? '&nbsp<font face="webdings">6</font>' : '&nbsp;&#x25BE;';
+					this.appendChild(sortfwdind);
+
+					// build an array to sort. This is a Schwartzian transform thing,
+					// i.e., we "decorate" each row with the actual sort key,
+					// sort based on the sort keys, and then put the rows back in order
+					// which is a lot faster because you only do getInnerText once per row
+					row_array = [];
+					col = this.sorttable_columnindex;
+					rows = this.sorttable_tbody.rows;
+					for (var j = 0; j < rows.length; j++) {
+						row_array[row_array.length] = [sorttable.getInnerText(rows[j].cells[col]), rows[j]];
+					}
+					/* If you want a stable sort, uncomment the following line */
+					//sorttable.shaker_sort(row_array, this.sorttable_sortfunction);
+					/* and comment out this one */
+					row_array.sort(this.sorttable_sortfunction);
+
+					tb = this.sorttable_tbody;
+					for (var j = 0; j < row_array.length; j++) {
+						tb.appendChild(row_array[j][1]);
+					}
+
+					delete row_array;
+				});
+			}
+		}
+	},
+
+	guessType: function(table, column) {
+		// guess the type of a column based on its first non-blank row
+		sortfn = sorttable.sort_alpha;
+		for (var i = 0; i < table.tBodies[0].rows.length; i++) {
+			text = sorttable.getInnerText(table.tBodies[0].rows[i].cells[column]);
+			if (text != '') {
+				if (text.match(/^-?[Å$Â¤]?[\d,.]+%?$/)) {
+					return sorttable.sort_numeric;
+				}
+				// check for a date: dd/mm/yyyy or dd/mm/yy 
+				// can have / or . or - as separator
+				// can be mm/dd as well
+				possdate = text.match(sorttable.DATE_RE)
+				if (possdate) {
+					// looks like a date
+					first = parseInt(possdate[1]);
+					second = parseInt(possdate[2]);
+					if (first > 12) {
+						// definitely dd/mm
+						return sorttable.sort_ddmm;
+					} else if (second > 12) {
+						return sorttable.sort_mmdd;
+					} else {
+						// looks like a date, but we can't tell which, so assume
+						// that it's dd/mm (English imperialism!) and keep looking
+						sortfn = sorttable.sort_ddmm;
+					}
+				}
+			}
+		}
+		return sortfn;
+	},
+
+	getInnerText: function(node) {
+		// gets the text we want to use for sorting for a cell.
+		// strips leading and trailing whitespace.
+		// this is *not* a generic getInnerText function; it's special to sorttable.
+		// for example, you can override the cell text with a customkey attribute.
+		// it also gets .value for <input> fields.
+
+		hasInputs = (typeof node.getElementsByTagName == 'function') &&
+			node.getElementsByTagName('input').length;
+
+		if (node.getAttribute("sorttable_customkey") != null) {
+			return node.getAttribute("sorttable_customkey");
+		} else if (typeof node.textContent != 'undefined' && !hasInputs) {
+			return node.textContent.replace(/^\s+|\s+$/g, '');
+		} else if (typeof node.innerText != 'undefined' && !hasInputs) {
+			return node.innerText.replace(/^\s+|\s+$/g, '');
+		} else if (typeof node.text != 'undefined' && !hasInputs) {
+			return node.text.replace(/^\s+|\s+$/g, '');
+		} else {
+			switch (node.nodeType) {
+				case 3:
+					if (node.nodeName.toLowerCase() == 'input') {
+						return node.value.replace(/^\s+|\s+$/g, '');
+					}
+				case 4:
+					return node.nodeValue.replace(/^\s+|\s+$/g, '');
+					break;
+				case 1:
+				case 11:
+					var innerText = '';
+					for (var i = 0; i < node.childNodes.length; i++) {
+						innerText += sorttable.getInnerText(node.childNodes[i]);
+					}
+					return innerText.replace(/^\s+|\s+$/g, '');
+					break;
+				default:
+					return '';
+			}
+		}
+	},
+
+	reverse: function(tbody) {
+		// reverse the rows in a tbody
+		newrows = [];
+		for (var i = 0; i < tbody.rows.length; i++) {
+			newrows[newrows.length] = tbody.rows[i];
+		}
+		for (var i = newrows.length - 1; i >= 0; i--) {
+			tbody.appendChild(newrows[i]);
+		}
+		delete newrows;
+	},
+
+	/* sort functions
+	   each sort function takes two parameters, a and b
+	   you are comparing a[0] and b[0] */
+	sort_numeric: function(a, b) {
+		aa = parseFloat(a[0].replace(/[^0-9.-]/g, ''));
+		if (isNaN(aa)) aa = 0;
+		bb = parseFloat(b[0].replace(/[^0-9.-]/g, ''));
+		if (isNaN(bb)) bb = 0;
+		return aa - bb;
+	},
+	sort_alpha: function(a, b) {
+		if (a[0] == b[0]) return 0;
+		if (a[0] < b[0]) return -1;
+		return 1;
+	},
+	sort_ddmm: function(a, b) {
+		mtch = a[0].match(sorttable.DATE_RE);
+		y = mtch[3];
+		m = mtch[2];
+		d = mtch[1];
+		if (m.length == 1) m = '0' + m;
+		if (d.length == 1) d = '0' + d;
+		dt1 = y + m + d;
+		mtch = b[0].match(sorttable.DATE_RE);
+		y = mtch[3];
+		m = mtch[2];
+		d = mtch[1];
+		if (m.length == 1) m = '0' + m;
+		if (d.length == 1) d = '0' + d;
+		dt2 = y + m + d;
+		if (dt1 == dt2) return 0;
+		if (dt1 < dt2) return -1;
+		return 1;
+	},
+	sort_mmdd: function(a, b) {
+		mtch = a[0].match(sorttable.DATE_RE);
+		y = mtch[3];
+		d = mtch[2];
+		m = mtch[1];
+		if (m.length == 1) m = '0' + m;
+		if (d.length == 1) d = '0' + d;
+		dt1 = y + m + d;
+		mtch = b[0].match(sorttable.DATE_RE);
+		y = mtch[3];
+		d = mtch[2];
+		m = mtch[1];
+		if (m.length == 1) m = '0' + m;
+		if (d.length == 1) d = '0' + d;
+		dt2 = y + m + d;
+		if (dt1 == dt2) return 0;
+		if (dt1 < dt2) return -1;
+		return 1;
+	},
+
+	shaker_sort: function(list, comp_func) {
+		// A stable sort function to allow multi-level sorting of data
+		// see: http://en.wikipedia.org/wiki/Cocktail_sort
+		// thanks to Joseph Nahmias
+		var b = 0;
+		var t = list.length - 1;
+		var swap = true;
+
+		while (swap) {
+			swap = false;
+			for (var i = b; i < t; ++i) {
+				if (comp_func(list[i], list[i + 1]) > 0) {
+					var q = list[i];
+					list[i] = list[i + 1];
+					list[i + 1] = q;
+					swap = true;
+				}
+			} // for
+			t--;
+
+			if (!swap) break;
+
+			for (var i = t; i > b; --i) {
+				if (comp_func(list[i], list[i - 1]) < 0) {
+					var q = list[i];
+					list[i] = list[i - 1];
+					list[i - 1] = q;
+					swap = true;
+				}
+			} // for
+			b++;
+
+		} // while(swap)
+	}
 }
 
 /* ******************************************************************
@@ -339,7 +351,7 @@ sorttable = {
 
 /* for Mozilla/Opera9 */
 if (document.addEventListener) {
-    document.addEventListener("DOMContentLoaded", sorttable.init, false);
+	document.addEventListener("DOMContentLoaded", sorttable.init, false);
 }
 
 /* for Internet Explorer */
@@ -356,11 +368,11 @@ if (document.addEventListener) {
 
 /* for Safari */
 if (/WebKit/i.test(navigator.userAgent)) { // sniff
-    var _timer = setInterval(function() {
-        if (/loaded|complete/.test(document.readyState)) {
-            sorttable.init(); // call the onload handler
-        }
-    }, 10);
+	var _timer = setInterval(function() {
+		if (/loaded|complete/.test(document.readyState)) {
+			sorttable.init(); // call the onload handler
+		}
+	}, 10);
 }
 
 /* for other browsers */
@@ -434,7 +446,7 @@ fixEvent.preventDefault = function() {
 	this.returnValue = false;
 };
 fixEvent.stopPropagation = function() {
-  this.cancelBubble = true;
+	this.cancelBubble = true;
 }
 
 // Dean's forEach: http://dean.edwards.name/base/forEach.js
@@ -490,4 +502,3 @@ var forEach = function(object, block, context) {
 		resolve.forEach(object, block, context);
 	}
 };
-

--- a/config/sarg/sarg_sync.xml
+++ b/config/sarg/sarg_sync.xml
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-	<![CDATA[
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    sarg_sync.xml
-    part of the sarg package for pfSense
-    Copyright (C) 2012 Marcello Coutinho
-    All rights reserved.            
-                                                                  */
-/* ========================================================================== */
+	sarg_sync.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
 	]]>
 	</copyright>
-	<description>Describe your package here</description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>sargsync</name>
-	<version>1.0</version>
+	<version>0.6.5</version>
 	<title>Status: Sarg Sync</title>
 	<include_file>/usr/local/pkg/sarg.inc</include_file>
 	<tabs>
@@ -75,16 +75,16 @@
 			<text>Help</text>
 			<url>/sarg_about.php</url>
 		</tab>
-</tabs>
+	</tabs>
 	<fields>
 		<field>
 			<name>XMLRPC Sync</name>
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Automatically sync sarg configuration changes</fielddescr>
+			<fielddescr>Automatically Sync Sarg Configuration Changes.</fielddescr>
 			<fieldname>synconchanges</fieldname>
-			<description>Select a sync method for sarg.</description>
+			<description>Select a sync method for Sarg.</description>
 			<type>select</type>
 			<required/>
 			<default_value>auto</default_value>
@@ -95,14 +95,14 @@
 			</options>
 		</field>
 		<field>
-			<fielddescr>Sync timeout</fielddescr>
+			<fielddescr>Sync Timeout</fielddescr>
 			<fieldname>synctimeout</fieldname>
 			<description>Select sync max wait time</description>
 			<type>select</type>
 			<required/>
 			<default_value>250</default_value>
 			<options>
-				<option><name>250 seconds(Default)</name><value>250</value></option>
+				<option><name>250 seconds (default)</name><value>250</value></option>
 				<option><name>120 seconds</name><value>120</value></option>
 				<option><name>90 seconds</name><value>90</value></option>
 				<option><name>60 seconds</name><value>60</value></option>
@@ -114,32 +114,26 @@
 			<fieldname>none</fieldname>
 			<type>rowhelper</type>
 			<rowhelper>
-			<rowhelperfield>
-				<fielddescr>IP Address</fielddescr>
-				<fieldname>ipaddress</fieldname>
-				<description>IP Address of remote server</description>
-				<type>input</type>
-				<size>20</size>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>Password</fielddescr>
-				<fieldname>password</fieldname>
-				<description>Password for remote server.</description>
-				<type>password</type>
-				<size>20</size>
-			</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>IP Address</fielddescr>
+					<fieldname>ipaddress</fieldname>
+					<description>IP Address of remote server</description>
+					<type>input</type>
+					<size>20</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Password</fielddescr>
+					<fieldname>password</fieldname>
+					<description>Password for remote server.</description>
+					<type>password</type>
+					<size>20</size>
+				</rowhelperfield>
 			</rowhelper>
 		</field>
 	</fields>
-	<custom_php_install_command>
-		sarg_php_install_command();
-	</custom_php_install_command>
-	<custom_php_deinstall_command>
-		sarg_php_deinstall_command();
-	</custom_php_deinstall_command>
 	<custom_php_validation_command>
 		sarg_validate_input($_POST, $input_errors);
-	</custom_php_validation_command>	
+	</custom_php_validation_command>
 	<custom_php_resync_config_command>
 		sarg_resync();
 	</custom_php_resync_config_command>

--- a/config/sarg/sarg_users.xml
+++ b/config/sarg/sarg_users.xml
@@ -1,49 +1,48 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-	<![CDATA[
+<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    sarg_users.xml
-    part of the sarg for pfSense
-    Copyright (C) 2012 Marcello Coutinho
-
-    All rights reserved.            
-			                                                                  */
-/* ========================================================================== */
+	sarg_users.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
 	]]>
 	</copyright>
-	<description>Describe your package here</description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>sarguser</name>
-	<version>1.0</version>
+	<version>0.6.5</version>
 	<title>Status: Sarg User Settings</title>
 	<include_file>/usr/local/pkg/sarg.inc</include_file>
 	<tabs>
@@ -76,7 +75,7 @@
 			<text>Help</text>
 			<url>/sarg_about.php</url>
 		</tab>
-</tabs>
+	</tabs>
 	<fields>
 		<field>
 			<name>User Settings</name>
@@ -85,134 +84,171 @@
 		<field>
 			<fielddescr>User Sort Field</fielddescr>
 			<fieldname>user_sort_field</fieldname>
-			<description><![CDATA[Sort field for the User Report.]]></description>
-	    	<type>select</type>
- 				<options>
- 				<option><name>BYTES(default)</name><value>BYTES</value></option>
+			<description>Select the sort field for the User Report.</description>
+			<type>select</type>
+ 			<options>
+ 				<option><name>BYTES (default)</name><value>BYTES</value></option>
  				<option><name>SITE normal</name><value>SITE</value></option>
  				<option><name>CONNECT</name><value>CONNECT</value></option>
  				<option><name>TIME</name><value>TIME</value></option>
- 				</options>
+ 			</options>
+			<default_value>BYTES</default_value>
 		</field>
 		<field>
-		 	<fielddescr>Ntlm User Format</fielddescr>
+		 	<fielddescr>NTLM Users Format</fielddescr>
 			<fieldname>ntlm_user_format</fieldname>
-		 	<description><![CDATA[NTLM users format]]></description>
+		 	<description>Select NTLM username format.</description>
 			<type>select</type>
 			<options>
-			<option><name>domainname+username (default)</name><value>domainname+username</value></option>
-			<option><name>username</name><value>user</value></option>
+				<option><name>domainname+username (default)</name><value>domainname+username</value></option>
+				<option><name>username</name><value>user</value></option>
 			</options>
+			<default_value>domainname+username</default_value>
 		</field>
 		<field>
-			<fielddescr>Exclude users</fielddescr>
+			<fielddescr>Exclude Users</fielddescr>
 			<fieldname>exclude_userlist</fieldname>
-			<description><![CDATA[Users within the file will be excluded from reports.<br>
-									You can use indexonly to have only index.html file.<br>
-									<strong>Format: one user per line.</strong>]]></description>
+			<description>
+				<![CDATA[
+				Users within the file will be excluded from reports.<br />
+				<strong>Format: One user per line.</strong>
+				]]>
+			</description>
 			<type>textarea</type>
 			<cols>70</cols>
 			<rows>10</rows>
 			<encoding>base64</encoding>
 		</field>
 		<field>
-			<fielddescr>Include users</fielddescr>
+			<fielddescr>Include Users</fielddescr>
 			<fieldname>include_userlist</fieldname>
-			<description><![CDATA[Reports will be generated only for listed users.<br> 
-								<strong>Format: user1:user2:...:usern</strong>]]></description>
+			<description>
+				<![CDATA[
+				Reports will be generated only for listed users.<br /> 
+				<strong>Format: user1:user2:...:userN</strong>
+				]]>
+			</description>
 			<type>input</type>
 			<size>70</size>
 		</field>
 		<field>
-			<fielddescr>Users association</fielddescr>
+			<fielddescr>Users Association</fielddescr>
 			<fieldname>usertab</fieldname>
-			<description><![CDATA[You can change the "userid" or the "ip address" to be a real user name on the reports.<br>
-									If resolve_ip is active, the ip address is resolved before being looked up into this file.<br>
-									That is, if you want to map the ip address, be sure to set resolv_ip to no or the resolved name will be looked into the file instead of the ip address.<br>
-									Note that it can be used to resolve any ip address known to the dns and then map the unresolved ip addresses to a name found in the usertab file.<br>
-									<strong>Table syntax: userid name   or   ip address name</strong><br>
-									Eg:<br>SirIsaac Isaac Newton<br>
-									vinci Leonardo da Vinci<br>
-									192.168.10.1 Karol Wojtyla]]></description>
+			<description>
+				<![CDATA[
+				You can change the "userid" or the "IP address" to be a real user name on the reports.<br />
+				If 'Convert IP address to DNS name' is active, the IP address is resolved before being looked up into this file.<br />
+				That is, if you want to map the IP address, be sure to set resolv_ip to no or the resolved name will be looked into the file instead of the IP address.<br />
+				Note that it can be used to resolve any IP address known to the dns and then map the unresolved IP addresses to a name found in the usertab file.<br />
+				<strong>Table syntax: 'userid name' or 'IP_address name'</strong><br /><br />
+				<strong>Examples:</strong><br />
+				SirIsaac Isaac Newton<br />
+				vinci Leonardo da Vinci<br />
+				192.168.10.1 Karol Wojtyla
+				]]>
+			</description>
 			<type>textarea</type>
 			<cols>70</cols>
 			<rows>10</rows>
 			<encoding>base64</encoding>
 		</field>
 		<field>
-			<name>Ldap Settings</name>
+			<name>LDAP Settings</name>
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Enable LDAP search</fielddescr>
+			<fielddescr>Enable LDAP Search</fielddescr>
 			<fieldname>ldap_enable</fieldname>
-			<description><![CDATA[Enable LDAP search for username replacement based on active directory info.<br>
-							This option is usefull to show full usernames in sarg reports instead of user logins.]]></description>
+			<description>
+				<![CDATA[
+				Enable LDAP search for username replacement based on Active Directory information.<br />
+				This option is useful to show full usernames in Sarg reports instead of user logins.
+				]]>
+			</description>
 			<type>checkbox</type>
 		</field>
 		<field>
 			<fielddescr>LDAP Hostname</fielddescr>
 			<fieldname>ldap_host</fieldname>
-			<description><![CDATA[FQDN or IP address of host with LDAP service or AD DC]]></description>
+			<description>FQDN or IP address of host with LDAP service or AD DC.</description>
 			<type>input</type>
 			<size>60</size>
 		</field>
 		<field>
 			<fielddescr>LDAP Port</fielddescr>
 			<fieldname>ldap_port</fieldname>
-			<description><![CDATA[LDAP service port number.<br>Default is 389]]></description>
+			<description>
+				<![CDATA[
+				LDAP service port number.<br />
+				Default: 389
+				]]>
+			</description>
 			<type>input</type>
 			<size>10</size>
+			<default_value>389</default_value>
 		</field>
 		<field>
-			<fielddescr>LDAP Bind DN</fielddescr>
+			<fielddescr>LDAP Bind User DN</fielddescr>
 			<fieldname>ldap_bind_dn</fieldname>
-			<description><![CDATA[DN of LDAP user, who is authorized to read user's names from LDAP base.<br>
-								Sample: CN=username,OU=group,DC=mydomain,DC=com<br>]]></description>
+			<description>
+				<![CDATA[
+				DN of the LDAP user who is authorized to the search the LDAP database.<br />
+				<strong>Example:</strong> CN=username,OU=group,DC=mydomain,DC=com<br />
+				]]>
+			</description>
 			<type>input</type>
 			<size>60</size>
 		</field>
 		<field>
 			<fielddescr>LDAP Bind Password</fielddescr>
 			<fieldname>ldap_bind_pw</fieldname>
-			<description><![CDATA[LDAPBindPW secret Password of DN, who is authorized to read user's names from LDAP base.]]></description>
+			<description>Input the password for 'LDAP Bind User DN' specified above.</description>
 			<type>password</type>
-			<size>10</size>
+			<size>20</size>
 		</field>
 		<field>
-			<fielddescr>LDAP Base Search</fielddescr>
+			<fielddescr>LDAP Search Base DN</fielddescr>
 			<fieldname>ldap_base_search</fieldname>
-			<description><![CDATA[LDAP search base.<br>
-							Sample: OU=users,DC=mydomain,DC=com]]></description>
+			<description>
+				<![CDATA[
+				Specify the LDAP search base DN. The search base is the place in the hierarchical LDAP structure where the search for user accounts starts.<br />
+				<strong>Example:</strong> OU=users,DC=mydomain,DC=com
+				]]>
+			</description>
 			<type>input</type>
 			<size>60</size>
 		</field>
 		<field>
-			<fielddescr>LDAP filter Search</fielddescr>
+			<fielddescr>LDAP Search Filter</fielddescr>
 			<fieldname>ldap_filter_search</fieldname>
-			<description><![CDATA[LDAPFilterSearch (uid=%s)<br>
-							User search filter by user's logins in LDAP. First founded record will be used.<br>
-							%s - will be changed to userlogins from access.log file filter string can have up to 5 '%s' tags.<br>
-							Default value is '(uid=%s)']]></description>
+			<description>
+				<![CDATA[
+				Use this to filter the user login entries to be returned for a search operation in LDAP. First found record will be used.<br />
+				%s - will be changed to user logins from access.log file filter. Search filter string can have up to 5 '%s' tags.<br />
+				Default value: '(uid=%s)'
+				]]>
+			</description>
 			<type>input</type>
 			<size>60</size>
+			<default_value>(uid=%s)</default_value>
 		</field>
 		<field>
-			<fielddescr>LDAP Target Attribute</fielddescr>
+			<fielddescr>LDAP Username DN Attribute</fielddescr>
 			<fieldname>ldap_target_attr</fieldname>
-			<description><![CDATA[Name of the attribute containing a name of the user<br>
-									Default value is 'cn']]></description>
+			<description>
+				<![CDATA[
+				Name of the attribute containing the login name of the user<br />
+				Default value is 'cn'. For Active Directory, use 'sAMAccountName'.
+				]]>
+			</description>
 			<type>input</type>
 			<size>60</size>
+			<default_value>cn</default_value>
 		</field>
 	</fields>
-	<custom_php_install_command>
-	</custom_php_install_command>
-	<custom_php_deinstall_command>
-	</custom_php_deinstall_command>
 	<custom_php_validation_command>
 		sarg_validate_input($_POST, $input_errors);
-	</custom_php_validation_command>	
+	</custom_php_validation_command>
 	<custom_php_resync_config_command>
 		sync_package_sarg();
 	</custom_php_resync_config_command>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -606,7 +606,7 @@
 		<config_file>https://packages.pfsense.org/packages/config/sarg/sarg.xml</config_file>
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,47765.0.html</pkginfolink>
 		<depends_on_package_pbi>sarg-2.3.9-##ARCH##.pbi</depends_on_package_pbi>
-		<version>0.6.4</version>
+		<version>0.6.5</version>
 		<status>Release</status>
 		<required_version>2.2</required_version>
 		<port_category>www</port_category>


### PR DESCRIPTION
sarg.xml
- Fix copyright header
- Nuke unused custom_php_(de)install_command
- Fix file permissions
- Code style and indentation fixes
- Make descriptions readable and improve English.

sarg_users.xml
- Fix copyright header
- Nuke unused custom_php_(de)install_command
- Code style and indentation fixes
- Make descriptions readable and improve English

sarg_schedule.xml
- Fix copyright header
- Nuke unused custom_php_(de)install_command
- Nuke some nonsensical extra menu under Diagnostics
- Fix file permissions
- Code style and indentation fixes
- Make descriptions readable and improve English.

sarg_schedule.xml
- Fix copyright header
- Nuke unused custom_php_(de)install_command
- Code style and indentation fixes
- Description cosmetics

sarg.inc
- Fix copyright header
- Code style and indentation fixes
- Make the arrays declarations readable
- Nuke useless sarg_php_install_command() / sarg_php_deinstall_command() functions

sarg.php
- Fix copyright header
- Code style and indentation fixes

sarg_frame.php
- Update copyright header
- Code style and indentation fixes

sarg_sorttable.js
- Run through JS prettify for readability

sarg_reports.php
- Code style and indentation fixes
- Nuke useless pfSense 1.2.x cruft

sarg_realtime.php
- Code style and indentation fixes
- Nuke useless pfSense 1.2.x cruft
- XHTML fixes

sarg_about.php
- Code style and indentation fixes
- Nuke useless pfSense 1.2.x cruft
- XHTML fixes

sarg.template
- Fix copyright header
- More typo and English fixes.