### PR TITLE
Included 'service-utils.inc' to fix Call to undefined function write_rcfile()

### DIFF
--- a/config/vhosts/vhosts.inc
+++ b/config/vhosts/vhosts.inc
@@ -27,6 +27,9 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
+
+require_once('service-utils.inc');
+
 //sort array
 function sort_host($a, $b) {
 	return strcmp($a["host"], $b["host"]);


### PR DESCRIPTION
Configuring an HTTPS vhost there is an error on line 589 because the function write_rcfile() is defined in /etc/inc/service-utils.inc and must be included to work correctly.