### PR TITLE
squid3 - XMLRPC fixes and improvements

### DIFF
--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -2163,28 +2163,45 @@ function squid_generate_rules($type) {
 
 /* XMLRPC sync configuration */
 function squid_sync_on_changes() {
-	global $config, $g;
+	global $config;
+
 	if (is_array($config['installedpackages']['squidsync']['config'])) {
 		$squid_sync = $config['installedpackages']['squidsync']['config'][0];
 		$synconchanges = $squid_sync['synconchanges'];
-		$synctimeout = $squid_sync['synctimeout'];
+		$synctimeout = $squid_sync['synctimeout'] ?: '250';
 		switch ($synconchanges) {
 			case "manual":
 				if (is_array($squid_sync['row'])) {
 					$rs = $squid_sync['row'];
 				} else {
-					log_error("[squid] XMLRPC sync is enabled but there is no hosts to push on Squid config.");
+					log_error("[squid] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
 					return;
 				}
 				break;
 			case "auto":
-				if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])) {
-					$system_carp = $config['installedpackages']['carpsettings']['config'][0];
+				if (is_array($config['hasync'])) {
+					$system_carp = $config['hasync'];
 					$rs[0]['ipaddress'] = $system_carp['synchronizetoip'];
 					$rs[0]['username'] = $system_carp['username'];
 					$rs[0]['password'] = $system_carp['password'];
+					$rs[0]['syncdestinenable'] = FALSE;
+
+					// XMLRPC sync is currently only supported over connections using the same protocol and port as this system
+					if ($config['system']['webgui']['protocol'] == "http") {
+						$rs[0]['syncprotocol'] = "http";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '80';
+					} else {
+						$rs[0]['syncprotocol'] = "https";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '443';
+					}
+					if ($system_carp['synchronizetoip'] == "") {
+						log_error("[squid] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+						return;
+					} else {
+						$rs[0]['syncdestinenable'] = TRUE;
+					}
 				} else {
-					log_error("[squid] XMLRPC sync is enabled but there is no system backup hosts to push Squid config.");
+					log_error("[squid] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 					return;
 				}
 				break;
@@ -2195,45 +2212,56 @@ function squid_sync_on_changes() {
 		if (is_array($rs)) {
 			log_error("[squid] XMLRPC sync is starting.");
 			foreach ($rs as $sh) {
-				$sync_to_ip = $sh['ipaddress'];
-				$password = $sh['password'];
-				if ($sh['username']) {
-					$username = $sh['username'];
-				} else {
-					$username = 'admin';
-				}
-				if ($password && $sync_to_ip) {
-					squid_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout);
+				// Only sync enabled replication targets
+				if ($sh['syncdestinenable']) {
+					$sync_to_ip = $sh['ipaddress'];
+					$port = $sh['syncport'];
+					$username = $sh['username'] ?: 'admin';
+					$password = $sh['password'];
+					$protocol = $sh['syncprotocol'];
+
+					$error = '';
+					$valid = TRUE;
+
+					if ($password == "") {
+						$error = "Password parameter is empty. ";
+						$valid = FALSE;
+					}
+					if (!is_ipaddr($sync_to_ip) && !is_hostname($sync_to_ip) && !is_domain($sync_to_ip)) {
+						$error .= "Misconfigured Replication Target IP Address or Hostname. ";
+						$valid = FALSE;
+					}
+					if (!is_port($port)) {
+						$error .= "Misconfigured Replication Target Port. ";
+						$valid = FALSE;
+					}
+					if ($valid) {
+						squid_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout);
+					} else {
+						log_error("[squid] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
+					}
 				}
 			}
-			log_error("[squid] XMLRPC sync is ending.");
+			log_error("[squid] XMLRPC sync completed.");
 		}
-	}
+ 	}
 }
 
 /* Perform the actual XMLRPC sync */
-function squid_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout) {
+function squid_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout) {
 	global $config, $g;
 
-	if (!$username || !$password || !$sync_to_ip) {
+	if ($username == "" || $password == "" || $sync_to_ip == "" || $port == "" || $protocol == "") {
+		log_error("[squid] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
 	}
 
-	if (!$synctimeout) {
-		$synctimeout = 250;
+	// Take care of IPv6 literal address
+	if (is_ipaddrv6($sync_to_ip)) {
+		$sync_to_ip = "[{$sync_to_ip}]";
 	}
 
-	$xmlrpc_sync_neighbor = $sync_to_ip;
-	if ($config['system']['webgui']['protocol'] != "") {
-		$synchronizetoip = $config['system']['webgui']['protocol'];
-		$synchronizetoip .= "://";
-	}
-	$port = $config['system']['webgui']['port'];
-	/* If port is empty let's rely on the protocol selection */
-	if ($port == "") {
-		$port = $config['system']['webgui']['protocol'] == "http" ? "80" : "443";
-	}
-	$synchronizetoip .= $sync_to_ip;
+	$url = "{$protocol}://{$sync_to_ip}";
 
 	/* XML will hold the sections to sync */
 	$xml = array();
@@ -2249,14 +2277,9 @@ function squid_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout) {
 	$xml['squidauth'] = $config['installedpackages']['squidauth'];
 	$xml['squidusers'] = $config['installedpackages']['squidusers'];
 	/* Assemble XMLRPC payload */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($xml)
-	);
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($xml));
 
 	/* Set a few variables needed for sync */
-	$url = $synchronizetoip;
-	log_error("[squid] Beginning XMLRPC sync to {$url}:{$port}.");
 	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
@@ -2267,14 +2290,14 @@ function squid_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout) {
 	/* Send our XMLRPC message and timeout after defined sync timeout value*/
 	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "[squid] Communication error occurred while attempting XMLRPC sync with {$url}:{$port}.";
-		log_error($error);
+		$error = "A communication error occurred while attempting XMLRPC sync with {$url}:{$port}.";
+		log_error("[squid] {$error}");
 		file_notice("sync_settings", $error, "Squid Settings Sync", "");
 	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, $synctimeout);
-		$error = "[squid] An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("[squid] {$error}");
 		file_notice("sync_settings", $error, "Squid Settings Sync", "");
 	} else {
 		log_error("[squid] XMLRPC sync successfully completed with {$url}:{$port}.");
@@ -2285,25 +2308,21 @@ function squid_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout) {
 	$execcmd = "require_once('/usr/local/pkg/squid.inc');\n";
 	$execcmd .= "squid_resync('yes');";
 	/* Assemble XMLRPC payload */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($execcmd)
-	);
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($execcmd));
 
-	log_error("[squid] XMLRPC reload data {$url}:{$port}.");
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
 	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "[squid] Communication error occurred while attempting XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-		log_error($error);
+		$error = "A communication error occurred while attempting XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
+		log_error("[squid] {$error}");
 		file_notice("sync_settings", $error, "Squid Settings Sync", "");
 	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, $synctimeout);
-		$error = "[squid] An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("[squid] {$error}");
 		file_notice("sync_settings", $error, "Squid Settings Sync", "");
 	} else {
 		log_error("[squid] XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");

--- a/config/squid3/34/squid_reverse_sync.xml
+++ b/config/squid3/34/squid_reverse_sync.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidsync</name>
-	<version>0.4.1</version>
+	<version>0.4.2</version>
 	<title>Reverse Proxy Server: XMLRPC Sync</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<tabs>
@@ -78,12 +78,18 @@
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Automatically sync Squid configuration changes</fielddescr>
+			<fielddescr>Enable Sync</fielddescr>
 			<fieldname>synconchanges</fieldname>
-			<description>Select a sync method for Squid.</description>
+			<description>
+				<![CDATA[
+				Select a sync method for Squid Reverse Proxy.<br/><br/>
+				<strong>Important:</strong> While using "Sync to host(s) defined below", only sync from host A to B, A to C but <strong>do not</strong> enable XMLRPC sync <b>to</b> A.
+				This will result in a loop!
+				]]>
+			</description>
 			<type>select</type>
 			<required/>
-			<default_value>auto</default_value>
+			<default_value>disabled</default_value>
 			<options>
 				<option><name>Sync to configured system backup server</name><value>auto</value></option>
 				<option><name>Sync to host(s) defined below</name><value>manual</value></option>
@@ -106,19 +112,45 @@
 			</options>
 		</field>
 		<field>
-			<fielddescr>Remote Server</fielddescr>
+			<fielddescr>Replication Targets</fielddescr>
 			<fieldname>none</fieldname>
 			<type>rowhelper</type>
 			<rowhelper>
 				<rowhelperfield>
-					<fielddescr>IP Address</fielddescr>
-					<fieldname>ipaddress</fieldname>
-					<type>input</type>
-					<size>20</size>
+					<fielddescr>Enable</fielddescr>
+					<fieldname>syncdestinenable</fieldname>
+					<description><![CDATA[Enable this host as a replication target]]></description>
+					<type>checkbox</type>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>Password (admin)</fielddescr>
+					<fielddescr>Protocol</fielddescr>
+					<fieldname>syncprotocol</fieldname>
+					<description><![CDATA[Choose the protocol used to sync with the destination host (HTTP or HTTPS).]]></description>
+					<type>select</type>
+					<default_value>HTTP</default_value>
+					<options>
+						<option><name>HTTP</name><value>http</value></option>
+						<option><name>HTTPS</name><value>https</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>IP Address/Hostname</fielddescr>
+					<fieldname>ipaddress</fieldname>
+					<description><![CDATA[IP address or hostname of the destination host.]]></description>
+					<type>input</type>
+					<size>40</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Port</fielddescr>
+					<fieldname>syncport</fieldname>
+					<description><![CDATA[Choose the sync port of the destination host.]]></description>
+					<type>input</type>
+					<size>3</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Admin Password</fielddescr>
 					<fieldname>password</fieldname>
+					<description><![CDATA[Password of the user "admin" on the destination host.]]></description>
 					<type>password</type>
 					<size>20</size>
 				</rowhelperfield>

--- a/config/squid3/34/squid_sync.xml
+++ b/config/squid3/34/squid_sync.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidsync</name>
-	<version>0.4.1</version>
+	<version>0.4.2</version>
 	<title>Proxy Server: XMLRPC Sync</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<tabs>
@@ -94,12 +94,18 @@
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Automatically sync Squid configuration changes</fielddescr>
+			<fielddescr>Enable Sync</fielddescr>
 			<fieldname>synconchanges</fieldname>
-			<description>Select a sync method for Squid.</description>
+			<description>
+				<![CDATA[
+				Select a sync method for Squid.<br/><br/>
+				<strong>Important:</strong> While using "Sync to host(s) defined below", only sync from host A to B, A to C but <strong>do not</strong> enable XMLRPC sync <b>to</b> A.
+				This will result in a loop!
+				]]>
+			</description>
 			<type>select</type>
 			<required/>
-			<default_value>auto</default_value>
+			<default_value>disabled</default_value>
 			<options>
 				<option><name>Sync to configured system backup server</name><value>auto</value></option>
 				<option><name>Sync to host(s) defined below</name><value>manual</value></option>
@@ -122,19 +128,45 @@
 			</options>
 		</field>
 		<field>
-			<fielddescr>Remote Server</fielddescr>
+			<fielddescr>Replication Targets</fielddescr>
 			<fieldname>none</fieldname>
 			<type>rowhelper</type>
 			<rowhelper>
 				<rowhelperfield>
-					<fielddescr>IP Address</fielddescr>
-					<fieldname>ipaddress</fieldname>
-					<type>input</type>
-					<size>20</size>
+					<fielddescr>Enable</fielddescr>
+					<fieldname>syncdestinenable</fieldname>
+					<description><![CDATA[Enable this host as a replication target]]></description>
+					<type>checkbox</type>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>Password (admin)</fielddescr>
+					<fielddescr>Protocol</fielddescr>
+					<fieldname>syncprotocol</fieldname>
+					<description><![CDATA[Choose the protocol used to sync with the destination host (HTTP or HTTPS).]]></description>
+					<type>select</type>
+					<default_value>HTTP</default_value>
+					<options>
+						<option><name>HTTP</name><value>http</value></option>
+						<option><name>HTTPS</name><value>https</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>IP Address/Hostname</fielddescr>
+					<fieldname>ipaddress</fieldname>
+					<description><![CDATA[IP address or hostname of the destination host.]]></description>
+					<type>input</type>
+					<size>40</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Port</fielddescr>
+					<fieldname>syncport</fieldname>
+					<description><![CDATA[Choose the sync port of the destination host.]]></description>
+					<type>input</type>
+					<size>3</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Admin Password</fielddescr>
 					<fieldname>password</fieldname>
+					<description><![CDATA[Password of the user "admin" on the destination host.]]></description>
 					<type>password</type>
 					<size>20</size>
 				</rowhelperfield>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1053,7 +1053,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>0.4.1.1</version>
+		<version>0.4.2</version>
 		<status>beta</status>
 		<required_version>2.2</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>


### PR DESCRIPTION
- Fix CARP/HA sync option
- Fix literal IPv6 handling for sync targets
- Add enable/disable checkbox per replication target
- Add protocol/port selection
- Do settings validation and only try to sync when configuration is valid
