### PR TITLE
snort - XMLRPC sync fixes

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -3802,11 +3802,7 @@ function snort_sync_on_changes() {
 					$protocol = $sh['varsyncprotocol'];
 					$error = '';
 					$success = TRUE;
-					if ($sh['varsyncusername']) {
-						$username = $sh['varsyncusername'];
-					} else {
-						$username = 'admin';
-					}
+					$username = $sh['varsyncusername'] ?: 'admin';
 					if ($password == "") {
 						$error = "Password parameter is empty. ";
 						$success = FALSE;

--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -3737,103 +3737,121 @@ function snort_sync_on_changes() {
 
 	/* Do not attempt a package sync while booting up or installing package */
 	if ($g['booting'] || $g['snort_postinstall']) {
-		log_error("[snort] No xmlrpc sync to CARP targets when booting up or during package reinstallation.");
+		log_error("[snort] Skipping XMLRPC sync when booting up or during package reinstallation.");
 		return;
 	}
 
 	if (is_array($config['installedpackages']['snortsync']['config'])){
-		$snort_sync=$config['installedpackages']['snortsync']['config'][0];
+		$snort_sync = $config['installedpackages']['snortsync']['config'][0];
 		$synconchanges = $snort_sync['varsynconchanges'];
-		$synctimeout = $snort_sync['varsynctimeout'];
+		$synctimeout = $snort_sync['varsynctimeout'] ?: '150';
 		$syncdownloadrules = $snort_sync['vardownloadrules'];
 		switch ($synconchanges){
 			case "manual":
 				if (is_array($snort_sync['row'])){
 					$rs=$snort_sync['row'];
-				}
-				else{
-					log_error("[snort] xmlrpc sync is enabled but there are no hosts configured as replication targets.");
+				} else {
+					log_error("[snort] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
 					return;
 				}
 				break;
 			case "auto":
-					if (is_array($config['hasync'])) {
-						$system_carp=$config['hasync'];
-						$rs[0]['varsyncipaddress']=$system_carp['synchronizetoip'];
-						$rs[0]['varsyncusername']=$system_carp['username'];
-						$rs[0]['varsyncpassword']=$system_carp['password'];
-						$rs[0]['varsyncsnortstart']="no";
-						if ($system_carp['synchronizetoip'] ==""){
-							log_error("[snort] xmlrpc sync is enabled but there are no system backup hosts configured as replication targets.");
-							return;
-						}
+				if (is_array($config['hasync'])) {
+					$system_carp = $config['hasync'];
+					$rs[0]['varsyncipaddress'] = $system_carp['synchronizetoip'];
+					$rs[0]['varsyncusername'] = $system_carp['username'];
+					$rs[0]['varsyncpassword'] = $system_carp['password'];
+					$rs[0]['varsyncsnortstart'] = FALSE;
+					$rs[0]['varsyncdestinenable'] = FALSE;
+					// XMLRPC sync is currently only supported over connections using the same protocol and port as this system
+					if ($config['system']['webgui']['protocol'] == "http") {
+						$rs[0]['varsyncprotocol'] = "http";
+						$rs[0]['varsyncport'] = $config['system']['webgui']['port'] ?: '80';
+					} else {
+						$rs[0]['varsyncprotocol'] = "https";
+						$rs[0]['varsyncport'] = $config['system']['webgui']['port'] ?: '443';
 					}
-					else{
-						log_error("[snort] xmlrpc sync is enabled but there are no system backup hosts configured as replication targets.");
+					if ($system_carp['synchronizetoip'] == "") {
+						log_error("[snort] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 						return;
+					} else {
+						$rs[0]['varsyncdestinenable'] = TRUE;
 					}
+				} else {
+					log_error("[snort] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+					return;
+				}
 				break;			
 			default:
 				return;
-			break;
+				break;
 		}
 		if (is_array($rs)){
-			log_error("[snort] Snort pkg xmlrpc sync is starting.");
-			foreach($rs as $sh){
-				if ($sh['varsyncsnortstart'])
-					$syncstartsnort = $sh['varsyncsnortstart'];
-				else
-					$syncstartsnort = "OFF";
-				$sync_to_ip = $sh['varsyncipaddress'];
-				$port = $sh['varsyncport'];
-				$password = $sh['varsyncpassword'];
-				if($sh['varsyncusername'])
-					$username = $sh['varsyncusername'];
-				else
-					$username = 'admin';
-				if($password && $sync_to_ip)
-					snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $username, $password, $synctimeout, $syncstartsnort);
+			log_error("[snort] XMLRPC sync is starting.");
+			foreach ($rs as $sh){
+				// Only sync enabled replication targets
+				if ($sh['varsyncdestinenable']) {
+					if ($sh['varsyncsnortstart']) {
+						$syncstartsnort = $sh['varsyncsnortstart'];
+					} else {
+						$syncstartsnort = "OFF";
+					}
+					$sync_to_ip = $sh['varsyncipaddress'];
+					$port = $sh['varsyncport'];
+					$password = $sh['varsyncpassword'];
+					$protocol = $sh['varsyncprotocol'];
+					$error = '';
+					$success = TRUE;
+					if ($sh['varsyncusername']) {
+						$username = $sh['varsyncusername'];
+					} else {
+						$username = 'admin';
+					}
+					if ($password == "") {
+						$error = "Password parameter is empty. ";
+						$success = FALSE;
+					}
+					if (!is_ipaddr($sync_to_ip) && !is_hostname($sync_to_ip) && !is_domain($sync_to_ip)) {
+						$error .= "Misconfigured Replication Target IP Address. ";
+						$success = FALSE;
+					}
+					if (!is_port($port)) {
+						$error .= "Misconfigured Replication Target Port. ";
+						$success = FALSE;
+					}
+					if ($success) {
+						snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol, $username, $password, $synctimeout, $syncstartsnort);
+					} else {
+						log_error("[snort] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
+					}
+				}
 			}
-			log_error("[snort] Snort pkg xmlrpc sync completed.");
+			log_error("[snort] XMLRPC sync completed.");
 		}
  	}
 }
 
 /* Do the actual XMLRPC sync */
-function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $username, $password, $synctimeout, $syncstartsnort) {
+function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol, $username, $password, $synctimeout = 150, $syncstartsnort) {
 	global $config, $g;
 
 	/* Do not attempt a package sync while booting up or installing package */
 	if ($g['booting'] || $g['snort_postinstall']) {
-		log_error("[snort] No xmlrpc sync to CARP targets when booting up or during package reinstallation.");
+		log_error("[snort] Skipping XMLRPC sync when booting up or during package reinstallation.");
 		return;
 	}
 
-	if(!$username || !$password || !$sync_to_ip) {
-		log_error("[snort] A required XMLRPC sync parameter (user, host IP or password) is empty ... aborting pkg sync");
+	if ($username == "" || $password == "" || $sync_to_ip == "" || $port == "" || $protocol == "") {
+		log_error("[snort] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
 	}
 
-	/* Test key variables and set defaults if empty */
-	if(!$synctimeout)
-		$synctimeout=150;
+	// Take care of IPv6 literal address
+	if (is_ipaddrv6($sync_to_ip)) {
+		$sync_to_ip = "[{$sync_to_ip}]";
+	}
 
-	$xmlrpc_sync_neighbor = $sync_to_ip;
-	if($config['system']['webgui']['protocol'] != "") {
-		$synchronizetoip = $config['system']['webgui']['protocol'];
-		$synchronizetoip .= "://";
-	}
-	if ($port == "")
-		$port = $config['system']['webgui']['port'];
-	/* if port is empty let's rely on the protocol selection */
-	if($port == "") {
-		if($config['system']['webgui']['protocol'] == "http") 
-			$port = "80";
-		else 
-			$port = "443";
-	}
-	$synchronizetoip .= $sync_to_ip;
-	$url = $synchronizetoip;
+	$url = "{$protocol}://{$sync_to_ip}";
 
 	/*************************************************/
 	/* Send over any auto-SID management files       */
@@ -3847,25 +3865,26 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $username,
 		$method = 'pfsense.exec_php';
 		$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
 	
-		log_error("[snort] Snort XMLRPC CARP sync sending auto-SID conf files to {$url}:{$port}.");
+		log_error("[snort] Snort XMLRPC sync sending auto-SID conf files to {$url}:{$port}.");
 		$msg = new XML_RPC_Message($method, $params);
 		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 		$cli->setCredentials($username, $password);
 		$resp = $cli->send($msg, $synctimeout);
 		$error = "";
 		if(!$resp) {
-			$error = "A communications error occurred while attempting Snort XMLRPC CARP sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
+			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
 			log_error($error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		} elseif($resp->faultCode()) {
-			$error = "An error code was received while attempting Snort XMLRPC CARP sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
+			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
 			log_error($error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		}
 	}
 
-	if (!empty($sid_files) && $error == "")
-		log_error("[snort] Snort pkg XMLRPC CARP sync auto-SID conf files success with {$url}:{$port} (pfsense.exec_php).");
+	if (!empty($sid_files) && $error == "") {
+		log_error("[snort] XMLRPC sync auto-SID conf files success with {$url}:{$port} (pfsense.exec_php).");
+	}
 
 	/*************************************************/
 	/* Send over any IPREP IP List files             */
@@ -3879,25 +3898,26 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $username,
 		$method = 'pfsense.exec_php';
 		$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
 	
-		log_error("[snort] Snort XMLRPC CARP sync sending IPREP files to {$url}:{$port}.");
+		log_error("[snort] Snort XMLRPC sync sending IPREP files to {$url}:{$port}.");
 		$msg = new XML_RPC_Message($method, $params);
 		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 		$cli->setCredentials($username, $password);
 		$resp = $cli->send($msg, $synctimeout);
 		$error = "";
-		if(!$resp) {
-			$error = "A communications error occurred while attempting Snort XMLRPC CARP sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
+		if (!$resp) {
+			$error = "A communications error occurred while attempting Snort XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
 			log_error($error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
-		} elseif($resp->faultCode()) {
-			$error = "An error code was received while attempting Snort XMLRPC CARP sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		} elseif ($resp->faultCode()) {
+			$error = "An error code was received while attempting Snort XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
 			log_error($error);
 			file_notice("sync_settings", $error, "Snort Settings Sync", "");
 		}
 	}
 
-	if (!empty($sid_files) && $error == "")
-		log_error("[snort] Snort pkg XMLRPC CARP sync IPREP files success with {$url}:{$port} (pfsense.exec_php).");
+	if (!empty($sid_files) && $error == "") {
+		log_error("[snort] XMLRPC sync IPREP files success with {$url}:{$port} (pfsense.exec_php).");
+	}
 
 	/**************************************************/
 	/* Send over the <snortglobal> portion of the     */
@@ -3911,7 +3931,7 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $username,
 		XML_RPC_encode($xml)
 	);
 
-	log_error("[snort] Beginning Snort pkg configuration XMLRPC sync to {$url}:{$port}.");
+	log_error("[snort] Beginning package configuration XMLRPC sync to {$url}:{$port}.");
 	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
@@ -3919,16 +3939,16 @@ function snort_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $username,
 
 	/* send our XMLRPC message and timeout after defined sync timeout value*/
 	$resp = $cli->send($msg, $synctimeout);
-	if(!$resp) {
+	if (!$resp) {
 		$error = "A communications error occurred while attempting snort XMLRPC sync with {$url}:{$port}.";
 		log_error($error);
 		file_notice("sync_settings", $error, "snort Settings Sync", "");
-	} elseif($resp->faultCode()) {
+	} elseif ($resp->faultCode()) {
 		$error = "An error code was received while attempting snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
 		log_error($error);
 		file_notice("sync_settings", $error, "snort Settings Sync", "");
 	} else {
-		log_error("[snort] Snort pkg configuration XMLRPC sync successfully completed with {$url}:{$port}.");
+		log_error("[snort] Package configuration XMLRPC sync successfully completed with {$url}:{$port}.");
 	}
 
 	$downloadrulescmd = "";
@@ -3992,16 +4012,16 @@ EOD;
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
 	$resp = $cli->send($msg, $synctimeout);
-	if(!$resp) {
+	if (!$resp) {
 		$error = "A communications error occurred while attempting snort XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
 		log_error($error);
 		file_notice("sync_settings", $error, "snort Settings Sync", "");
-	} elseif($resp->faultCode()) {
+	} elseif ($resp->faultCode()) {
 		$error = "An error code was received while attempting snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
 		log_error($error);
 		file_notice("sync_settings", $error, "snort Settings Sync", "");
 	} else {
-		log_error("[snort] Snort pkg XMLRPC reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+		log_error("[snort] XMLRPC reload configuration success with {$url}:{$port} (pfsense.exec_php).");
 	}
 
 	/*************************************************/
@@ -4016,16 +4036,16 @@ EOD;
 	log_error("[snort] Snort XMLRPC sending {$url}:{$port} cmd to execute configuration reload.");
 	$msg2 = new XML_RPC_Message($method, $params2);
 	$resp = $cli->send($msg2, $synctimeout);
-	if(!$resp) {
+	if (!$resp) {
 		$error = "A communications error occurred while attempting snort XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
 		log_error($error);
 		file_notice("sync_settings", $error, "snort Settings Sync", "");
-	} elseif($resp->faultCode()) {
+	} elseif ($resp->faultCode()) {
 		$error = "An error code was received while attempting snort XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
 		log_error($error);
 		file_notice("sync_settings", $error, "snort Settings Sync", "");
 	} else {
-		log_error("[snort] Snort pkg XMLRPC reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+		log_error("[snort] XMLRPC reload configuration success with {$url}:{$port} (pfsense.exec_php).");
 	}
 }
 

--- a/config/snort/snort_sync.xml
+++ b/config/snort/snort_sync.xml
@@ -172,11 +172,11 @@
 					</options>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>IP-Address</fielddescr>
+					<fielddescr>IP Address/Hostname</fielddescr>
 					<fieldname>varsyncipaddress</fieldname>
-					<description><![CDATA[IP Address of the destination host.]]></description>
+					<description><![CDATA[IP address or hostname of the destination host.]]></description>
 					<type>input</type>
-					<size>15</size>
+					<size>40</size>
 				</rowhelperfield>
 				<rowhelperfield>
 					<fielddescr>Port</fielddescr>
@@ -202,8 +202,6 @@
 			</rowhelper>
 		</field>
 	</fields>
-	<custom_delete_php_command>
-	</custom_delete_php_command>	
 	<custom_php_resync_config_command>
 		write_config("Snort pkg: saved changes to XMLRPC sync configuration.");snort_sync_on_changes();
 	</custom_php_resync_config_command>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -395,7 +395,7 @@
 		</build_pbi>
 		<build_options>barnyard2_UNSET_FORCE=ODBC PGSQL PRELUDE;barnyard2_SET_FORCE=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET_FORCE=BARNYARD PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;snort_UNSET_FORCE=PULLEDPORK FILEINSPECT HA</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>3.2.8.2</version>
+		<version>3.2.8.3</version>
 		<required_version>2.2</required_version>
 		<status>Stable</status>
 		<configurationfile>/snort.xml</configurationfile>


### PR DESCRIPTION
- Fix CARP protocol/port selection
- Properly disable 'Start Snort' for CARP/HA targets
- Do some validations (IP/hostname, port, password) before attempting to sync
- Handle IPv6 addresses for sync target
- The enable checkbox was not being used at all
- The foreach loop skipped all remaining targets if one was misconfigured, due to the 'return' in there
- Do some code style cleanups and polish log messages a bit while here