### PR TITLE
squid3/squid3-dev - multiple fixes (Bug #5154, Bug #4452, Bug #3847)

### DIFF
--- a/config/squid3/31/squid.inc
+++ b/config/squid3/31/squid.inc
@@ -976,9 +976,9 @@ cache_mem $memory_cache_size MB
 maximum_object_size_in_memory {$max_objsize_in_mem} KB
 memory_replacement_policy {$memory_policy}
 cache_replacement_policy {$cache_policy}
-$disk_cache_opts
 minimum_object_size {$min_objsize} KB
 maximum_object_size {$max_objsize}
+$disk_cache_opts
 offline_mode {$offline_mode}
 EOD;
 

--- a/config/squid3/33/squid.inc
+++ b/config/squid3/33/squid.inc
@@ -1055,6 +1055,8 @@ if(empty($settings['cache_dynamic_content'])){
 }
 else{
 	if(preg_match('/youtube/',$settings['refresh_patterns'])){
+		// Broken (Bug #3847) and not working (http://wiki.squid-cache.org/ConfigExamples/DynamicContent/YouTube#Discussion)
+		/*
 		$conf.=<<< EOC
 # Break HTTP standard for flash videos. Keep them in cache even if asked not to.
 refresh_pattern -i \.flv$ 10080 90% 999999 ignore-no-cache override-expire ignore-private
@@ -1064,6 +1066,7 @@ acl youtube dstdomain .youtube.com
 cache allow youtube
 
 EOC;
+*/
 	}
 	if(preg_match('/windows/',$settings['refresh_patterns'])){
 		$conf.=<<< EOC

--- a/config/squid3/33/squid.inc
+++ b/config/squid3/33/squid.inc
@@ -1125,9 +1125,9 @@ cache_mem $memory_cache_size MB
 maximum_object_size_in_memory {$max_objsize_in_mem} KB
 memory_replacement_policy {$memory_policy}
 cache_replacement_policy {$cache_policy}
-$disk_cache_opts
 minimum_object_size {$min_objsize} KB
 maximum_object_size {$max_objsize}
+$disk_cache_opts
 offline_mode {$offline_mode}
 
 EOD;
@@ -2387,7 +2387,7 @@ function squid_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout) {
 	$xml['squid'] = $config['installedpackages']['squid'];
 	$xml['squidupstream'] = $config['installedpackages']['squidupstream'];
 	$xml['squidcache'] = $config['installedpackages']['squidcache'];
-	$xml['squidantivirus'] = $config['installedpackages']['squidanitivirus'];
+	$xml['squidantivirus'] = $config['installedpackages']['squidantivirus'];
 	$xml['squidnac'] = $config['installedpackages']['squidnac'];
 	$xml['squidtraffic'] = $config['installedpackages']['squidtraffic'];
 	$xml['squidreversegeneral'] = $config['installedpackages']['squidreversegeneral'];

--- a/config/squid3/33/squid_cache.xml
+++ b/config/squid3/33/squid_cache.xml
@@ -280,14 +280,14 @@
 		<field>
 			<fielddescr>Refresh Patterns</fielddescr>
 			<fieldname>refresh_patterns</fieldname>
-			<description><![CDATA[With dynamic cache enabled, you can also apply squid wiki refresh_patterns to sites like <a target=_new href='http://wiki.squid-cache.org/ConfigExamples/DynamicContent/YouTube'>Youtube</a> and <a target=_new href='http://wiki.squid-cache.org/SquidFaq/WindowsUpdate'>windowsupdate</a><br>
+			<description><![CDATA[With dynamic cache enabled, you can also apply squid wiki refresh_patterns to sites like <a target=_new href='http://wiki.squid-cache.org/SquidFaq/WindowsUpdate'>windowsupdate</a><br>
 			<br><strong>Notes:</strong><br>
 			Squid wiki suggests 'Finish transfer if less than x KB remaining' on 'traffic mgmt' squid tab to -1 but you can apply your own values to control cache.<br><br>
 			set Maximum download size on 'traffic mgmt' squid tab to a value that fits patterns your are applying.<br>Microsoft may need 200Mb and youtube 4GB.]]></description>
 			<type>select</type>
 			<default_value>none</default_value>
 			<options>
-				<option><name>Youtube</name><value>youtube</value></option>
+				<!--<option><name>Youtube</name><value>youtube</value></option>-->
 				<option><name>Windows Update</name><value>windows</value></option>
 				<option><name>Symantec Antivirus</name><value>symantec</value></option>
 				<option><name>Avira</name><value>avira</value></option>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1140,7 +1140,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>3.1.20 pkg 2.1.2</version>
+		<version>3.1.20 pkg 2.1.3</version>
 		<status>beta</status>
 		<required_version>2.0</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>
@@ -1167,7 +1167,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>3.3.10 pkg 2.2.8</version>
+		<version>3.3.10 pkg 2.2.9</version>
 		<status>beta</status>
 		<required_version>2.0</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1127,7 +1127,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>3.1.20 pkg 2.1.2</version>
+		<version>3.1.20 pkg 2.1.3</version>
 		<status>beta</status>
 		<required_version>2.0</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>
@@ -1154,7 +1154,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>3.3.10 pkg 2.2.8</version>
+		<version>3.3.10 pkg 2.2.9</version>
 		<status>beta</status>
 		<required_version>2.0</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>


### PR DESCRIPTION
This is for 2.1.x

- move min/max_object_size directives (Bug #5154)
- fix typo breaking squidantivirus XMLRPC sync (Bug #4452)
- make the YouTube caching no-op since it is broken (Bug #3847) and not working anyway because of how YT works (http://wiki.squid-cache.org/ConfigExamples/DynamicContent/YouTube#Discussion)