### PR TITLE
haproxy1_5: add the port option for health-checks in pools interface

### DIFF
--- a/config/haproxy1_5/pkg/haproxy.inc
+++ b/config/haproxy1_5/pkg/haproxy.inc
@@ -697,6 +697,9 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 			$checkinter = " check inter {$pool['checkinter']}";
 		else 
 			$checkinter = " check inter 1000";
+
+		if($pool['checkport'])
+			$checkinter .= " port {$pool['checkport']}";
 	}
 	
 	//agent-check requires at least haproxy v1.5dev20

--- a/config/haproxy1_5/www/haproxy_pool_edit.php
+++ b/config/haproxy1_5/www/haproxy_pool_edit.php
@@ -59,7 +59,7 @@ if (isset($_GET['dup']))
 global $simplefields;
 $simplefields = array(
 "name","balance","transparent_clientip","transparent_interface",
-"check_type","checkinter","log-health-checks","httpcheck_method","monitor_uri","monitor_httpversion","monitor_username","monitor_domain","monitor_agentport",
+"check_type","checkinter","checkport","log-health-checks","httpcheck_method","monitor_uri","monitor_httpversion","monitor_username","monitor_domain","monitor_agentport",
 "agent_check","agent_port","agent_inter",
 "connection_timeout","server_timeout","retries",
 "stats_enabled","stats_username","stats_password","stats_uri","stats_scope","stats_realm","stats_admin","stats_node","stats_desc","stats_refresh",
@@ -232,6 +232,9 @@ if ($_POST) {
 	
 	if ($_POST['checkinter'] !== "" && !is_numeric($_POST['checkinter']))
 		$input_errors[] = "The field 'Check frequency' value is not a number.";
+
+	if ($_POST['checkport'] !== "" && !is_numeric($_POST['checkport']))
+		$input_errors[] = "The field 'Check Port' value is not a number.";
 	
 	if ($_POST['connection_timeout'] !== "" && !is_numeric($_POST['connection_timeout']))
 		$input_errors[] = "The field 'Connection timeout' value is not a number.";
@@ -648,6 +651,13 @@ foreach($simplefields as $field){
 			<td width="78%" class="vtable" colspan="2">
 				<input name="checkinter" type="text" <?if(isset($pconfig['checkinter'])) echo "value=\"{$pconfig['checkinter']}\"";?> size="20" /> milliseconds
 				<br/>For HTTP/HTTPS defaults to 1000 if left blank. For TCP no check will be performed if left empty.
+			</td>
+		</tr>
+		<tr align="left" class="haproxy_check_enabled">
+			<td width="22%" valign="top" class="vncell">Check port</td>
+			<td width="78%" class="vtable" colspan="2">
+				<input name="checkport" type="text" <?if(isset($pconfig['checkport'])) echo "value=\"{$pconfig['checkport']}\"";?> size="20" />
+				<br/>Use an alternative port to send health-checks.
 			</td>
 		</tr>
 		<tr align="left" class="haproxy_check_enabled">


### PR DESCRIPTION
In HAProxy1_5 package, handle the option "port" on backends health-checks to use a custom port. For example HAproxy is load-balancing on my webservers on port 80 but I have a custom check service available on port 9200.

See documentation :
http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#port

![check-port-option](https://cloud.githubusercontent.com/assets/6303650/10488498/3a1807ea-7299-11e5-8dc6-3bd0092dfdb3.jpg)
