### PR TITLE
suricata - XMLRPC sync fixes round two

### DIFF
--- a/config/suricata/suricata.inc
+++ b/config/suricata/suricata.inc
@@ -3304,7 +3304,7 @@ function suricata_sync_on_changes() {
 
 	/* Do not attempt a package sync while booting up or installing package */
 	if ($g['booting'] || $g['suricata_postinstall'] == TRUE) {
-		log_error("[suricata] No xmlrpc sync to CARP targets when booting up or during package reinstallation.");
+		log_error("[suricata] Skipping XMLRPC sync when booting up or during package reinstallation.");
 		return;
 	}
 
@@ -3318,17 +3318,18 @@ function suricata_sync_on_changes() {
 				if (is_array($suricata_sync['row'])) {
 					$rs = $suricata_sync['row'];
 				} else {
-					log_error("[suricata] xmlrpc CARP sync is enabled but there are no hosts configured as replication targets.");
+					log_error("[suricata] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
 					return;
 				}
 				break;
 			case "auto":
-				if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])) {
-					$system_carp = $config['installedpackages']['carpsettings']['config'][0];
+				if (is_array($config['hasync'])) {
+					$system_carp = $config['hasync'];
 					$rs[0]['varsyncipaddress'] = $system_carp['synchronizetoip'];
 					$rs[0]['varsyncusername'] = $system_carp['username'];
 					$rs[0]['varsyncpassword'] = $system_carp['password'];
 					$rs[0]['varsyncsuricatastart'] = "no";
+					$rs[0]['varsyncdestinenable'] = FALSE;
 					// XMLRPC sync is currently only supported over connections using the same protocol and port as this system
 					if ($config['system']['webgui']['protocol'] == "http") {
 						$rs[0]['varsyncprotocol'] = "http";
@@ -3338,11 +3339,13 @@ function suricata_sync_on_changes() {
 						$rs[0]['varsyncport'] = $config['system']['webgui']['port'] ?: '443';
 					}
 					if ($system_carp['synchronizetoip'] == "") {
-						log_error("[suricata] xmlrpc CARP sync is enabled but there are no system backup hosts configured as replication targets.");
+						log_error("[suricata] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 						return;
+					} else {
+						$rs[0]['varsyncdestinenable'] = TRUE;
 					}
 				} else {
-					log_error("[suricata] xmlrpc CARP sync is enabled but there are no system backup hosts configured as replication targets.");
+					log_error("[suricata] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 					return;
 				}
 				break;			
@@ -3351,44 +3354,42 @@ function suricata_sync_on_changes() {
 				break;
 		}
 		if (is_array($rs)) {
-			log_error("[suricata] Suricata pkg xmlrpc CARP sync is starting.");
+			log_error("[suricata] XMLRPC sync is starting.");
 			foreach ($rs as $sh) {
-				if ($sh['varsyncsuricatastart']) {
-					$syncstartsuricata = $sh['varsyncsuricatastart'];
-				} else {
-					$syncstartsuricata = "OFF";
-				}
-				$sync_to_ip = $sh['varsyncipaddress'];
-				$password = $sh['varsyncpassword'];
-				$port = $sh['varsyncport'];
-				$protocol = $sh['varsyncprotocol'];
-				$error = '';
-				$success = TRUE;
-				if ($sh['varsyncusername']) {
-					$username = $sh['varsyncusername'];
-				} else {
-					$username = 'admin';
-				}
-				if ($password == "") {
-					$error = "Password parameter is empty. ";
-					$success = FALSE;
-				}
-				if (!is_ipaddr($sync_to_ip) && !is_hostname($sync_to_ip) && !is_domain($sync_to_ip)) {
-					$error .= "Misconfigured Replication Target IP Address. ";
-					$success = FALSE;
-				}
-				if (!is_port($port)) {
-					$error .= "Misconfigured Replication Target Port. ";
-					$success = FALSE;
-				}
-				if ($success) {
-					suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol, $username, $password, $synctimeout, $syncstartsuricata);
-				} else {
-					log_error("[suricata] Suricata pkg xmlrpc CARP sync aborted due to the following error(s): {$error}");
-					return;
+				// Only sync enabled replication targets
+				if ($sh['varsyncdestinenable']) {
+					if ($sh['varsyncsuricatastart']) {
+						$syncstartsuricata = $sh['varsyncsuricatastart'];
+					} else {
+						$syncstartsuricata = "OFF";
+					}
+					$sync_to_ip = $sh['varsyncipaddress'];
+					$password = $sh['varsyncpassword'];
+					$port = $sh['varsyncport'];
+					$protocol = $sh['varsyncprotocol'];
+					$error = '';
+					$success = TRUE;
+					$username = $sh['varsyncusername'] ?: 'admin';
+					if ($password == "") {
+						$error = "Password parameter is empty. ";
+						$success = FALSE;
+					}
+					if (!is_ipaddr($sync_to_ip) && !is_hostname($sync_to_ip) && !is_domain($sync_to_ip)) {
+						$error .= "Misconfigured Replication Target IP Address. ";
+						$success = FALSE;
+					}
+					if (!is_port($port)) {
+						$error .= "Misconfigured Replication Target Port. ";
+						$success = FALSE;
+					}
+					if ($success) {
+						suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protocol, $username, $password, $synctimeout, $syncstartsuricata);
+					} else {
+						log_error("[suricata] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
+					}
 				}
 			}
-			log_error("[suricata] Suricata pkg xmlrpc CARP sync completed.");
+			log_error("[suricata] XMLRPC sync completed.");
 		}
  	}
 }
@@ -3399,12 +3400,12 @@ function suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protoc
 
 	/* Do not attempt a package sync while booting up or installing package */
 	if ($g['booting'] || isset($g['suricata_postinstall'])) {
-		log_error("[suricata] No xmlrpc sync to CARP targets when booting up or during package reinstallation.");
+		log_error("[suricata] Skipping XMLRPC sync when booting up or during package reinstallation.");
 		return;
 	}
 
 	if ($username == "" || $password == "" || $sync_to_ip == "" || $port == "" || $protocol == "") {
-		log_error("[suricata] A required XMLRPC CARP sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
+		log_error("[suricata] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
 	}
 
@@ -3428,25 +3429,25 @@ function suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protoc
 		$method = 'pfsense.exec_php';
 		$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
 	
-		log_error("[suricata] Suricata XMLRPC CARP sync sending auto-SID conf files to {$url}:{$port}.");
+		log_error("[suricata] XMLRPC sync sending auto-SID conf files to {$url}:{$port}.");
 		$msg = new XML_RPC_Message($method, $params);
 		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 		$cli->setCredentials($username, $password);
 		$resp = $cli->send($msg, $synctimeout);
 		$error = "";
 		if (!$resp) {
-			$error = "A communications error occurred while attempting Suricata XMLRPC CARP sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
+			$error = "A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
 			log_error($error);
 			file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 		} elseif ($resp->faultCode()) {
-			$error = "An error code was received while attempting Suricata XMLRPC CARP sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
+			$error = "An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
 			log_error($error);
 			file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 		}
 	}
 
 	if (!empty($sid_files) && $error == "") {
-		log_error("[suricata] Suricata pkg XMLRPC CARP sync auto-SID conf files success with {$url}:{$port} (pfsense.exec_php).");
+		log_error("[suricata] XMLRPC sync auto-SID conf files success with {$url}:{$port} (pfsense.exec_php).");
 	}
 
 	/*************************************************/
@@ -3461,25 +3462,25 @@ function suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protoc
 		$method = 'pfsense.exec_php';
 		$params = array( XML_RPC_encode($password), XML_RPC_encode($payload) );
 	
-		log_error("[suricata] Suricata XMLRPC CARP sync sending IPREP files to {$url}:{$port}.");
+		log_error("[suricata] Suricata XMLRPC sync sending IPREP files to {$url}:{$port}.");
 		$msg = new XML_RPC_Message($method, $params);
 		$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 		$cli->setCredentials($username, $password);
 		$resp = $cli->send($msg, $synctimeout);
 		$error = "";
 		if (!$resp) {
-			$error = "A communications error occurred while attempting Suricata XMLRPC CARP sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
+			$error = "A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port}.  Failed to transfer file: " . basename($file);
 			log_error($error);
 			file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 		} elseif ($resp->faultCode()) {
-			$error = "An error code was received while attempting Suricata XMLRPC CARP sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
+			$error = "An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port}. Failed to transfer file: " . basename($file) . " - Code " . $resp->faultCode() . ": " . $resp->faultString();
 			log_error($error);
 			file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 		}
 	}
 
 	if (!empty($iprep_files) && $error == "") {
-		log_error("[suricata] Suricata pkg XMLRPC CARP sync IPREP files success with {$url}:{$port} (pfsense.exec_php).");
+		log_error("[suricata] XMLRPC sync IPREP files success with {$url}:{$port} (pfsense.exec_php).");
 	}
 
 	/**************************************************/
@@ -3494,7 +3495,7 @@ function suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protoc
 		XML_RPC_encode($xml)
 	);
 
-	log_error("[suricata] Beginning Suricata pkg configuration XMLRPC sync to {$url}:{$port}.");
+	log_error("[suricata] Beginning package configuration XMLRPC sync to {$url}:{$port}.");
 	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
@@ -3503,30 +3504,30 @@ function suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protoc
 	/* send our XMLRPC message and timeout after defined sync timeout value*/
 	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "A communications error occurred while attempting Suricata XMLRPC CARP sync with {$url}:{$port}.";
+		$error = "A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port}.";
 		log_error($error);
 		file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 	} elseif ($resp->faultCode()) {
-		$error = "An error code was received while attempting Suricata XMLRPC CARP sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		$error = "An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
 		log_error($error);
 		file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 	} else {
-		log_error("[suricata] Suricata pkg configuration XMLRPC CARP sync successfully completed with {$url}:{$port}.");
+		log_error("[suricata] Package configuration XMLRPC sync successfully completed with {$url}:{$port}.");
 	}
 
 	$downloadrulescmd = "";
 	if ($syncdownloadrules == "yes") {
-		$downloadrulescmd = "log_error(gettext(\"[suricata] XMLRPC pkg CARP sync: Update of downloaded rule sets requested...\"));\n";
+		$downloadrulescmd = "log_error(gettext(\"[suricata] XMLRPC pkg sync: Update of downloaded rule sets requested...\"));\n";
 		$downloadrulescmd .= "\tinclude_once(\"/usr/local/pkg/suricata/suricata_check_for_rule_updates.php\");\n";
 	}
 	$suricatastart = "";
 	if ($syncstartsuricata == "ON") {
-		$suricatastart = "log_error(gettext(\"[suricata] XMLRPC pkg CARP sync: Checking Suricata status...\"));\n";
+		$suricatastart = "log_error(gettext(\"[suricata] XMLRPC pkg sync: Checking Suricata status...\"));\n";
 		$suricatastart .= "\tif (!is_process_running(\"suricata\")) {\n";
-		$suricatastart .= "\t\tlog_error(gettext(\"[suricata] XMLRPC pkg CARP sync: Suricata not running. Sending a start command...\"));\n";
+		$suricatastart .= "\t\tlog_error(gettext(\"[suricata] XMLRPC pkg sync: Suricata not running. Sending a start command...\"));\n";
 		$suricatastart .= "\t\t\$sh_script = RCFILEPREFIX . \"suricata.sh\";\n";
 		$suricatastart .= "\t\tmwexec_bg(\"{\$sh_script} start\");\n\t}\n";
-		$suricatastart .= "\telse {\n\t\tlog_error(gettext(\"[suricata] XMLRPC pkg CARP sync: Suricata is running...\"));\n\t}\n";
+		$suricatastart .= "\telse {\n\t\tlog_error(gettext(\"[suricata] XMLRPC pkg sync: Suricata is running...\"));\n\t}\n";
 	}
 
 	/*************************************************/
@@ -3546,14 +3547,14 @@ function suricata_do_xmlrpc_sync($syncdownloadrules, $sync_to_ip, $port, $protoc
 	\$pkg_interface = "console";
 	{$downloadrulescmd}
 	unset(\$g["suricata_postinstall"]);
-	log_error(gettext("[suricata] XMLRPC pkg CARP sync: Generating suricata.yaml file using Master Host settings..."));
+	log_error(gettext("[suricata] XMLRPC pkg sync: Generating suricata.yaml file using Master Host settings..."));
 	\$rebuild_rules = true;
 	conf_mount_rw();
 	sync_suricata_package_config();
 	conf_mount_ro();
 	\$rebuild_rules = false;
 	{$suricatastart}
-	log_error(gettext("[suricata] XMLRPC pkg CARP sync process on this host is complete..."));
+	log_error(gettext("[suricata] XMLRPC pkg sync process on this host is complete..."));
 	\$pkg_interface = \$orig_pkg_interface;
 	unset(\$g["suricata_sync_in_progress"]);
 	return true;
@@ -3574,21 +3575,21 @@ EOD;
 		XML_RPC_encode($execcmd)
 	);
 	
-	log_error("[suricata] Suricata XMLRPC CARP sync sending reload configuration cmd set as a file to {$url}:{$port}.");
+	log_error("[suricata] XMLRPC sync sending reload configuration cmd set as a file to {$url}:{$port}.");
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
 	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "A communications error occurred while attempting Suricata XMLRPC CARP sync with {$url}:{$port} (pfsense.exec_php).";
+		$error = "A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
 		log_error($error);
 		file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 	} elseif ($resp->faultCode()) {
-		$error = "An error code was received while attempting Suricata XMLRPC CARP sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		$error = "An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
 		log_error($error);
 		file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 	} else {
-		log_error("[suricata] Suricata pkg XMLRPC CARP sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+		log_error("[suricata] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
 	}
 
 	/*************************************************/
@@ -3600,19 +3601,19 @@ EOD;
 		XML_RPC_encode($password),
 		XML_RPC_encode($execcmd)
 	);
-	log_error("[suricata] Suricata XMLRPC CARP sync sending {$url}:{$port} cmd to execute configuration reload.");
+	log_error("[suricata] XMLRPC sync sending {$url}:{$port} cmd to execute configuration reload.");
 	$msg2 = new XML_RPC_Message($method, $params2);
 	$resp = $cli->send($msg2, $synctimeout);
 	if (!$resp) {
-		$error = "A communications error occurred while attempting Suricata XMLRPC CARP sync with {$url}:{$port} (pfsense.exec_php).";
+		$error = "A communications error occurred while attempting Suricata XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
 		log_error($error);
 		file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 	} elseif ($resp->faultCode()) {
-		$error = "An error code was received while attempting Suricata XMLRPC CARP sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		$error = "An error code was received while attempting Suricata XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
 		log_error($error);
 		file_notice("sync_settings", $error, "Suricata Settings Sync", "");
 	} else {
-		log_error("[suricata] Suricata pkg XMLRPC CARP sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
+		log_error("[suricata] XMLRPC sync reload configuration success with {$url}:{$port} (pfsense.exec_php).");
 	}
 }
 

--- a/config/suricata/suricata.inc
+++ b/config/suricata/suricata.inc
@@ -3328,7 +3328,7 @@ function suricata_sync_on_changes() {
 					$rs[0]['varsyncipaddress'] = $system_carp['synchronizetoip'];
 					$rs[0]['varsyncusername'] = $system_carp['username'];
 					$rs[0]['varsyncpassword'] = $system_carp['password'];
-					$rs[0]['varsyncsuricatastart'] = "no";
+					$rs[0]['varsyncsuricatastart'] = FALSE;
 					$rs[0]['varsyncdestinenable'] = FALSE;
 					// XMLRPC sync is currently only supported over connections using the same protocol and port as this system
 					if ($config['system']['webgui']['protocol'] == "http") {

--- a/config/suricata/suricata_sync.xml
+++ b/config/suricata/suricata_sync.xml
@@ -1,56 +1,49 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-  <copyright>
+	<copyright>
 <![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-based on snortsync.xml developed as part
-of pfSense (http://www.pfSense.com)  
-Copyright (C) 2013 Marcello Coutinho
-based on pfblocker_sync.xml
-All rights reserved.
-
-modified for use with Suricata package  
-Copyright (C) 2014 Bill Meeks
-All rights reserved.
-
-Based on m0n0wall (http://m0n0.ch/wall)
-Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-All rights reserved.
+	suricata_sync.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013 Marcello Coutinho
+	Copyright (C) 2014-2015 Bill Meeks
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code MUST retain the above copyright notice,
-this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form MUST reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
-/* ========================================================================== */
-]]></copyright>
-	<description><![CDATA[Describe your package here]]></description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>suricatasync</name>
-	<version>1.0</version>
+	<version>2.1.8</version>
 	<title>Suricata: XMLRPC Sync</title>
 	<include_file>/usr/local/pkg/suricata/suricata.inc</include_file>
 	<tabs>
@@ -183,11 +176,11 @@ POSSIBILITY OF SUCH DAMAGE.
 					</options>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>IP-Address</fielddescr>
+					<fielddescr>IP Address/Hostname</fielddescr>
 					<fieldname>varsyncipaddress</fieldname>
-					<description><![CDATA[IP Address of the destination host.]]></description>
+					<description><![CDATA[IP address or hostname of the destination host.]]></description>
 					<type>input</type>
-					<size>15</size>
+					<size>40</size>
 				</rowhelperfield>
 				<rowhelperfield>
 					<fielddescr>Port</fielddescr>
@@ -213,8 +206,6 @@ POSSIBILITY OF SUCH DAMAGE.
 			</rowhelper>
 		</field>
 	</fields>
-	<custom_delete_php_command>
-	</custom_delete_php_command>	
 	<custom_php_resync_config_command>
 		write_config("Suricata pkg: updating CARP sync info.");suricata_sync_on_changes();
 	</custom_php_resync_config_command>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1707,7 +1707,7 @@
 		<website>http://suricata-ids.org/</website>
 		<descr>High Performance Network IDS, IPS and Security Monitoring engine by OISF.</descr>
 		<category>Security</category>
-		<version>2.1.7</version>
+		<version>2.1.8</version>
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/suricata/suricata.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1815,7 +1815,7 @@
 		<website>http://suricata-ids.org/</website>
 		<descr><![CDATA[High Performance Network IDS, IPS and Security Monitoring engine by OISF.]]></descr>
 		<category>Security</category>
-		<version>2.0.4 pkg v2.1.7</version>
+		<version>2.0.4 pkg v2.1.8</version>
 		<status>Stable</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/suricata/suricata.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1802,7 +1802,7 @@
 		<website>http://suricata-ids.org/</website>
 		<descr><![CDATA[High Performance Network IDS, IPS and Security Monitoring engine by OISF.]]></descr>
 		<category>Security</category>
-		<version>2.0.4 pkg v2.1.7</version>
+		<version>2.0.4 pkg v2.1.8</version>
 		<status>Stable</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/suricata/suricata.xml</config_file>


### PR DESCRIPTION
- the CARP (auto) option has never worked due to outdated system settings location being checked
- the enable checkbox was not being used at all
- the foreach loop skipped all remaining targets if one was misconfigured, due to the 'return' in there
- polish log messages a bit