### PR TITLE
sshdcond - add privileges configuration, improve XMLRPC sync

### DIFF
--- a/config/sshdcond/sshdcond.inc
+++ b/config/sshdcond/sshdcond.inc
@@ -37,8 +37,6 @@ function restart_sshd() {
 }
 
 function sshdcond_custom_php_install_command() {
-	global $g, $config;
-
 	/* We need to generate an outfile for our extra commands.
 	The patched g_szSSHDFileGenerate php file then reads and appends that config.
 	*/
@@ -48,8 +46,6 @@ function sshdcond_custom_php_install_command() {
 }
 
 function sshdcond_custom_php_deinstall_command() {
-	global $g, $config;
-
 	/* Delete our config file. */
 	unlink_if_exists("/etc/ssh/sshd_extra");
 
@@ -59,7 +55,7 @@ function sshdcond_custom_php_deinstall_command() {
 }
 
 function sshdcond_custom_php_write_config() {
-	global $g, $config, $pkg_interface;
+	global $g, $config;
 
 	/* Detect boot process, do nothing during boot. */
 	if (function_exists("platform_booting")) {
@@ -113,71 +109,113 @@ function sshdcond_custom_php_write_config() {
 
 /* Uses XMLRPC to synchronize the changes to a remote node. */
 function sshdcond_sync_on_changes() {
-	global $config, $g;
+	global $config;
 
-	/* Basically, this package was never configured */
-	if (!is_array($config['installedpackages']['sshdcondsync'])) {
-		return;
-	}
-	/* Package is configured but XMLRPC sync is disabled */
-	if (!isset($config['installedpackages']['sshdcondsync']['config'][0]['synconchanges'])) {
-		return;
-	}
-	/* Do XMLRPC sync */
-	log_error("[sshdcond] xmlrpc sync is starting.");
-	foreach ($config['installedpackages']['sshdcondsync']['config'] as $rs) {
-		foreach($rs['row'] as $sh) {
-			$sync_to_ip = $sh['ipaddress'];
-			$password = $sh['password'];
-			if ($password && $sync_to_ip) {
-				sshdcond_do_xmlrpc_sync($sync_to_ip, $password);
-			}
+	if (is_array($config['installedpackages']['sshdcondsync']['config'])) {
+		$sshdcond_sync = $config['installedpackages']['sshdcondsync']['config'][0];
+		$synconchanges = $sshdcond_sync['synconchanges'];
+		$synctimeout = $sshdcond_sync['synctimeout'] ?: '150';
+		switch ($synconchanges) {
+			case "manual":
+				if (is_array($sshdcond_sync['row'])) {
+					$rs = $sshdcond_sync['row'];
+				} else {
+					log_error("[sshdcond] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
+					return;
+				}
+				break;
+			case "auto":
+				if (is_array($config['hasync'])) {
+					$system_carp = $config['hasync'];
+					$rs[0]['ipaddress'] = $system_carp['synchronizetoip'];
+					$rs[0]['username'] = $system_carp['username'];
+					$rs[0]['password'] = $system_carp['password'];
+					$rs[0]['syncdestinenable'] = FALSE;
+
+					// XMLRPC sync is currently only supported over connections using the same protocol and port as this system
+					if ($config['system']['webgui']['protocol'] == "http") {
+						$rs[0]['syncprotocol'] = "http";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '80';
+					} else {
+						$rs[0]['syncprotocol'] = "https";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '443';
+					}
+					if ($system_carp['synchronizetoip'] == "") {
+						log_error("[sshdcond] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+						return;
+					} else {
+						$rs[0]['syncdestinenable'] = TRUE;
+					}
+				} else {
+					log_error("[sshdcond] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+					return;
+				}
+				break;			
+			default:
+				return;
+				break;
 		}
-	}
-	log_error("[sshdcond] xmlrpc sync is ending.");
+		if (is_array($rs)) {
+			log_error("[sshdcond] XMLRPC sync is starting.");
+			foreach ($rs as $sh) {
+				// Only sync enabled replication targets
+				if ($sh['syncdestinenable']) {
+					$sync_to_ip = $sh['ipaddress'];
+					$port = $sh['syncport'];
+					$username = $sh['username'] ?: 'admin';
+					$password = $sh['password'];
+					$protocol = $sh['syncprotocol'];
+
+					$error = '';
+					$valid = TRUE;
+
+					if ($password == "") {
+						$error = "Password parameter is empty. ";
+						$valid = FALSE;
+					}
+					if (!is_ipaddr($sync_to_ip) && !is_hostname($sync_to_ip) && !is_domain($sync_to_ip)) {
+						$error .= "Misconfigured Replication Target IP Address or Hostname. ";
+						$valid = FALSE;
+					}
+					if (!is_port($port)) {
+						$error .= "Misconfigured Replication Target Port. ";
+						$valid = FALSE;
+					}
+					if ($valid) {
+						sshdcond_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout);
+					} else {
+						log_error("[sshdcond] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
+					}
+				}
+			}
+			log_error("[sshdcond] XMLRPC sync completed.");
+		}
+ 	}
 }
 
 /* Do the actual XMLRPC sync. */
-function sshdcond_do_xmlrpc_sync($sync_to_ip, $password) {
+function sshdcond_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout) {
 	global $config, $g;
 
-	if (!$password) {
+	if ($username == "" || $password == "" || $sync_to_ip == "" || $port == "" || $protocol == "") {
+		log_error("[sshdcond] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
 	}
 
-	if (!$sync_to_ip) {
-		return;
+	// Take care of IPv6 literal address
+	if (is_ipaddrv6($sync_to_ip)) {
+		$sync_to_ip = "[{$sync_to_ip}]";
 	}
 
-	$username='admin';
-	$xmlrpc_sync_neighbor = $sync_to_ip;
-	if ($config['system']['webgui']['protocol'] != "") {
-		$synchronizetoip = $config['system']['webgui']['protocol'];
-		$synchronizetoip .= "://";
-	}
-	$port = $config['system']['webgui']['port'];
-	/* If port is empty, let's rely on the protocol selection. */
-	if ($port == "") {
-		if ($config['system']['webgui']['protocol'] == "http") {
-			$port = "80";
-		} else {
-			$port = "443";
-		}
-	}
-	$synchronizetoip .= $sync_to_ip;
+	$url = "{$protocol}://{$sync_to_ip}";
 
-	/* xml will hold the sections to sync. */
+	/* XML will hold the sections to sync. */
 	$xml = array();
 	$xml['sshdcond'] = $config['installedpackages']['sshdcond'];
 	/* Assemble XMLRPC payload. */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($xml)
-	);
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($xml));
 
-	/* Set a few variables needed for sync code; borrowed from filter.inc. */
-	$url = $synchronizetoip;
-	log_error("Beginning sshdcond XMLRPC sync to {$url}:{$port}.");
+	/* Set a few variables needed for sync code */
 	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
@@ -185,20 +223,20 @@ function sshdcond_do_xmlrpc_sync($sync_to_ip, $password) {
 	if ($g['debug']) {
 		$cli->setDebug(1);
 	}
-	/* Send our XMLRPC message and timeout after 250 seconds. */
-	$resp = $cli->send($msg, "250");
+	/* Send our XMLRPC message and timeout after defined sync timeout value */
+	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "A communications error occurred while attempting sshdcond XMLRPC sync with {$url}:{$port}.";
-		log_error($error);
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port}.";
+		log_error("[sshdcond] {$error}");
 		file_notice("sync_settings", $error, "sshdcond Settings Sync", "");
 	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
-		$resp = $cli->send($msg, "250");
+		$resp = $cli->send($msg, $synctimeout);
 		$error = "An error code was received while attempting sshdcond XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		log_error("[sshdcond] {$error}");
 		file_notice("sync_settings", $error, "sshdcond Settings Sync", "");
 	} else {
-		log_error("sshdcond XMLRPC sync successfully completed with {$url}:{$port}.");
+		log_error("[sshdcond] XMLRPC sync successfully completed with {$url}:{$port}.");
 	}
 
 	/* Tell sshdcond to reload our settings on the destination sync host. */
@@ -206,28 +244,24 @@ function sshdcond_do_xmlrpc_sync($sync_to_ip, $password) {
 	$execcmd = "require_once('/usr/local/pkg/sshdcond.inc');\n";
 	$execcmd .= "sshdcond_custom_php_write_config();";
 	/* Assemble XMLRPC payload. */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($execcmd)
-	);
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($execcmd));
 
-	log_error("sshdcond XMLRPC reload data {$url}:{$port}.");
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
-	$resp = $cli->send($msg, "250");
+	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
 		$error = "A communications error occurred while attempting sshdcond XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-		log_error($error);
+		log_error("[sshdcond] {$error}");
 		file_notice("sync_settings", $error, "sshdcond Settings Sync", "");
 	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
-		$resp = $cli->send($msg, "250");
+		$resp = $cli->send($msg, $synctimeout);
 		$error = "An error code was received while attempting sshdcond XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		log_error("[sshdcond] {$error}");
 		file_notice("sync_settings", $error, "sshdcond Settings Sync", "");
 	} else {
-		log_error("sshdcond XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
+		log_error("[sshdcond] XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
 	}
 }
 ?>

--- a/config/sshdcond/sshdcond.priv.inc
+++ b/config/sshdcond/sshdcond.priv.inc
@@ -1,0 +1,42 @@
+<?php
+/*
+	sshdcond.priv.inc
+	part of pfSense (http://www.pfSense.org/)
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+global $priv_list;
+
+$priv_list['page-services-sshdcond'] = array();
+$priv_list['page-services-sshdcond']['name'] = "WebCfg - Services: SSHDCond package";
+$priv_list['page-services-sshdcond']['descr'] = "Allow access to SSHDCond package GUI";
+$priv_list['page-services-sshdcond']['match'] = array();
+
+$priv_list['page-services-sshdcond']['match'][] = "pkg.php?xml=sshdcond.xml*";
+$priv_list['page-services-sshdcond']['match'][] = "pkg.php?xml=sshdcond_sync.xml*";
+
+$priv_list['page-services-sshdcond']['match'][] = "pkg_edit.php?xml=sshdcond.xml*";
+$priv_list['page-services-sshdcond']['match'][] = "pkg_edit.php?xml=sshdcond_sync.xml*";
+
+?>

--- a/config/sshdcond/sshdcond.xml
+++ b/config/sshdcond/sshdcond.xml
@@ -43,12 +43,10 @@
 	]]>
 	</copyright>
 	<name>sshdcond</name>
-	<version>1.0.2</version>
-	<title>SSH Conditional</title>
-	<description>SSH Conditional blocks</description>
+	<version>1.0.6</version>
+	<title>Services: SSH Conditional Options</title>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/sshdcond.inc</include_file>
-
 	<menu>
 		<name>SSH Conditions</name>
 		<tooltiptext>Configure SSH conditional exceptions</tooltiptext>
@@ -59,6 +57,10 @@
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
 		<item>https://packages.pfsense.org/packages/config/sshdcond/sshdcond.inc</item>
+	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/etc/inc/priv/</prefix>
+		<item>https://packages.pfsense.org/packages/config/sshdcond/sshdcond.priv.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
@@ -93,7 +95,6 @@
 		<field>
 			<type>listtopic</type>
 			<name>Conditional SSH Options</name>
-			<fieldname>temp</fieldname>
 		</field>
 		<field>
 		<fielddescr>Enable</fielddescr>
@@ -187,7 +188,4 @@
 	<custom_php_resync_config_command>
 		sshdcond_custom_php_write_config();
 	</custom_php_resync_config_command>
-	<custom_php_command_before_form>
-		unset($_POST['temp']);
-	</custom_php_command_before_form>
 </packagegui>

--- a/config/sshdcond/sshdcond_sync.xml
+++ b/config/sshdcond/sshdcond_sync.xml
@@ -42,8 +42,8 @@
 	]]>
 	</copyright>
 	<name>sshdcondsync</name>
-	<version>1.0.2</version>
-	<title>SSH Conditional - Sync</title>
+	<version>1.0.6</version>
+	<title>Services: SSH Conditional Options - Sync</title>
 	<include_file>/usr/local/pkg/sshdcond.inc</include_file>
 	<tabs>
 		<tab>
@@ -62,30 +62,74 @@
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Automatically sync configuration changes</fielddescr>
+			<fielddescr>Enable Sync</fielddescr>
 			<fieldname>synconchanges</fieldname>
-			<description>Automatically sync changes to the hosts defined below.</description>
-			<type>checkbox</type>
+			<description>
+				<![CDATA[
+				When enabled, this will sync all configuration settings to the Replication Targets.<br/><br/>
+				<b>Important:</b> While using "Sync to host(s) defined below", only sync from host A to B, A to C but <strong>do not</strong> enable XMLRPC sync <b>to</b> A. This will result in a loop!
+				]]>
+			</description>
+			<type>select</type>
+			<required/>
+			<default_value>disabled</default_value>
+			<options>
+				<option><name>Sync to configured system backup server</name><value>auto</value></option>
+				<option><name>Sync to host(s) defined below</name><value>manual</value></option>
+				<option><name>Do not sync this package configuration</name><value>disabled</value></option>
+			</options>
 		</field>
 		<field>
-			<fielddescr>Remote Server</fielddescr>
+			<fielddescr>XMLRPC Timeout</fielddescr>
+			<fieldname>synctimeout</fieldname>
+			<description><![CDATA[XMLRPC timeout in seconds. Default: 150]]></description>
+			<type>input</type>
+			<default_value>150</default_value>
+			<size>5</size>
+		</field>
+		<field>
+			<fielddescr>Replication Targets</fielddescr>
 			<fieldname>none</fieldname>
 			<type>rowhelper</type>
 			<rowhelper>
-			<rowhelperfield>
-				<fielddescr>IP Address</fielddescr>
-				<fieldname>ipaddress</fieldname>
-				<description>IP Address of remote server.</description>
-				<type>input</type>
-				<size>20</size>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>Password</fielddescr>
-				<fieldname>password</fieldname>
-				<description>Password for remote server.</description>
-				<type>password</type>
-				<size>20</size>
-			</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Enable</fielddescr>
+					<fieldname>syncdestinenable</fieldname>
+					<description><![CDATA[Enable this host as a replication target]]></description>
+					<type>checkbox</type>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Protocol</fielddescr>
+					<fieldname>syncprotocol</fieldname>
+					<description><![CDATA[Choose the protocol used to sync with the destination host (HTTP or HTTPS).]]></description>
+					<type>select</type>
+					<default_value>HTTP</default_value>
+					<options>
+						<option><name>HTTP</name><value>http</value></option>
+						<option><name>HTTPS</name><value>https</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>IP Address/Hostname</fielddescr>
+					<fieldname>ipaddress</fieldname>
+					<description><![CDATA[IP address or hostname of the destination host.]]></description>
+					<type>input</type>
+					<size>40</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Port</fielddescr>
+					<fieldname>syncport</fieldname>
+					<description><![CDATA[Choose the sync port of the destination host.]]></description>
+					<type>input</type>
+					<size>3</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Admin Password</fielddescr>
+					<fieldname>password</fieldname>
+					<description><![CDATA[Password of the user "admin" on the destination host.]]></description>
+					<type>password</type>
+					<size>20</size>
+				</rowhelperfield>
 			</rowhelper>
 		</field>
 	</fields>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1339,7 +1339,7 @@
 			]]>
 		</descr>
 		<category>Enhancements</category>
-		<version>1.0.5</version>
+		<version>1.0.6</version>
 		<status>Beta</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/sshdcond/sshdcond.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1503,10 +1503,10 @@
 	</package>
 	<package>
 		<name>SSHDCond</name>
-		<descr><![CDATA[Allows to define SSH overrides for users,groups,hosts and addresses using Match in a convenient way.<br />
-				This package acts as an access list frontend for ssh connections]]></descr>
+		<descr><![CDATA[Allows to define SSH overrides for users, groups, hosts and addresses using Match in a convenient way.<br />
+				This package acts as an access list frontend for ssh connections.]]></descr>
 		<category>Enhancements</category>
-		<version>1.0.5</version>
+		<version>1.0.6</version>
 		<status>Beta</status>
 		<required_version>2.0</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/sshdcond/sshdcond.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1490,10 +1490,10 @@
 	</package>
 	<package>
 		<name>SSHDCond</name>
-		<descr><![CDATA[Allows to define SSH overrides for users,groups,hosts and addresses using Match in a convenient way.<br />
-				This package acts as an access list frontend for ssh connections]]></descr>
+		<descr><![CDATA[Allows to define SSH overrides for users, groups, hosts and addresses using Match in a convenient way.<br />
+				This package acts as an access list frontend for ssh connections.]]></descr>
 		<category>Enhancements</category>
-		<version>1.0.5</version>
+		<version>1.0.6</version>
 		<status>Beta</status>
 		<required_version>2.0</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/sshdcond/sshdcond.xml</config_file>


### PR DESCRIPTION
- Add privileges configuration to sshdcond package

**Improve XMLRCP sync**
- Add CARP/HA sync option
- Add enable/disable checkbox per replication target
- Add port/protocol selection
- Add timeout setting
- Fix literal IPv6 handling for sync targets
- Do settings validation and only try to sync when configuration is valid