### PR TITLE
haproxy1_5: remove weird visibility:hidden when a listener is secondary

### DIFF
--- a/config/haproxy1_5/www/haproxy_listeners.php
+++ b/config/haproxy1_5/www/haproxy_listeners.php
@@ -205,7 +205,7 @@ function js_callback(req) {
 						title="<?=gettext("click to toggle enable/disable this frontend");?>" alt="icon" />
 					</a>
 				  </td>
-				  <td class="listr" style="<?=$frontend['secondary']=='yes'?"visibility:hidden;":""?>" ondblclick="document.location='haproxy_listeners_edit.php?id=<?=$frontendname;?>';">
+				  <td class="listr" ondblclick="document.location='haproxy_listeners_edit.php?id=<?=$frontendname;?>';">
 					<?=$frontend['secondary']!='yes'?"yes":"no";?>
 				  </td>
 				  <td class="listr" ondblclick="document.location='haproxy_listeners_edit.php?id=<?=$frontendname;?>';">


### PR DESCRIPTION
With the current version of haproxy1_5 package, I have this behavior in the interface when having shared frontends (in the frontends section) :
![current](https://cloud.githubusercontent.com/assets/6303650/10425007/6ddcf0ac-70d4-11e5-9889-09d1265a16c0.jpg)

With the patch I get something more normal :
![withpatch](https://cloud.githubusercontent.com/assets/6303650/10425010/72dbb62e-70d4-11e5-9a0a-cf3a5f4d409b.jpg)
