### PR TITLE
squid3 - fix inverted boot check, another attempt to fix pinger (Bug #5114)

### DIFF
--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -309,7 +309,7 @@ function squid_install_command() {
 	/* make sure pinger is executable and suid root */
 	// XXX: Bug #5114
 	if (file_exists(SQUID_LOCALBASE. "/libexec/squid/pinger"))
-		chmod(SQUID_LOCALBASE. "/libexec/squid/pinger", 4755);
+		chgrp(SQUID_LOCALBASE. "/libexec/squid/pinger", SQUID_GID);
 
 	// XXX: Is it really necessary?
 	if (file_exists("/usr/local/etc/rc.d/squid"))
@@ -1880,7 +1880,7 @@ function squid_resync($via_rpc="no") {
 	/* make sure pinger is executable and suid root */
 	// XXX: Bug #5114
 	if (file_exists(SQUID_LOCALBASE . "/libexec/squid/pinger"))
-		chmod(SQUID_LOCALBASE. "/libexec/squid/pinger", 4755);
+		chgrp(SQUID_LOCALBASE. "/libexec/squid/pinger", SQUID_GID);
 
 	$log_dir="";
 	// check if squid is enabled

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -1840,7 +1840,7 @@ function squid_resync($via_rpc="no") {
 
 	// detect boot process
 	if (is_array($_POST)) {
-		if (platform_booting()) {
+		if (!platform_booting()) {
 			unset($boot_process);
 		} else {
 			$boot_process="on";

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1052,7 +1052,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>0.3.1</version>
+		<version>0.3.2</version>
 		<status>beta</status>
 		<required_version>2.2</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>


### PR DESCRIPTION
- The boot check got inverted (obvious brainfart)
- Regarding pinger, the permissions that 4510 (-r-s--x---) root:squid in the (PBI) package. Since we are messing with the GID depending on pfSense version, need to chgrp this to SQUID_GID.