### PR TITLE
Fix the package manager idiocy with trailing slash

### DIFF
--- a/config/squid3/34/squid.xml
+++ b/config/squid3/34/squid.xml
@@ -128,7 +128,7 @@
 		<item>https://packages.pfsense.org/packages/config/squid3/34/squid_antivirus.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
-		<prefix>/usr/local/www/widgets/include</prefix>
+		<prefix>/usr/local/www/widgets/include/</prefix>
 		<item>https://packages.pfsense.org/packages/config/squid3/34/squid_antivirus_status.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
@@ -204,7 +204,7 @@
 	<!-- END XML files -->
 	<!-- START additional PHP files -->
 	<additional_files_needed>
-		<prefix>/usr/local/www/widgets/widgets</prefix>
+		<prefix>/usr/local/www/widgets/widgets/</prefix>
 		<item>https://packages.pfsense.org/packages/config/squid3/34/squid_antivirus_status.widget.php</item>
 	</additional_files_needed>
 	<additional_files_needed>


### PR DESCRIPTION
Seriously, people? It cannot handle this and mangles things to includesquid_antivirus_status.inc and  widgetssquid_antivirus_status.widget.php? Kindly fix the thing.