### PR TITLE
squid3 - bugfixes round 2

### DIFF
--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -1564,6 +1564,10 @@ EOF;
 			$clamav_m[1] = "@http\://proxy.domain.dom/cgi-bin/clwarn.cgi@";
 			$clamav_r[0] = "/var/run/clamav/clamd.sock";
 			$clamav_r[1] = "{$config['system']['webgui']['protocol']}://{$config['system']['hostname']}.{$config['system']['domain']}/squid_clwarn.php";
+			if ($antivirus_config['clamav_safebrowsing'] == "on") {
+				$clamav_m[2] = "@safebrowsing\s0@";
+				$clamav_r[2] = "safebrowsing 1";
+			}
 			file_put_contents(SQUID_LOCALBASE . "/etc/c-icap/squidclamav.conf.sample", preg_replace($clamav_m, $clamav_r, $sample_file), LOCK_EX);
 		}
 		// c-icap.conf
@@ -1615,6 +1619,10 @@ EOF;
 			if ($clamav_mirrors != "") {
 				$freshclam_m[1] = "@#DatabaseMirror db.XY.clamav.net@";
 				$freshclam_r[1] = "{$clamav_mirrors}";
+			}
+			if ($antivirus_config['clamav_safebrowsing'] == "on") {
+				$freshclam_m[2] = "@#SafeBrowsing yes@";
+				$freshclam_r[2] = "SafeBrowsing yes";
 			}
 			file_put_contents(SQUID_LOCALBASE . "/etc/freshclam.conf.sample", preg_replace($freshclam_m, $freshclam_r, $sample_file), LOCK_EX);
 		}
@@ -1682,7 +1690,10 @@ EOF;
 		// Check clamav database
 		if (count(glob("/var/db/clamav/*d")) == 0) {
 			log_error("Squid - Missing /var/db/clamav/*.cvd or *.cld files. Running freshclam in background.");
-			mwexec_bg(SQUID_BASE . "/bin/freshclam");
+			mwexec_bg(SQUID_BASE . "/bin/freshclam --config-file=" . SQUID_BASE . "/etc/freshclam.conf");
+		} elseif (($antivirus_config['clamav_safebrowsing'] == "on") && (!is_file("/var/db/clamav/safebrowsing.cvd"))) {
+			log_error("Squid - Google Safe Browsing is enabled but missing safebrowsing.cvd definitions. Running freshclam in background.");
+			mwexec_bg(SQUID_BASE . "/bin/freshclam --config-file=" . SQUID_BASE . "/etc/freshclam.conf");
 		}
 
 		// check antivirus daemons

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -1621,11 +1621,7 @@ EOF;
 			file_put_contents(SQUID_LOCALBASE . "/etc/freshclam.conf.sample", preg_replace($freshclam_m, $freshclam_r, $sample_file), LOCK_EX);
 		}
 		// freshclam cronjob
-		if ($antivirus_config['enable'] == "on") {
-			squid_install_freshclam_cron(true);
-		} else {
-			squid_install_freshclam_cron(false);
-		}
+		squid_install_freshclam_cron(true);
 
 		// check squidclamav files until PBIs are gone (https://redmine.pfsense.org/issues/4197)
 		$ln_icap = array('bin/c-icap', 'bin/c-icap-client', 'c-icap-config', 'c-icap-libicapapi-config', 'c-icap-stretch', 'lib/c_icap', 'share/c_icap', 'etc/c-icap');

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -1533,7 +1533,12 @@ EOF;
 			$cicap_m[0] = "@Manager:Apassword\S+@";
 			$cicap_r[0] = "";
 			// XXX: Bug #4615
-			$logdir = ($settings['log_dir'] ? $settings['log_dir'] : '/var/squid/logs');
+			if (is_array($config['installedpackages']['squid'])) {
+				$squidsettings = $config['installedpackages']['squid']['config'][0];
+			} else {
+				$squidsettings = array();
+			}
+			$logdir = ($squidsettings['log_dir'] ? $squidsettings['log_dir'] : '/var/squid/logs');
 			$cicap_m[1] = "@DebugLevel\s1@";
 			$cicap_r[1] = "DebugLevel 0";
 			$cicap_m[2] = "@AccessLog /var/log/c-icap/access.log@";

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -1513,9 +1513,9 @@ EOF;
 			if (file_exists(SQUID_LOCALBASE . "/etc/c-icap/squidclamav.conf.default")) {
 				$sample_file = file_get_contents(SQUID_LOCALBASE . "/etc/c-icap/squidclamav.conf.default");
 				$clamav_m[0] = "@/var/run/clamav/clamd.ctl@";
-				$clamav_m[1] = "@cgi-bin/clwarn.cgi@";
+				$clamav_m[1] = "@http\://proxy.domain.dom/cgi-bin/clwarn.cgi@";
 				$clamav_r[0] = "/var/run/clamav/clamd.sock";
-				$clamav_r[1] = "squid_clwarn.php";
+				$clamav_r[1] = "{$config['system']['webgui']['protocol']}://{$config['system']['hostname']}.{$config['system']['domain']}/squid_clwarn.php";
 				file_put_contents(SQUID_LOCALBASE . "/etc/c-icap/squidclamav.conf.sample", preg_replace($clamav_m, $clamav_r, $sample_file), LOCK_EX);
 			}
 		}

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -141,15 +141,20 @@ function squid_dash_z($cache_action = 'none') {
 	// If it already exists, delete it.
 	if ($cachesettings['harddisk_cache_system'] == "null") {
 		if (is_dir($cachedir)) {
-			log_error("Deleting Squid cache dir {$cachedir} since 'Hard Disk Cache System' is set to null.");
-			// cannot nuke disk cache while Squid is running
-			squid_stop_monitor();
-			if (is_service_running('squid')) {
-				stop_service("squid");
+			if (substr($cachedir, 0, 11) === "/var/squid/") {
+				log_error("Deleting Squid cache dir {$cachedir} since 'Hard Disk Cache System' is set to null.");
+				// cannot nuke disk cache while Squid is running
+				squid_stop_monitor();
+				if (is_service_running('squid')) {
+					stop_service("squid");
+				}
+				rename($cachedir, "{$cachedir}.old");
+				mwexec_bg("/bin/rm -rf {$cachedir}.old");
+				squid_restart_services();
+			} else {
+				log_error("'Hard Disk Cache System' is set to null.");
+				log_error("Will NOT delete Squid cache dir '{$cachedir}' since it is not located under /var/squid. Delete manually if required.");
 			}
-			rename($cachedir, "{$cachedir}.old");
-			mwexec_bg("/bin/rm -rf {$cachedir}.old");
-			squid_restart_services();
 		}
 		return;
 	}
@@ -163,8 +168,12 @@ function squid_dash_z($cache_action = 'none') {
 			stop_service("squid");
 		}
 		if (is_dir($cachedir)) {
-			rename($cachedir, "{$cachedir}.old");
-			mwexec_bg("/bin/rm -rf {$cachedir}.old");
+			if (substr($cachedir, 0, 11) === "/var/squid/") {
+				rename($cachedir, "{$cachedir}.old");
+				mwexec_bg("/bin/rm -rf {$cachedir}.old");
+			} else {
+				log_error("Will NOT delete Squid cache dir '{$cachedir}' since it is not located under /var/squid. Delete manually if required.");
+			}
 		}
 		squid_create_cachedir();
 		squid_restart_services();
@@ -423,10 +432,18 @@ function squid_deinstall_command() {
 	$logdir = ($squidsettings['log_dir'] ? $squidsettings['log_dir'] : '/var/squid/logs');
 	// XXX: Is it ok to remove cache and logs? It's going to happen every time package is updated
 	if (is_dir("{$cachedir}")) {
-		mwexec_bg("/bin/rm -rf {$cachedir}");
+		if (substr($cachedir, 0, 11) === "/var/squid/") {
+			mwexec_bg("/bin/rm -rf {$cachedir}");
+		} else {
+			log_error("Will NOT delete Squid cache dir '{$cachedir}' since it is not located under /var/squid. Delete manually if required.");
+		}
 	}
 	if (is_dir("{$logdir}")) {
-		mwexec("/bin/rm -rf {$logdir}");
+		if (substr($logdir, 0, 11) === "/var/squid/") {
+			mwexec("/bin/rm -rf {$logdir}");
+		} else {
+			log_error("Will NOT delete Squid log dir '{$logdir}' since it is not located under /var/squid. Delete manually if required.");
+		}
 	}
 	$dirs = array("/var/run/c-icap", "/var/log/c-icap", "/var/log/clamav", "/var/run/clamav", "/var/db/clamav", "/var/run/squid", "/var/squid");
 	foreach ($dirs as $dir) {
@@ -620,6 +637,18 @@ function squid_validate_cache($post, &$input_errors) {
 				$input_errors[] = "The host '$host' is not a valid IP or hostname.";
 			}
 		}
+	}
+
+	if (substr($post['harddisk_cache_location'], -1, 1) == '/') {
+		$input_errors[] = 'Log location must not end with a / character.';
+	}
+
+	if ($post['harddisk_cache_location']{0} != '/') {
+		$input_errors[] = 'Log location must start with a / character.';
+	}
+
+	if (strlen($post['harddisk_cache_location']) <= 3) {
+		$input_errors[] = "Configured log location directory is not valid.";
 	}
 }
 

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -394,8 +394,9 @@ function squid_install_command() {
 		squid_chown_recursive($dir, SQUID_UID, SQUID_GID);
 	}
 
-	if (!file_exists(SQUID_CONFBASE . '/mime.conf') && file_exists(SQUID_CONFBASE . '/mime.conf.default'))
+	if (!file_exists(SQUID_CONFBASE . '/mime.conf') && file_exists(SQUID_CONFBASE . '/mime.conf.default')) {
 		copy(SQUID_CONFBASE . '/mime.conf.default', SQUID_CONFBASE . '/mime.conf');
+	}
 
 }
 
@@ -1534,7 +1535,7 @@ adaptation_access service_avi_resp allow all
 
 EOF;
 
-		// check if icap is enabled on rc.conf.local
+		// check if clamav/c_icap is enabled in rc.conf.local
 		// XXX: This whole thing sucks and should be redone to install/enable services in pfSense way
 		if (file_exists("/etc/rc.conf.local")) {
 			$rc_old_file = file("/etc/rc.conf.local");

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -1558,15 +1558,13 @@ EOF;
 		squid_check_clamav_user('clamav');
 		// patch sample files to pfsense dirs
 		// squidclamav.conf
-		if (!file_exists(SQUID_LOCALBASE . "/etc/c-icap/squidclamav.conf.sample")) {
-			if (file_exists(SQUID_LOCALBASE . "/etc/c-icap/squidclamav.conf.default")) {
-				$sample_file = file_get_contents(SQUID_LOCALBASE . "/etc/c-icap/squidclamav.conf.default");
-				$clamav_m[0] = "@/var/run/clamav/clamd.ctl@";
-				$clamav_m[1] = "@http\://proxy.domain.dom/cgi-bin/clwarn.cgi@";
-				$clamav_r[0] = "/var/run/clamav/clamd.sock";
-				$clamav_r[1] = "{$config['system']['webgui']['protocol']}://{$config['system']['hostname']}.{$config['system']['domain']}/squid_clwarn.php";
-				file_put_contents(SQUID_LOCALBASE . "/etc/c-icap/squidclamav.conf.sample", preg_replace($clamav_m, $clamav_r, $sample_file), LOCK_EX);
-			}
+		if (file_exists(SQUID_LOCALBASE . "/etc/c-icap/squidclamav.conf.default")) {
+			$sample_file = file_get_contents(SQUID_LOCALBASE . "/etc/c-icap/squidclamav.conf.default");
+			$clamav_m[0] = "@/var/run/clamav/clamd.ctl@";
+			$clamav_m[1] = "@http\://proxy.domain.dom/cgi-bin/clwarn.cgi@";
+			$clamav_r[0] = "/var/run/clamav/clamd.sock";
+			$clamav_r[1] = "{$config['system']['webgui']['protocol']}://{$config['system']['hostname']}.{$config['system']['domain']}/squid_clwarn.php";
+			file_put_contents(SQUID_LOCALBASE . "/etc/c-icap/squidclamav.conf.sample", preg_replace($clamav_m, $clamav_r, $sample_file), LOCK_EX);
 		}
 		// c-icap.conf
 		// make a backup of default c-icap.conf.sample first

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -394,18 +394,12 @@ function squid_deinstall_command() {
 	update_status("Stopping services...");
 	/* kill all running services */
 	mwexec('/usr/local/etc/rc.d/sqp_monitor.sh stop');
-	if (is_process_running("c-icap")) {
-		mwexec('/usr/local/etc/rc.d/c-icap stop');
-	}
-	if (is_process_running("clamd")) {
-		mwexec('/usr/local/etc/rc.d/clamav-clamd stop');
-	}
-	if (is_process_running("freshclam")) {
-		mwexec('/usr/local/etc/rc.d/clamav-freshclam stop');
-	}
-	mwexec("/bin/ps awux | /usr/bin/grep \"squid\" | /usr/bin/grep -v \"grep\" | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
-	mwexec("/bin/ps awux | /usr/bin/grep \"dnsserver\" | /usr/bin/grep -v \"grep\" | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
-	mwexec("/bin/ps awux | /usr/bin/grep \"unlinkd\" | /usr/bin/grep -v \"grep\" | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
+	mwexec("/bin/ps awux | /usr/bin/grep '[c]-icap' | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
+	mwexec("/bin/ps awux | /usr/bin/grep '[c]lamd' | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
+	mwexec("/bin/ps awux | /usr/bin/grep '[f]reshclam' | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
+	mwexec("/bin/ps awux | /usr/bin/grep '[s]quid' | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
+	mwexec("/bin/ps awux | /usr/bin/grep '[d]nsserver' | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
+	mwexec("/bin/ps awux | /usr/bin/grep '[u]nlinkd' | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
 	/* delete rc scripts */
 	unlink_if_exists('/usr/local/etc/rc.d/sqp_monitor.sh');
 	unlink_if_exists('/usr/local/etc/rc.d/c-icap');
@@ -434,7 +428,7 @@ function squid_deinstall_command() {
 	if (is_dir("{$logdir}")) {
 		mwexec("/bin/rm -rf {$logdir}");
 	}
-	$dirs = array("/var/run/c-icap", "/var/log/c-icap", "/var/log/clamav", "/var/run/clamav", "/var/db/clamav");
+	$dirs = array("/var/run/c-icap", "/var/log/c-icap", "/var/log/clamav", "/var/run/clamav", "/var/db/clamav", "/var/run/squid", "/var/squid");
 	foreach ($dirs as $dir) {
 		if (is_dir("{$dir}")) {
 			mwexec("/bin/rm -rf {$dir}");
@@ -453,7 +447,6 @@ function squid_deinstall_command() {
 			unlink("/usr/local/lib/libicapapi.so.3");
 		}
 	}
-
 
 	update_status("Reloading filter...");
 	filter_configure();

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -1729,7 +1729,34 @@ EOF;
 		} else {
 			mwexec_bg("/usr/local/etc/rc.d/clamav-clamd start");
 		}
+	} else {
+		// stop AV services and disable all C-ICAP/AV features
+		log_error("Squid antivirus features disabled.");
+		if (is_process_running("clamd")) {
+			log_error("Stopping ClamAV...");
+			mwexec("/bin/ps awux | /usr/bin/grep '[c]lamd' | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
+		}
+		if (is_process_running("c-icap")) {
+			log_error("Stopping C-ICAP...");
+			mwexec_bg("/usr/local/etc/rc.d/c-icap stop");
+		}
+		// freshclam cronjob
+		log_error("Removing freshclam cronjob...");
+		squid_install_freshclam_cron(false);
+
+		// check if clamav/c_icap is enabled in rc.conf.local
+		// XXX: This whole thing sucks and should be redone to install/enable services in pfSense way
+		if (file_exists("/etc/rc.conf.local")) {
+			log_error("Removing antivirus services from /etc/rc.conf.local...");
+			$sample_file = file_get_contents("/etc/rc.conf.local");
+			$rcconf_local_m[0] = "@c_icap_enable(.*)\n@";
+			$rcconf_local_m[1] = "@clamav_clamd_enable(.*)\n@";
+			$rcconf_local_r[0] = "";
+			$rcconf_local_r[1] = "";
+			file_put_contents("/etc/rc.conf.local", preg_replace($rcconf_local_m, $rcconf_local_r, $sample_file), LOCK_EX);
+		}
 	}
+
 	return $conf;
 }
 

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -138,10 +138,23 @@ function squid_dash_z($cache_action = 'none') {
 	}
 
 	// If the cache system is null, there is no need to initialize the (irrelevant) cache dir.
+	// If it already exists, delete it.
 	if ($cachesettings['harddisk_cache_system'] == "null") {
+		if (is_dir($cachedir)) {
+			log_error("Deleting Squid cache dir {$cachedir} since 'Hard Disk Cache System' is set to null.");
+			// cannot nuke disk cache while Squid is running
+			squid_stop_monitor();
+			if (is_service_running('squid')) {
+				stop_service("squid");
+			}
+			rename($cachedir, "{$cachedir}.old");
+			mwexec_bg("/bin/rm -rf {$cachedir}.old");
+			squid_restart_services();
+		}
 		return;
 	}
-	// Re-create the cachedir if clean is forced by cronjob/manually, or
+
+	// Re-create the cachedir if clean is forced by cronjob/manually,
 	// or if the cachedir changed, or level1_subdirs don't exist or the number of level1_subdirs changed
 	if ($cache_action == "clean" || ((!is_dir($cachedir)) || (!is_dir($cachedir . '/00'))) || ($numdirs !== $currentdirs)) {
 		// cannot nuke disk cache while Squid is running

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -119,6 +119,11 @@ function squid_check_clamav_user($user) {
 	}
 }
 
+function squid_update_clamav() {
+	log_error("Updating ClamAV definitions now... This will take a while. Check /var/log/clamav/freshclam.log for progress information.");
+	mwexec_bg(SQUID_BASE . "/bin/freshclam --config-file=" . SQUID_BASE . "/etc/freshclam.conf");
+}
+
 /* setup cache */
 function squid_dash_z($cache_action = 'none') {
 	global $config;
@@ -397,8 +402,9 @@ function squid_install_command() {
 function squid_deinstall_command() {
 	global $config, $g;
 
-	/* remove cronjob */
+	/* remove cronjobs */
 	squid_install_cron(false);
+	squid_install_freshclam_cron(false);
 
 	update_status("Stopping services...");
 	/* kill all running services */
@@ -472,6 +478,12 @@ function squid_deinstall_command() {
 function squid_validate_antivirus($post, &$input_errors) {
 	global $config;
 
+	/* Manual ClamAV database update */
+	if ($post['submit'] == 'Update AV') {
+		squid_update_clamav();
+		return;
+	}
+
 	if ($post['enable'] != "on") {
 		return;
 	}
@@ -487,6 +499,15 @@ function squid_validate_antivirus($post, &$input_errors) {
 		}
 		if (preg_match("/(Manager:Apassword\S+)/", $post['c-icap_conf'], $c_match)) {
 			$input_errors[] = "Remove ldap configuration'{$c_match[1]}' from 'c-icap.conf' field.";
+		}
+	}
+
+	if ($post['clamav_dbservers']) {
+		foreach (explode(";", $post['clamav_dbservers']) as $dbserver) {
+			$dbserver = trim($dbserver);
+			if (!empty($dbserver) && !is_ipaddr($dbserver) && !is_hostname($dbserver)) {
+				$input_errors[] = "'Optional ClamAV Database Update Servers' entry '$dbserver' is not a valid IP address or hostname.";
+			}
 		}
 	}
 }
@@ -897,6 +918,32 @@ function squid_install_cron($should_install) {
 		}
 	} else {
 		install_cron_job("{$swapstate_cmd}", false);
+	}
+}
+
+function squid_install_freshclam_cron($should_install) {
+	global $config;
+	
+	if (platform_booting()) {
+		return;
+	}
+
+	if (is_array($config['installedpackages']['squidantivirus'])) {
+		$antivirus_config = $config['installedpackages']['squidantivirus']['config'][0];
+	} else {
+		$antivirus_config = array();
+	}
+
+	$freshclam_cmd = (SQUID_BASE . "/bin/freshclam --config-file=" . SQUID_BASE . "/etc/freshclam.conf");
+	if ($should_install) {
+		if ($antivirus_config['clamav_update'] != "0") {
+			$minutes = ($antivirus_config['clamav_update'] * 60);
+			install_cron_job("{$freshclam_cmd}", true, "*/{$minutes}", "*", "*", "*", "*", "clamav");
+		} else {
+			install_cron_job("{$freshclam_cmd}", false);
+		}
+	} else {
+		install_cron_job("{$freshclam_cmd}", false);
 	}
 }
 
@@ -1444,10 +1491,11 @@ EOD;
 function squid_resync_antivirus() {
 	global $config;
 
-	if (is_array($config['installedpackages']['squidantivirus']))
+	if (is_array($config['installedpackages']['squidantivirus'])) {
 		$antivirus_config = $config['installedpackages']['squidantivirus']['config'][0];
-	else
+	} else {
 		$antivirus_config = array();
+	}
 
 	if ($antivirus_config['enable'] == "on") {
 		switch ($antivirus_config['client_info']) {
@@ -1547,6 +1595,36 @@ EOF;
 			$cicap_r[3] = "ServerLog $logdir/c-icap-server.log";
 			file_put_contents(SQUID_LOCALBASE . "/etc/c-icap/c-icap.conf.sample", preg_replace($cicap_m, $cicap_r, $sample_file), LOCK_EX);
 		}
+		// freshclam.conf
+		// make a backup of default freshclam.conf.sample first
+		if (!file_exists(SQUID_LOCALBASE . "/etc/freshclam.conf.default")) {
+			copy(SQUID_LOCALBASE . "/etc/freshclam.conf.sample", SQUID_LOCALBASE . "/etc/freshclam.conf.default");
+		}
+		if (file_exists(SQUID_LOCALBASE . "/etc/freshclam.conf.default")) {
+			$sample_file = file_get_contents(SQUID_LOCALBASE . "/etc/freshclam.conf.default");
+			$freshclam_m[0] = "@#Example@";
+			$freshclam_r[0] = "";
+			$clamav_mirrors = "";
+			if ($antivirus_config['clamav_dbregion'] != "") {
+				$clamav_mirrors .= "DatabaseMirror db.{$antivirus_config['clamav_dbregion']}.clamav.net\n";
+			}
+			if ($antivirus_config['clamav_dbservers'] != "") {
+				foreach (explode(";", $antivirus_config['clamav_dbservers']) as $dbserver) {
+					$clamav_mirrors .= "DatabaseMirror {$dbserver}\n";
+				}
+			}
+			if ($clamav_mirrors != "") {
+				$freshclam_m[1] = "@#DatabaseMirror db.XY.clamav.net@";
+				$freshclam_r[1] = "{$clamav_mirrors}";
+			}
+			file_put_contents(SQUID_LOCALBASE . "/etc/freshclam.conf.sample", preg_replace($freshclam_m, $freshclam_r, $sample_file), LOCK_EX);
+		}
+		// freshclam cronjob
+		if ($antivirus_config['enable'] == "on") {
+			squid_install_freshclam_cron(true);
+		} else {
+			squid_install_freshclam_cron(false);
+		}
 
 		// check squidclamav files until PBIs are gone (https://redmine.pfsense.org/issues/4197)
 		$ln_icap = array('bin/c-icap', 'bin/c-icap-client', 'c-icap-config', 'c-icap-libicapapi-config', 'c-icap-stretch', 'lib/c_icap', 'share/c_icap', 'etc/c-icap');
@@ -1572,6 +1650,10 @@ EOF;
 			$config['installedpackages']['squidantivirus']['config'][0]['c-icap_magic'] = base64_encode(str_replace("\r", "", file_get_contents(SQUID_LOCALBASE . "/etc/c-icap/c-icap.magic.sample")));
 			$loadsample++;
 		}
+		if ($antivirus_config['freshclam_conf'] == "" && file_exists(SQUID_LOCALBASE . "/etc/freshclam.conf.sample")) {
+			$config['installedpackages']['squidantivirus']['config'][0]['freshclam_conf'] = base64_encode(str_replace("\r", "", file_get_contents(SQUID_LOCALBASE . "/etc/freshclam.conf.sample")));
+			$loadsample++;
+		}
 		if ($loadsample > 0) {
 			write_config();
 			$antivirus_config = $config['installedpackages']['squidantivirus']['config'][0];
@@ -1588,11 +1670,7 @@ EOF;
 			safe_mkdir($dir_path, 0755);
 			squid_chown_recursive($dir_path, $dir_user, "wheel");
 		}
-		// Check clamav database
-		if (count(glob("/var/db/clamav/*d")) == 0) {
-			log_error("Squid - Missing /var/db/clamav/*.cvd or *.cld files. Running freshclam in background.");
-			mwexec_bg(SQUID_BASE . "/bin/freshclam");
-		}
+
 		$rcd_files = scandir(SQUID_LOCALBASE."/etc/rc.d");
 		foreach ($rcd_files as $rcd_file) {
 			if (SQUID_LOCALBASE != '/usr/local' && !file_exists("/usr/local/etc/rc.d/{$rcd_file}")) {
@@ -1600,10 +1678,17 @@ EOF;
 			}
 		}
 
-		// write advanced icap config files
+		// write advanced clamav/icap config files
 		file_put_contents(SQUID_LOCALBASE . "/etc/c-icap/squidclamav.conf", base64_decode($antivirus_config['squidclamav']), LOCK_EX);
 		file_put_contents(SQUID_LOCALBASE . "/etc/c-icap/c-icap.conf", base64_decode($antivirus_config['c-icap_conf']), LOCK_EX);
 		file_put_contents(SQUID_LOCALBASE . "/etc/c-icap/c-icap.magic", base64_decode($antivirus_config['c-icap_magic']), LOCK_EX);
+		file_put_contents(SQUID_LOCALBASE . "/etc/freshclam.conf", base64_decode($antivirus_config['freshclam_conf']), LOCK_EX);
+
+		// Check clamav database
+		if (count(glob("/var/db/clamav/*d")) == 0) {
+			log_error("Squid - Missing /var/db/clamav/*.cvd or *.cld files. Running freshclam in background.");
+			mwexec_bg(SQUID_BASE . "/bin/freshclam");
+		}
 
 		// check antivirus daemons
 		// check icap

--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -369,6 +369,7 @@ function squid_install_command() {
 		chgrp(SQUID_LOCALBASE . "/libexec/squid/pinger", SQUID_GID);
 	}
 
+	// create squid rcfile
 	squid_write_rcfile();
 
 	// XXX: Is it really necessary? mode is set to 0755 in squid.xml
@@ -376,11 +377,15 @@ function squid_install_command() {
 		@chmod("/usr/local/pkg/swapstate_check.php", 0755);
 	}
 
+	// create squid monitor rcfile
 	write_rcfile(array(
 		"file" => "sqp_monitor.sh",
 		"start" => "/usr/local/pkg/sqpmon.sh &",
 		"stop" => "/bin/ps awux | /usr/bin/grep \"sqpmon\" | /usr/bin/grep -v \"grep\" | /usr/bin/grep -v \"php\" | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill")
 	);
+	
+	// create c-icap rcfile
+	squid_write_cicap_rcfile();
 
 	// make a backup of default c-icap config file on install; also see squid_resync_antivirus() function below
 	if (!file_exists(SQUID_LOCALBASE . "/etc/c-icap/c-icap.conf.default")) {
@@ -410,7 +415,9 @@ function squid_deinstall_command() {
 	update_status("Stopping services...");
 	/* kill all running services */
 	mwexec('/usr/local/etc/rc.d/sqp_monitor.sh stop');
-	mwexec("/bin/ps awux | /usr/bin/grep '[c]-icap' | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
+	if (is_process_running("c-icap")) {
+		mwexec('/bin/echo -n "stop" > /var/run/c-icap/c-icap.ctl');
+	}
 	mwexec("/bin/ps awux | /usr/bin/grep '[c]lamd' | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
 	mwexec("/bin/ps awux | /usr/bin/grep '[f]reshclam' | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
 	mwexec("/bin/ps awux | /usr/bin/grep '[s]quid' | /usr/bin/awk '{ print $2 }' | /usr/bin/xargs kill");
@@ -419,6 +426,7 @@ function squid_deinstall_command() {
 	/* delete rc scripts */
 	unlink_if_exists('/usr/local/etc/rc.d/sqp_monitor.sh');
 	unlink_if_exists('/usr/local/etc/rc.d/c-icap');
+	unlink_if_exists("/usr/local/etc/rc.d/c-icap.sh");
 	unlink_if_exists('/usr/local/etc/rc.d/clamav-clamd');
 	unlink_if_exists('/usr/local/etc/rc.d/clamav-freshclam');
 
@@ -458,6 +466,7 @@ function squid_deinstall_command() {
 			mwexec("/bin/rm -rf {$dir}");
 		}
 	}
+
 	/* clean up created PBI symlinks */
 	update_status("Finishing package cleanup.");
 	if (SQUID_LOCALBASE != '/usr/local') {
@@ -470,6 +479,17 @@ function squid_deinstall_command() {
 		if (is_link("/usr/local/lib/libicapapi.so.3")) {
 			unlink("/usr/local/lib/libicapapi.so.3");
 		}
+	}
+
+	/* check if clamav/c_icap is enabled in rc.conf.local */
+	if (file_exists("/etc/rc.conf.local")) {
+		update_status("Removing antivirus services from /etc/rc.conf.local...");
+		$sample_file = file_get_contents("/etc/rc.conf.local");
+		$rcconf_local_m[0] = "@c_icap_enable(.*)\n@";
+		$rcconf_local_m[1] = "@clamav_clamd_enable(.*)\n@";
+		$rcconf_local_r[0] = "";
+		$rcconf_local_r[1] = "";
+		file_put_contents("/etc/rc.conf.local", preg_replace($rcconf_local_m, $rcconf_local_r, $sample_file), LOCK_EX);
 	}
 
 	update_status("Reloading filter...");
@@ -1535,21 +1555,18 @@ adaptation_access service_avi_resp allow all
 
 EOF;
 
-		// check if clamav/c_icap is enabled in rc.conf.local
+		// check if clamav is enabled in rc.conf.local
 		// XXX: This whole thing sucks and should be redone to install/enable services in pfSense way
 		if (file_exists("/etc/rc.conf.local")) {
 			$rc_old_file = file("/etc/rc.conf.local");
 			foreach ($rc_old_file as $rc_line) {
-				if (preg_match("/^(c_icap_enable|clamav_clamd_enable)/", $rc_line, $matches)) {
+				if (preg_match("/^clamav_clamd_enable/", $rc_line, $matches)) {
 					$rc_file .= $matches[1] . '="YES"' . "\n";
 					${$matches[1]} = "ok";
 				} else {
 					$rc_file .= $rc_line;
 				}
 			}
-		}
-		if (!isset($c_icap_enable)) {
-			$rc_file .= 'c_icap_enable="YES"' . "\n";
 		}
 		if (!isset($clamav_clamd_enable)) {
 			$rc_file .= 'clamav_clamd_enable="YES"' . "\n";
@@ -1698,20 +1715,14 @@ EOF;
 
 		// check antivirus daemons
 		// check icap
+		$c_icap_rcfile = "/usr/local/etc/rc.d/c-icap.sh";
+		if (!file_exists($c_icap_rcfile)) {
+			squid_write_cicap_rcfile();
+		}
 		if (is_process_running("c-icap")) {
 			mwexec_bg('/bin/echo -n "reconfigure" > /var/run/c-icap/c-icap.ctl');
 		} else {
-			// check c-icap user on startup file
-			$c_icap_rcfile = "/usr/local/etc/rc.d/c-icap";
-			if (file_exists($c_icap_rcfile)) {
-				$sample_file = file_get_contents($c_icap_rcfile);
-				$cicapm[0] = "@c_icap_user=.*}@";
-				$cicapr[0] = 'c_icap_user="clamav"}';
-				$cicapm[1] = "@/usr/local@";
-				$cicapr[1] = SQUID_LOCALBASE;
-				file_put_contents($c_icap_rcfile, preg_replace($cicapm, $cicapr, $sample_file), LOCK_EX);
-			}
-			mwexec_bg("/usr/local/etc/rc.d/c-icap start");
+			mwexec_bg("{$c_icap_rcfile} start");
 		}
 		// check clamav/freshclam
 		$rc_files = array("clamav-freshclam", "clamav-clamd");
@@ -1744,21 +1755,19 @@ EOF;
 		}
 		if (is_process_running("c-icap")) {
 			log_error("Stopping C-ICAP...");
-			mwexec_bg("/usr/local/etc/rc.d/c-icap stop");
+			mwexec_bg("/usr/local/etc/rc.d/c-icap.sh stop");
 		}
 		// freshclam cronjob
 		log_error("Removing freshclam cronjob...");
 		squid_install_freshclam_cron(false);
 
-		// check if clamav/c_icap is enabled in rc.conf.local
+		// check if clamav is enabled in rc.conf.local
 		// XXX: This whole thing sucks and should be redone to install/enable services in pfSense way
 		if (file_exists("/etc/rc.conf.local")) {
 			log_error("Removing antivirus services from /etc/rc.conf.local...");
 			$sample_file = file_get_contents("/etc/rc.conf.local");
-			$rcconf_local_m[0] = "@c_icap_enable(.*)\n@";
-			$rcconf_local_m[1] = "@clamav_clamd_enable(.*)\n@";
+			$rcconf_local_m[0] = "@clamav_clamd_enable(.*)\n@";
 			$rcconf_local_r[0] = "";
-			$rcconf_local_r[1] = "";
 			file_put_contents("/etc/rc.conf.local", preg_replace($rcconf_local_m, $rcconf_local_r, $sample_file), LOCK_EX);
 		}
 	}
@@ -2630,6 +2639,25 @@ EOD;
 	write_rcfile($rc);
 	// force delete the PBI initscript that keeps creeping back
 	unlink_if_exists("/usr/local/etc/rc.d/squid");
+	conf_mount_ro();
+}
+
+function squid_write_cicap_rcfile() {
+	$c_icap_rcfile = "c-icap.sh";
+	$cicap_libdir = SQUID_LOCALBASE . "/lib";
+	$cicap_bin = SQUID_LOCALBASE . "/bin/c-icap";
+	$cicap_conf = SQUID_LOCALBASE . "/etc/c-icap/c-icap.conf";
+	$cicap_start_cmd = "LD_LIBRARY_PATH={$cicap_libdir} {$cicap_bin} -f {$cicap_conf}";
+	$cicap_stop_cmd = '/bin/echo -n "stop" > /var/run/c-icap/c-icap.ctl';
+	conf_mount_rw();
+	write_rcfile(array(
+		"file" => "{$c_icap_rcfile}",
+		"start" => "{$cicap_start_cmd}",
+		"stop" => "{$cicap_stop_cmd}"
+		)
+	);
+	// force delete the PBI initscript that keeps creeping back
+	unlink_if_exists("/usr/local/etc/rc.d/c-icap");
 	conf_mount_ro();
 }
 

--- a/config/squid3/34/squid.xml
+++ b/config/squid3/34/squid.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squid</name>
-	<version>0.3.5.1</version>
+	<version>0.3.7</version>
 	<title>Proxy Server: General Settings</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<menu>
@@ -71,7 +71,7 @@
 	</service>
 	<service>
 		<name>c-icap</name>
-		<rcfile>c-icap</rcfile>
+		<rcfile>c-icap.sh</rcfile>
 		<executable>c-icap</executable>
 		<description>ICAP Inteface for Squid and ClamAV integration</description>
 	</service>
@@ -725,17 +725,14 @@
 	</custom_php_resync_config_command>
 	<custom_php_install_command>
 	<![CDATA[
-		update_status("Checking Squid cache... One moment please...");
 		update_output_window("This operation may take quite some time, please be patient. Do not press stop or attempt to navigate away from this page during this process.");
 		squid_install_command();
-		exec("/bin/rm -f /usr/local/etc/rc.d/squid");
+		unlink_if_exists("/usr/local/etc/rc.d/squid");
+		unlink_if_exists("/usr/local/etc/rc.d/c-icap");
 	]]>
 	</custom_php_install_command>
 	<custom_php_deinstall_command>
-	<![CDATA[
 		squid_deinstall_command();
-		exec("/bin/rm -f /usr/local/etc/rc.d/squid*");
-	]]>
 	</custom_php_deinstall_command>
 	<filter_rules_needed>squid_generate_rules</filter_rules_needed>
 </packagegui>

--- a/config/squid3/34/squid_antivirus.xml
+++ b/config/squid3/34/squid_antivirus.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidantivirus</name>
-	<version>0.3.5</version>
+	<version>0.3.7</version>
 	<title>Proxy server: Antivirus</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<tabs>
@@ -117,6 +117,74 @@
 			</options>
 		</field>
 		<field>
+			<fielddescr>ClamAV Database Update</fielddescr>
+			<fieldname>clamav_update</fieldname>
+			<description>
+				<![CDATA[
+				Optionally, you can schedule ClamAV definitions updates via cron.<br/>
+				Select the desired frequency here.<br/><br/>
+				<input name='submit' type='submit' value='Update AV' />
+				Click the button to update AV databases now.<br/>
+				<strong>Note: This will take a while.</strong> Check /var/log/clamav/freshclam.log for progress information.
+				]]>
+			</description>
+			<type>select</type>
+			<default_value>0</default_value>
+			<options>
+				<option><name>never	  </name><value>0</value></option>
+				<option><name>every 1  hours</name><value>1</value></option>
+				<option><name>every 2  hours</name><value>2</value></option>
+				<option><name>every 3  hours</name><value>3</value></option>
+				<option><name>every 4  hours</name><value>4</value></option>
+				<option><name>every 6  hours</name><value>5</value></option>
+				<option><name>every 8  hours</name><value>6</value></option>
+				<option><name>every 12 hours</name><value>12</value></option>
+				<option><name>every 24 hours</name><value>24</value></option>
+			</options>
+		</field>
+		<field>
+			<fielddescr>Regional ClamAV Database Update Mirror</fielddescr>
+			<fieldname>clamav_dbregion</fieldname>
+			<description>
+				<![CDATA[
+				Select regional database mirror.<br/>
+				<strong><span class="errmsg">Note:</span> It is strongly recommended to choose something here and/or configure your own mirrors manually below.</strong>
+				The default ClamAV database mirror performs extremely slow.
+				]]>
+			</description>
+			<type>select</type>
+			<options>
+				<option><value></value><name>none</name></option>
+				<option><value>au</value><name>Australia</name></option>
+				<option><value>europe</value><name>Europe</name></option>
+				<option><value>ca</value><name>Canada</name></option>
+				<option><value>cn</value><name>China</name></option>
+				<option><value>id</value><name>Indonesia</name></option>
+				<option><value>jp</value><name>Japan</name></option>
+				<option><value>kr</value><name>Korea</name></option>
+				<option><value>ml</value><name>Malaysia</name></option>
+				<option><value>ru</value><name>Russia</name></option>
+				<option><value>sa</value><name>South Africa</name></option>
+				<option><value>tw</value><name>Taiwan</name></option>
+				<option><value>uk</value><name>United Kingdom</name></option>
+				<option><value>us</value><name>United States</name></option>
+			</options>
+		</field>
+		<field>
+			<fielddescr>Optional ClamAV Database Update Servers</fielddescr>
+			<fieldname>clamav_dbservers</fieldname>
+			<description>
+				<![CDATA[
+				Enter ClamAV update servers here, or leave empty.<br />
+				Note: For official update mirrors, use db.XY.clamav.net format. (Replace XY with your <a href="http://www.iana.org/domains/root/db">country code</a>.)<br/>
+				<strong>Note: Separate entries by semi-colons (;)</strong>
+				]]>
+			</description>
+			<type>input</type>
+			<cols>60</cols>
+			<rows>5</rows>
+		</field>
+		<field>
 			<name>Advanced Options</name>
 			<type>listtopic</type>
 		</field>
@@ -142,6 +210,15 @@
 			<fielddescr>c-icap.magic</fielddescr>
 			<fieldname>c-icap_magic</fieldname>
 			<description>c-icap.conf file. Leave empty to load sample file. Edit only if you know what are you doing.</description>
+			<type>textarea</type>
+			<encoding>base64</encoding>
+			<cols>85</cols>
+			<rows>15</rows>
+		</field>
+		<field>
+			<fielddescr>freshclam.conf</fielddescr>
+			<fieldname>freshclam_conf</fieldname>
+			<description>freshclam.conf file. Leave empty to load sample file. Edit only if you know what are you doing.</description>
 			<type>textarea</type>
 			<encoding>base64</encoding>
 			<cols>85</cols>

--- a/config/squid3/34/squid_antivirus.xml
+++ b/config/squid3/34/squid_antivirus.xml
@@ -117,6 +117,19 @@
 			</options>
 		</field>
 		<field>
+			<fielddescr>Google Safe Browsing</fielddescr>
+			<fieldname>clamav_safebrowsing</fieldname>
+			<description>
+				<![CDATA[
+				This option enables support for <a href="http://www.clamav.net/doc/safebrowsing.html">Google Safe Browsing</a>.
+				Google Safe Browsing database includes information about websites that may be <a href="https://support.google.com/code/answer/70015">phishing sites or possible sources of malware</a>.<br/>
+				<strong>Note: This option consumes significant amount of RAM.</strong><br/>
+				<strong><span class="errmsg">Important:</span> Set 'ClamAV Database Update' below to 'every 1 hours' if you want to use this feature!</strong>
+				]]>
+			</description>
+			<type>checkbox</type>
+		</field>
+		<field>
 			<fielddescr>ClamAV Database Update</fielddescr>
 			<fieldname>clamav_update</fieldname>
 			<description>

--- a/config/squid3/34/squid_cache.xml
+++ b/config/squid3/34/squid_cache.xml
@@ -403,10 +403,40 @@
 			<encoding>base64</encoding>
 		</field>
 	</fields>
+	<custom_php_command_before_form>
+	<![CDATA[
+		global $oldcachedir;
+		// do not leave orphaned cachedirs if harddisk_cache_location changed
+		if ($_POST['harddisk_cache_location'] != $config['installedpackages']['squidcache']['config'][0]['harddisk_cache_location']) {
+			$oldcachedir = $config['installedpackages']['squidcache']['config'][0]['harddisk_cache_location'];
+			$cachedir_changed = true;
+		}
+	]]>
+	</custom_php_command_before_form>
 	<custom_php_validation_command>
 		squid_validate_cache($_POST, $input_errors);
 	</custom_php_validation_command>
 	<custom_php_resync_config_command>
+		<![CDATA[
+		if ($cachedir_changed) {
+			// only delete directories under sane paths automatically
+			if (substr($oldcachedir, 0, 11) === "/var/squid/") {
+				log_error("Deleting Squid cache dir '{$oldcachedir}' since 'Hard Disk Cache Location' changed to '{$_POST['harddisk_cache_location']}'.");
+				// cannot nuke disk cache while Squid is running
+				squid_stop_monitor();
+				if (is_service_running('squid')) {
+					stop_service("squid");
+				}
+				rename($oldcachedir, "{$oldcachedir}.old");
+				mwexec_bg("/bin/rm -rf {$oldcachedir}.old");
+				// new cachedir will be created on squid_resync() below which calls squid_dash_z()
+				// also the services will get restarted there
+			} else {
+				log_error("'Hard Disk Cache Location' changed to '{$_POST['harddisk_cache_location']}'.");
+				log_error("Will NOT delete Squid cache dir '{$oldcachedir}' since it is not located under /var/squid. Delete manually if required.");
+			}
+		}
 		squid_resync();
+	]]>
 	</custom_php_resync_config_command>
 </packagegui>

--- a/config/squid3/34/squid_reverse_redir.xml
+++ b/config/squid3/34/squid_reverse_redir.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidreverseredir</name>
-	<version>0.3.5</version>
+	<version>0.3.7</version>
 	<title>Reverse Proxy Server: Redirects</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<tabs>
@@ -138,19 +138,19 @@
 			</options>
 		</field>
 		<field>
-			<fielddescr>Blocked Domains</fielddescr>
+			<fielddescr>
+				<![CDATA[
+				Blocked Domains<br/><br/>
+				Enter the domains to match here.<br/>
+				<strong>Example:</strong> example.com sub.example.com www.example.com<br/><br/>
+				<strong>Do NOT enter http:// or https:// here!</strong> Only the hostname is required.
+				]]>
+			</fielddescr>
 			<fieldname>none</fieldname>
 			<description>Domains to redirect for.</description>
 			<type>rowhelper</type>
 			<rowhelper>
 				<rowhelperfield>
-					<fielddescr>
-						<![CDATA[
-						Enter the domains to match here.<br/>
-						Example: example.com sub.example.com www.example.com<br/><br/>
-						Do <strong>NOT</strong> enter http:// or https:// here! Only the hostname is required.
-						]]>
-					</fielddescr>
 					<fieldname>uri</fieldname>
 					<type>input</type>
 					<size>60</size>

--- a/config/squid3/34/squid_reverse_sync.xml
+++ b/config/squid3/34/squid_reverse_sync.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidsync</name>
-	<version>0.3.5</version>
+	<version>0.3.7</version>
 	<title>Reverse Proxy Server: XMLRPC Sync</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<tabs>
@@ -93,12 +93,12 @@
 		<field>
 			<fielddescr>Sync Timeout</fielddescr>
 			<fieldname>synctimeout</fieldname>
-			<description>Select sync max wait time.</description>
+			<description>XMLRPC timeout in seconds.</description>
 			<type>select</type>
 			<required/>
 			<default_value>250</default_value>
 			<options>
-				<option><name>250 seconds(Default)</name><value>250</value></option>
+				<option><name>250 seconds (Default)</name><value>250</value></option>
 				<option><name>120 seconds</name><value>120</value></option>
 				<option><name>90 seconds</name><value>90</value></option>
 				<option><name>60 seconds</name><value>60</value></option>
@@ -113,14 +113,12 @@
 				<rowhelperfield>
 					<fielddescr>IP Address</fielddescr>
 					<fieldname>ipaddress</fieldname>
-					<description>IP address of remote server.</description>
 					<type>input</type>
 					<size>20</size>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>Password</fielddescr>
+					<fielddescr>Password (admin)</fielddescr>
 					<fieldname>password</fieldname>
-					<description>Password for remote server.</description>
 					<type>password</type>
 					<size>20</size>
 				</rowhelperfield>

--- a/config/squid3/34/squid_reverse_uri.xml
+++ b/config/squid3/34/squid_reverse_uri.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidreverseuri</name>
-	<version>0.3.5</version>
+	<version>0.3.7</version>
 	<title>Reverse Proxy Server: Mappings</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<tabs>
@@ -137,20 +137,20 @@
 			<size>05</size>
 		</field>
 		<field>
-			<fielddescr>URIs</fielddescr>
+			<fielddescr>
+				<![CDATA[
+				URIs<br/><br/>
+				Enter URL <strong>regex</strong> to match.<br/><br/>
+				<strong>Examples:</strong><br/>
+				.mydomain.com .mydomain.com/test<br/>
+				www.mydomain.com http://www.mydomain.com/ ^http://www.mydomain.com/.*$
+				]]>
+			</fielddescr>
 			<fieldname>none</fieldname>
 			<description>URI to publish.</description>
 			<type>rowhelper</type>
 			<rowhelper>
 				<rowhelperfield>
-					<fielddescr>
-						<![CDATA[
-						Enter URL <strong>regex</strong> to match.<br/><br/>
-						Examples:<br/>
-						.mydomain.com .mydomain.com/test<br/>
-						www.mydomain.com http://www.mydomain.com/ ^http://www.mydomain.com/.*$
-						]]>
-					</fielddescr>
 					<fieldname>uri</fieldname>
 					<type>input</type>
 					<size>70</size>

--- a/config/squid3/34/squid_sync.xml
+++ b/config/squid3/34/squid_sync.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidsync</name>
-	<version>0.3.5</version>
+	<version>0.3.7</version>
 	<title>Proxy server: XMLRPC Sync</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<tabs>
@@ -109,12 +109,12 @@
 		<field>
 			<fielddescr>Sync Timeout</fielddescr>
 			<fieldname>synctimeout</fieldname>
-			<description>Select sync max wait time.</description>
+			<description>XMLRPC timeout in seconds.</description>
 			<type>select</type>
 			<required/>
 			<default_value>250</default_value>
 			<options>
-				<option><name>250 seconds(Default)</name><value>250</value></option>
+				<option><name>250 seconds (Default)</name><value>250</value></option>
 				<option><name>120 seconds</name><value>120</value></option>
 				<option><name>90 seconds</name><value>90</value></option>
 				<option><name>60 seconds</name><value>60</value></option>
@@ -129,14 +129,12 @@
 				<rowhelperfield>
 					<fielddescr>IP Address</fielddescr>
 					<fieldname>ipaddress</fieldname>
-					<description>IP address of remote server.</description>
 					<type>input</type>
 					<size>20</size>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>Password</fielddescr>
+					<fielddescr>Password (admin)</fielddescr>
 					<fieldname>password</fieldname>
-					<description>Password for remote server.</description>
 					<type>password</type>
 					<size>20</size>
 				</rowhelperfield>

--- a/config/squid3/34/swapstate_check.php
+++ b/config/squid3/34/swapstate_check.php
@@ -36,12 +36,19 @@ global $config;
 $settings = $config['installedpackages']['squidcache']['config'][0];
 // Only check the cache if Squid is actually caching.
 // If there is no cache then quietly do nothing.
+// If cache dir is located outside of /var/squid hierarchy, log some instructions.
 if (isset($settings['harddisk_cache_system']) && $settings['harddisk_cache_system'] != "null") {
 	$cachedir = ($settings['harddisk_cache_location'] ? $settings['harddisk_cache_location'] : '/var/squid/cache');
 	$swapstate = $cachedir . '/swap.state';
 	if (!file_exists($swapstate)) {
 		return;
 	}
+	if (substr($cachedir, 0, 11) !== "/var/squid/") {
+		log_error("swapstate_check.php will NOT manage Squid cache dir '{$cachedir}' since it is not located under /var/squid.");
+		log_error("Disable 'Clear Cache on Log Rotate' on the 'Local Cache' tab or relocate your cache dir under /var/squid.");
+		return;
+	}
+
 	$disktotal = disk_total_space(dirname($cachedir));
 	$diskfree = disk_free_space(dirname($cachedir));
 	$diskusedpct = round((($disktotal - $diskfree) / $disktotal) * 100);

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1052,7 +1052,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>0.3.6</version>
+		<version>0.3.7</version>
 		<status>beta</status>
 		<required_version>2.2</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>


### PR DESCRIPTION
- Put additional safety checks on cachedir and logdir handling
- Don't leave orphaned cache dirs around
- Better out-of-the-box experience with the AV features (set up sane defaults and do not nag users with confusing input errors)
- Add ClamAV mirrors configuration and cron definition updates
- Add manual AV defs update button to GUI
- Add Google Safe Browsing feature
- Fix C-ICAP so that it actually works
- Some other cleanups and cosmetics