### PR TITLE
ntopng - fix up 2.1.x vs. 2.2.x PBI mess, make $ntopng_config global in ntopng_sync_package()

### DIFF
--- a/config/ntopng/ntopng.inc
+++ b/config/ntopng/ntopng.inc
@@ -151,8 +151,10 @@ function ntopng_sync_package() {
 
 	$start = "";
 	$stop = "";
-	if ($pf_version == "2.1" || $pf_version == "2.2") {
-		$start .= "ldconfig -m /usr/pbi/ntopng-" . php_uname("m") . "/lib\n";
+	if ($pf_version == "2.2") {
+		$start .= "/sbin/ldconfig -m /usr/pbi/ntopng-" . php_uname("m") . "/local/lib\n";
+	} elseif ($pf_version == "2.1") {
+		$start .= "/sbin/ldconfig -m /usr/pbi/ntopng-" . php_uname("m") . "/lib\n";
 	}
 	$start .= "\t{$redis_path}/redis-server --dir /var/db/ntopng/ --dbfilename ntopng.rdb &\n";
 	// TODO:
@@ -206,7 +208,9 @@ function ntopng_redis_started() {
 		$redis_path = "/usr/local/bin";
 	}
 	if (!is_process_running("redis-server")) {
-		if ($pf_version == "2.1" || $pf_version == "2.2") {
+		if ($pf_version == "2.2") {
+			mwexec("/sbin/ldconfig -m /usr/pbi/ntopng-" . php_uname("m") . "/local/lib");
+		} elseif ($pf_version == "2.1") {
 			mwexec("/sbin/ldconfig -m /usr/pbi/ntopng-" . php_uname("m") . "/lib");
 		}
 		mwexec_bg("{$redis_path}/redis-server --dir /var/db/ntopng/ --dbfilename ntopng.rdb");
@@ -260,7 +264,9 @@ function ntopng_update_geoip() {
 	$geoip_asnum = "https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz";
 	$geoip_asnum_v6 = "https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz";
 	$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
-	if ($pf_version == "2.1" || $pf_version == "2.2") {
+	if ($pf_version == "2.2") {
+		$output_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/local/share/ntopng";
+	} elseif ($pf_version == "2.1") {
 		$output_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/share/ntopng";
 	} else {
 		$output_dir = "/usr/local/share/ntopng";
@@ -285,8 +291,11 @@ function ntopng_update_geoip() {
 
 function ntopng_fixup_geoip() {
 	$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
-	if ($pf_version == "2.1" || $pf_version == "2.2") {
+	if ($pf_version == "2.2") {
 		$target_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/local/share/ntopng/httpdocs/geoip";
+		$source_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/local/share/ntopng";
+	} elseif ($pf_version == "2.1") {
+		$target_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/share/ntopng/httpdocs/geoip";
 		$source_dir = "/usr/pbi/ntopng-" . php_uname("m") . "/share/ntopng";
 	} else {
 		$target_dir = "/usr/local/share/ntopng/httpdocs/geoip";

--- a/config/ntopng/ntopng.inc
+++ b/config/ntopng/ntopng.inc
@@ -89,7 +89,7 @@ function ntopng_sync_package() {
 		return;
 	}
 
-	global $g, $config, $pf_version;
+	global $g, $config, $pf_version, $ntopng_config;
 	$pf_version = substr(trim(file_get_contents("/etc/version")), 0, 3);
 
 	$ifaces = "";

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -299,8 +299,8 @@
 			<ports_before>databases/redis databases/gdbm net/GeoIP x11-fonts/font-util x11-fonts/webfonts graphics/graphviz</ports_before>
 			<port>net/ntopng</port>
 		</build_pbi>
-		<version>0.8.0</version>
-		<status>ALPHA</status>
+		<version>0.8.1</version>
+		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/ntopng/ntopng.xml</config_file>
 		<configurationfile>ntopng.xml</configurationfile>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -368,8 +368,8 @@
 			<ports_before>databases/redis databases/gdbm net/GeoIP x11-fonts/font-util x11-fonts/webfonts graphics/graphviz</ports_before>
 			<port>net/ntopng</port>
 		</build_pbi>
-		<version>1.1 v0.8.0</version>
-		<status>ALPHA</status>
+		<version>1.1 v0.8.1</version>
+		<status>BETA</status>
 		<required_version>2.1.4</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/ntopng/ntopng.xml</config_file>
 		<configurationfile>ntopng.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -355,8 +355,8 @@
 			<ports_before>databases/redis databases/gdbm net/GeoIP x11-fonts/font-util x11-fonts/webfonts graphics/graphviz</ports_before>
 			<port>net/ntopng</port>
 		</build_pbi>
-		<version>1.1 v0.8.0</version>
-		<status>ALPHA</status>
+		<version>1.1 v0.8.1</version>
+		<status>BETA</status>
 		<required_version>2.1.4</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/ntopng/ntopng.xml</config_file>
 		<configurationfile>ntopng.xml</configurationfile>


### PR DESCRIPTION
Put $ntopng_config into globals, might fix the service restart after package reinstall...

Note: If someone's going to rebuild the PBIs for https://redmine.pfsense.org/issues/4831 in a reasonable timeframe, this one can definitely wait for that. :wink: 
