### PR TITLE
Squid3 - cronjob handling fixes

### DIFF
--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -260,7 +260,7 @@ function squid_dash_z($cache_action = 'none') {
 		return;
 	}
 
-	// Re-create the cachedir if clean is forced by cronjob/manually,
+	// Re-create the cachedir if clean is forced by manually,
 	// or if the cachedir changed, or level1_subdirs don't exist or the number of level1_subdirs changed
 	if ($cache_action == "clean" || !is_dir($cachedir) || !is_dir($cachedir . '/00') || $numdirs != $currentdirs) {
 		// cannot nuke disk cache while Squid is running
@@ -319,32 +319,15 @@ function squid_create_cachedir() {
 
 /* Handle cronjob install/uninstall */
 function squid_install_cron($should_install) {
-	global $config;
-
 	if (platform_booting()) {
 		return;
 	}
 
-	parse_config(true);
-	if (is_array($config['installedpackages']['squidcache'])) {
-		$settings = $config['installedpackages']['squidcache']['config'][0];
-	} else {
-		$settings = array();
-	}
-
-	$cron_cmd = ($settings['clear_cache'] == 'on' ? "/usr/local/pkg/swapstate_check.php clean; " : "");
-	$cron_cmd .= SQUID_BASE . "/sbin/squid -k rotate -f " . SQUID_CONFFILE;
-	install_cron_job("{$cron_cmd}", $should_install, "0", "0", "*", "*", "*", "root");
-
-	$swapstate_cmd = "/usr/local/pkg/swapstate_check.php clean; ";
+	$cron_cmd = SQUID_BASE . "/sbin/squid -k rotate -f " . SQUID_CONFFILE;
 	if (($should_install) && (squid_enabled())) {
-		if ($settings['clear_cache'] == 'on' ) {
-			install_cron_job("{$swapstate_cmd}", true, "*/360");
-		} else {
-			install_cron_job("{$swapstate_cmd}", false);
-		}
+		install_cron_job("{$cron_cmd}", $should_install, "0", "0", "*", "*", "*", "root");
 	} else {
-		install_cron_job("{$swapstate_cmd}", false);
+		install_cron_job("{$cron_cmd}", false);
 	}
 }
 
@@ -506,6 +489,9 @@ function squid_install_command() {
 
 	// remove unwanted PBI rc script
 	unlink_if_exists("/usr/local/etc/rc.d/squid");
+
+	// remove broken cronjob possibly left over after 'Clear Cache on Log Rotate' misfeature
+	install_cron_job("/usr/local/pkg/swapstate_check.php clean;", false);
 
 }
 

--- a/config/squid3/34/squid_antivirus.inc
+++ b/config/squid3/34/squid_antivirus.inc
@@ -73,15 +73,14 @@ function squid_install_freshclam_cron($should_install) {
 		return;
 	}
 
-	if (is_array($config['installedpackages']['squidantivirus'])) {
-		$antivirus_config = $config['installedpackages']['squidantivirus']['config'][0];
-	} else {
-		$antivirus_config = array();
-	}
-
 	$freshclam_cmd = (SQUID_BASE . "/bin/freshclam --config-file=" . SQUID_BASE . "/etc/freshclam.conf");
 	if (($should_install) && (squid_enabled())) {
-		if ($antivirus_config['clamav_update'] != "0") {
+		if (is_array($config['installedpackages']['squidantivirus'])) {
+			$antivirus_config = $config['installedpackages']['squidantivirus']['config'][0];
+		} else {
+			$antivirus_config = array();
+		}
+		if ($antivirus_config['clamav_update'] != "") {
 			log_error("[squid] Adding freshclam cronjob.");
 			$minutes = ($antivirus_config['clamav_update'] * 60);
 			install_cron_job("{$freshclam_cmd}", true, "*/{$minutes}", "*", "*", "*", "*", "clamav");

--- a/config/squid3/34/squid_antivirus.xml
+++ b/config/squid3/34/squid_antivirus.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidantivirus</name>
-	<version>0.3.9</version>
+	<version>0.3.9.2</version>
 	<title>Proxy server: Antivirus</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<tabs>
@@ -179,13 +179,13 @@
 			<type>select</type>
 			<default_value>0</default_value>
 			<options>
-				<option><name>never	  </name><value>0</value></option>
+				<option><name>never	  </name><value></value></option>
 				<option><name>every 1  hours</name><value>1</value></option>
 				<option><name>every 2  hours</name><value>2</value></option>
 				<option><name>every 3  hours</name><value>3</value></option>
 				<option><name>every 4  hours</name><value>4</value></option>
-				<option><name>every 6  hours</name><value>5</value></option>
-				<option><name>every 8  hours</name><value>6</value></option>
+				<option><name>every 6  hours</name><value>6</value></option>
+				<option><name>every 8  hours</name><value>8</value></option>
 				<option><name>every 12 hours</name><value>12</value></option>
 				<option><name>every 24 hours</name><value>24</value></option>
 			</options>

--- a/config/squid3/34/squid_cache.xml
+++ b/config/squid3/34/squid_cache.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidcache</name>
-	<version>0.3.5</version>
+	<version>0.3.9.2</version>
 	<title>Proxy Server: Cache management</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<tabs>
@@ -215,17 +215,6 @@
 				<option><name>diskd</name><value>diskd</value></option>
 				<option><name>null</name><value>null</value></option>
 			</options>
-		</field>
-		<field>
-			<fielddescr>Clear Cache on Log Rotate</fielddescr>
-			<fieldname>clear_cache</fieldname>
-			<description>
-				<![CDATA[
-				If set, Squid will clear cache and swap.state every time the log is rotated.<br/>
-				Note: This action will be executed automatically if the swap.state file is taking up more than 75% of available space, or the filesystem is 90% full.
-				]]>
-			</description>
-			<type>checkbox</type>
 		</field>
 		<field>
 			<fielddescr>Level 1 Directories</fielddescr>

--- a/config/squid3/34/swapstate_check.php
+++ b/config/squid3/34/swapstate_check.php
@@ -44,8 +44,7 @@ if (isset($settings['harddisk_cache_system']) && $settings['harddisk_cache_syste
 		return;
 	}
 	if (substr($cachedir, 0, 11) !== "/var/squid/") {
-		log_error("swapstate_check.php will NOT manage Squid cache dir '{$cachedir}' since it is not located under /var/squid.");
-		log_error("Disable 'Clear Cache on Log Rotate' on the 'Local Cache' tab or relocate your cache dir under /var/squid.");
+		log_error("[squid] swapstate_check.php will NOT manage Squid cache dir '{$cachedir}' since it is not located under /var/squid.");
 		return;
 	}
 
@@ -67,15 +66,12 @@ if (isset($settings['harddisk_cache_system']) && $settings['harddisk_cache_syste
 	if ($swapstate_size > 1024*1024*1024) {
 		$rotate_reason .= "$cachedir/swap.state is larger than 1GB. ";
 	}
-	if ($settings['clear_cache'] == 'on') {
-		$rotate_reason .= "'Clear Cache on Log Rotate' is enabled in 'Local Cache' settings. ";
-	}
 	if ($argv[1] == "clean") {
-		$rotate_reason .= "Clear cache forced by cronjob. ";
+		$rotate_reason .= "Clear cache forced by running swapstate_check.php manually with {$argv[1]} argument. ";
 	}
 	if (($swapstate_pct > 75) || (($diskusedpct > 90) && ($swapstate_size > 1024*1024*1024)) || $argv[1] == "clean") {
 		squid_dash_z('clean');
-		log_error(gettext(sprintf("$rotate_reason Removing and rotating. File was %d bytes, %d%% of total disk space.", $swapstate_size, $swapstate_pct)));
+		log_error(gettext(sprintf("[squid] $rotate_reason Removing and rotating. File was %d bytes, %d%% of total disk space.", $swapstate_size, $swapstate_pct)));
 	}
 }
 ?>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1052,7 +1052,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>0.3.9.1</version>
+		<version>0.3.9.2</version>
 		<status>beta</status>
 		<required_version>2.2</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>


### PR DESCRIPTION
- Remove 'Clear Cache on Log Rotate' misfeature from local cache settings. This has only been a source of complaints, breakage and confusion, plus was breaking Save on the General tab for people.
- Fix freshclam cronjob frequency handling