### PR TITLE
Do not allow HAVP to be installed along Squid3

### DIFF
--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1201,6 +1201,7 @@
 			<ports_after>security/clamav</ports_after>
 		</build_pbi>
 		<build_options>CLAMAVUSER=havp;CLAMAVGROUP=havp</build_options>
+		<conflicts>squid3</conflicts>
 		<version>1.10.0</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1377,6 +1377,7 @@
 		<depends_on_package_pbi>havp-0.91_1-i386.pbi</depends_on_package_pbi>
 		<build_port_path>/usr/ports/www/havp</build_port_path>
 		<build_options>CLAMAVUSER=havp;CLAMAVGROUP=havp</build_options>
+		<conflicts>squid3-dev</conflicts>
 		<version>0.91_1 pkg v1.10.0</version>
 		<status>BETA</status>
 		<required_version>1.2.2</required_version>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1364,6 +1364,7 @@
 		<depends_on_package_pbi>havp-0.91_1-amd64.pbi</depends_on_package_pbi>
 		<build_port_path>/usr/ports/www/havp</build_port_path>
 		<build_options>CLAMAVUSER=havp;CLAMAVGROUP=havp</build_options>
+		<conflicts>squid3-dev</conflicts>
 		<version>0.91_1 pkg v1.10.0</version>
 		<status>BETA</status>
 		<required_version>1.2.2</required_version>


### PR DESCRIPTION
This uses same directories as Squid3 for ClamAV, installs duplicate ClamAV service, screws directory permissions for Squid's ClamAV instance and produces general mess. People with Squid3 should use C-ICAP and not this dead thing!