### PR TITLE
Squid3 - squid pinger helper needs to be suid root (Bug #5114)

### DIFF
--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -309,7 +309,7 @@ function squid_install_command() {
 	/* make sure pinger is executable and suid root */
 	// XXX: Bug #5114
 	if (file_exists(SQUID_LOCALBASE. "/libexec/squid/pinger"))
-		chmod(SQUID_LOCALBASE. "/libexec/squid/pinger", 4755);
+		chmod(SQUID_LOCALBASE. "/libexec/squid/pinger", octdec(4755));
 
 	// XXX: Is it really necessary?
 	if (file_exists("/usr/local/etc/rc.d/squid"))
@@ -1880,7 +1880,7 @@ function squid_resync($via_rpc="no") {
 	/* make sure pinger is executable and suid root */
 	// XXX: Bug #5114
 	if (file_exists(SQUID_LOCALBASE . "/libexec/squid/pinger"))
-		chmod(SQUID_LOCALBASE. "/libexec/squid/pinger", 4755);
+		chmod(SQUID_LOCALBASE. "/libexec/squid/pinger", octdec(4755));
 
 	$log_dir="";
 	// check if squid is enabled

--- a/config/squid3/34/squid.xml
+++ b/config/squid3/34/squid.xml
@@ -46,7 +46,7 @@
     <requirements>Describe your package requirements here</requirements>
     <faq>Currently there are no FAQ items provided.</faq>
 	<name>squid</name>
-	<version>0.2.8</version>
+	<version>0.3.2</version>
 	<title>Proxy server: General settings</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<menu>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1052,7 +1052,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>0.3.1</version>
+		<version>0.3.2</version>
 		<status>beta</status>
 		<required_version>2.2</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>


### PR DESCRIPTION
Squid3 - squid pinger helper needs to be suid root (Bug #5114)