### PR TITLE
servicewatchdog - code style fixes

### DIFF
--- a/config/servicewatchdog/services_servicewatchdog.php
+++ b/config/servicewatchdog/services_servicewatchdog.php
@@ -1,7 +1,9 @@
 <?php
 /*
 	services_servicewatchdog.php
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2013 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -78,7 +80,8 @@ if (isset($_POST['Update'])) {
 				}
 			}
 		}
-	} else { /* No notifies selected, remove them all. */
+	} else {
+		/* No notifies selected, remove them all. */
 		foreach ($a_pwservices as $idx => $thisservice) {
 			unset($a_pwservices[$idx]['notify']);
 		}
@@ -201,15 +204,15 @@ $nservices = $i = 0;
 foreach ($a_pwservices as $thisservice):
 ?>
 	<tr valign="top" id="fr<?=$nservices;?>">
-		<td class="listt"><input type="checkbox" id="frc<?=$nservices;?>" name="pwservices[]" value="<?=$i;?>" onClick="fr_bgcolor('<?=$nservices;?>')" style="margin: 0; padding: 0; width: 15px; height: 15px;" /></td>
-		<td class="listlr"><input type="checkbox" id="notify<?=$nservices;?>" name="notifies[]" value="<?=$i;?>" style="margin: 0; padding: 0; width: 15px; height: 15px;" <?PHP if (isset($thisservice['notify'])) echo 'checked="CHECKED"';?>/></td>
+		<td class="listt"><input type="checkbox" id="frc<?=$nservices;?>" name="pwservices[]" value="<?=$i;?>" onclick="fr_bgcolor('<?=$nservices;?>')" style="margin: 0; padding: 0; width: 15px; height: 15px;" /></td>
+		<td class="listlr"><input type="checkbox" id="notify<?=$nservices;?>" name="notifies[]" value="<?=$i;?>" style="margin: 0; padding: 0; width: 15px; height: 15px;" <?PHP if (isset($thisservice['notify'])) echo 'checked="checked"';?>/></td>
 		<td class="listr" onclick="fr_toggle(<?=$nservices;?>)" id="frd<?=$nservices;?>" ondblclick="document.location='services_servicewatchdog_add.php?id=<?=$nservices;?>';">
 			<?=$thisservice['name'];?>
 		</td>
 		<td class="listr" onclick="fr_toggle(<?=$nservices;?>)" id="frd<?=$nservices;?>" ondblclick="document.location='services_servicewatchdog_add.php?id=<?=$nservices;?>';">
 			<?=$thisservice['description'];?>
 		</td>
-		<td valign="middle" class="list" nowrap>
+		<td valign="middle" class="list" nowrap="nowrap">
 			<table border="0" cellspacing="0" cellpadding="1" summary="add">
 				<tr>
 					<td><input onmouseover="fr_insline(<?=$nservices;?>, true)" onmouseout="fr_insline(<?=$nservices;?>, false)" name="move_<?=$i;?>" src="/themes/<?= $g['theme']; ?>/images/icons/icon_left.gif" title="<?=gettext("move selected services before this service");?>" height="17" type="image" width="17" border="0" /></td>
@@ -225,7 +228,7 @@ endforeach;
 ?>
 	<tr>
 		<td class="list" colspan="4"></td>
-		<td class="list" valign="middle" nowrap>
+		<td class="list" valign="middle" nowrap="nowrap">
 			<table border="0" cellspacing="0" cellpadding="1" summary="add">
 				<tr>
 					<td><?php if ($nservices == 0): ?><img src="/themes/<?= $g['theme']; ?>/images/icons/icon_left_d.gif" width="17" height="17" title="<?=gettext("move selected services to end"); ?>" border="0" alt="move" /><?php else: ?><input name="move_<?=$i;?>" type="image" src="/themes/<?= $g['theme']; ?>/images/icons/icon_left.gif" width="17" height="17" title="<?=gettext("move selected services to end");?>" border="0" alt="move" /><?php endif; ?></td>

--- a/config/servicewatchdog/services_servicewatchdog_add.php
+++ b/config/servicewatchdog/services_servicewatchdog_add.php
@@ -1,7 +1,9 @@
 <?php
 /*
 	services_servicewatchdog_add.php
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2013 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -54,8 +56,9 @@ $system_services = get_services();
 unset($input_errors);
 
 if ($_POST) {
-	if (!is_numeric($_POST['svcid']))
+	if (!is_numeric($_POST['svcid'])) {
 		return;
+	}
 
 	if (!isset($system_services[$_POST['svcid']])) {
 		$input_errors[] = gettext("The supplied service appears to be invalid.");
@@ -93,7 +96,7 @@ include("head.inc");
 	<td width="22%" valign="top" class="vncell"><?=gettext("Service to Add:"); ?></td>
 	<td width="78%" class="vtable">
 		<select name="svcid" class="formselect" id="svcid">
-<?php		$i=0;
+<?php		$i = 0;
 		foreach ($system_services as $svc): ?>
 			<?php if (!servicewatchdog_is_service_watched($svc)): ?>
 			<?php $svc['description'] = empty($svc['description']) ? get_pkg_descr($svc['name']) : $svc['description']; ?>

--- a/config/servicewatchdog/servicewatchdog.inc
+++ b/config/servicewatchdog/servicewatchdog.inc
@@ -1,4 +1,32 @@
 <?php
+/*
+	servicewatchdog.inc
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
 require_once("config.inc");
 require_once("services.inc");
 require_once("service-utils.inc");

--- a/config/servicewatchdog/servicewatchdog.xml
+++ b/config/servicewatchdog/servicewatchdog.xml
@@ -3,24 +3,29 @@
 <?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
 	<copyright>
-	<![CDATA[
-/* ========================================================================== */
+<![CDATA[
+/* $Id$ */
+/* ====================================================================================== */
 /*
 	servicewatchdog.xml
-	part of pfSense (http://www.pfSense.com)
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2013 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
-/* ========================================================================== */
+*/
+/* ====================================================================================== */
 /*
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:
 
-	 1. Redistributions of source code must retain the above copyright notice,
-		this list of conditions and the following disclaimer.
 
-	 2. Redistributions in binary form must reproduce the above copyright
-		notice, this list of conditions and the following disclaimer in the
-		documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
 
 	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
 	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
@@ -32,15 +37,14 @@
 	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
-										*/
-/* ==========================================================================	*/
+*/
+/* ====================================================================================== */
 	]]>
 	</copyright>
 	<description>Service Watchdog</description>
-	<requirements>None</requirements>
 	<faq>Monitors for stopped services and restarts them.</faq>
 	<name>Service Watchdog</name>
-	<version>1.7</version>
+	<version>1.7.1</version>
 	<title>Services: Service Watchdog</title>
 	<include_file>/usr/local/pkg/servicewatchdog.inc</include_file>
 	<menu>
@@ -51,12 +55,10 @@
 	</menu>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>644</chmod>
 		<item>https://packages.pfsense.org/packages/config/servicewatchdog/services_servicewatchdog.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/www/</prefix>
-		<chmod>644</chmod>
 		<item>https://packages.pfsense.org/packages/config/servicewatchdog/services_servicewatchdog_add.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
@@ -66,7 +68,6 @@
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
-		<chmod>644</chmod>
 		<item>https://packages.pfsense.org/packages/config/servicewatchdog/servicewatchdog.inc</item>
 	</additional_files_needed>
 	<custom_php_install_command>

--- a/config/servicewatchdog/servicewatchdog_cron.php
+++ b/config/servicewatchdog/servicewatchdog_cron.php
@@ -1,12 +1,44 @@
 #!/usr/local/bin/php -f
 <?php
+/*
+	servicewatchdog_cron.php
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
 require_once("globals.inc");
 require_once("servicewatchdog.inc");
 
 global $g;
 
 /* Do nothing at bootup. */
-if ($g['booting'] || file_exists("{$g['varrun_path']}/booting")) {
+if (function_exists("platform_booting")) {
+	if (platform_booting()) {
+		return;
+	}
+} elseif ($g['booting']) {
 	return;
 }
 

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1639,7 +1639,7 @@
 		<internal_name>Service_Watchdog</internal_name>
 		<descr>Monitors for stopped services and restarts them.</descr>
 		<maintainer>jimp@pfsense.org</maintainer>
-		<version>1.7</version>
+		<version>1.7.1</version>
 		<category>Services</category>
 		<status>Release</status>
 		<config_file>https://packages.pfsense.org/packages/config/servicewatchdog/servicewatchdog.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1807,7 +1807,7 @@
 		<name>Service Watchdog</name>
 		<descr>Monitors for stopped services and restarts them.</descr>
 		<maintainer>jimp@pfsense.org</maintainer>
-		<version>1.6</version>
+		<version>1.7.1</version>
 		<category>Services</category>
 		<status>Release</status>
 		<config_file>https://packages.pfsense.org/packages/config/servicewatchdog/servicewatchdog.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1794,7 +1794,7 @@
 		<name>Service Watchdog</name>
 		<descr>Monitors for stopped services and restarts them.</descr>
 		<maintainer>jimp@pfsense.org</maintainer>
-		<version>1.6</version>
+		<version>1.7.1</version>
 		<category>Services</category>
 		<status>Release</status>
 		<config_file>https://packages.pfsense.org/packages/config/servicewatchdog/servicewatchdog.xml</config_file>


### PR DESCRIPTION
services_servicewatchdog.php
- Update copyright header and some XHTML cosmetics.

services_servicewatchdog_add.php
- Update copyright header, code style cosmetics.

servicewatchdog.inc
- Add copyright header

servicewatchdog.xml
- Fix copyright header
- Nuke useless tags

servicewatchdog_cron.php
- Add copyright header
- Fix boot check