### PR TITLE
Quagga webgui fix for 2.3-alpha

### DIFF
--- a/config/quagga_ospfd/quagga_ospfd.xml
+++ b/config/quagga_ospfd/quagga_ospfd.xml
@@ -112,6 +112,10 @@
 	</plugins>
 	<fields>
 		<field>
+			<name></name>
+			<type>listtopic</type>
+		</field>
+		<field>
 			<fielddescr>Master Password</fielddescr>
 			<fieldname>password</fieldname>
 			<description>Password to access the Zebra and OSPF management daemons. Required.</description>

--- a/config/quagga_ospfd/quagga_ospfd_interfaces.xml
+++ b/config/quagga_ospfd/quagga_ospfd_interfaces.xml
@@ -98,6 +98,10 @@
 	</service>
 	<fields>
 		<field>
+			<name></name>
+			<type>listtopic</type>
+		</field>	
+		<field>
 			<fielddescr>Interface</fielddescr>
 			<fieldname>interface</fieldname>
 			<description>Enter the desired participating interface here.</description>

--- a/config/quagga_ospfd/quagga_ospfd_raw.xml
+++ b/config/quagga_ospfd/quagga_ospfd_raw.xml
@@ -88,6 +88,10 @@
 	</service>
 	<fields>
 		<field>
+			<name></name>
+			<type>listtopic</type>
+		</field>
+		<field>
 			<fielddescr>ospfd.conf</fielddescr>
 			<fieldname>ospfd</fieldname>
 			<description>


### PR DESCRIPTION
see https://forum.pfsense.org/index.php?topic=100249.0 
https://redmine.pfsense.org/issues/5239

it appears you need a "listtopic" field with a name or else addInput spawns an error. (perhaps it can be worked around in another way aswell)

if this is not the intended behaviour, then it might be better if someone took a look at addInput() and work around it there.