### PR TITLE
squid3/squid3-dev - fix XMLRPC sync with CARP/HA

### DIFF
--- a/config/squid3/31/squid.inc
+++ b/config/squid3/31/squid.inc
@@ -1854,8 +1854,8 @@ function squid_sync_on_changes() {
 		$synctimeout = $squid_sync['synctimeout'];
 		switch ($synconchanges){
 			case "manual":
-				if (is_array($squid_sync[row])){
-					$rs=$squid_sync[row];
+				if (is_array($squid_sync['row'])){
+					$rs=$squid_sync['row'];
 					}
 				else{
 					log_error("[squid] xmlrpc sync is enabled but there is no hosts to push on squid config.");
@@ -1863,8 +1863,8 @@ function squid_sync_on_changes() {
 					}
 				break;
 			case "auto":
-					if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])){
-						$system_carp=$config['installedpackages']['carpsettings']['config'][0];
+					if (is_array($config['hasync'])) {
+						$system_carp = $config['hasync'];
 						$rs[0]['ipaddress']=$system_carp['synchronizetoip'];
 						$rs[0]['username']=$system_carp['username'];
 						$rs[0]['password']=$system_carp['password'];

--- a/config/squid3/33/squid.inc
+++ b/config/squid3/33/squid.inc
@@ -2314,8 +2314,8 @@ function squid_sync_on_changes() {
 		$synctimeout = $squid_sync['synctimeout'];
 		switch ($synconchanges){
 			case "manual":
-				if (is_array($squid_sync[row])){
-					$rs=$squid_sync[row];
+				if (is_array($squid_sync['row'])){
+					$rs=$squid_sync['row'];
 					}
 				else{
 					log_error("[squid] xmlrpc sync is enabled but there is no hosts to push on squid config.");
@@ -2323,8 +2323,8 @@ function squid_sync_on_changes() {
 					}
 				break;
 			case "auto":
-					if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])){
-						$system_carp=$config['installedpackages']['carpsettings']['config'][0];
+					if (is_array($config['hasync'])) {
+						$system_carp = $config['hasync'];
 						$rs[0]['ipaddress']=$system_carp['synchronizetoip'];
 						$rs[0]['username']=$system_carp['username'];
 						$rs[0]['password']=$system_carp['password'];

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1141,9 +1141,9 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>3.1.20 pkg 2.1.3</version>
+		<version>3.1.20 pkg 2.1.4</version>
 		<status>beta</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
 		<depends_on_package>squid-3.1.20.tbz</depends_on_package>
@@ -1168,9 +1168,9 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>3.3.10 pkg 2.3.0</version>
+		<version>3.3.10 pkg 2.3.1</version>
 		<status>beta</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
 		<depends_on_package>squid-3.3.5.tbz</depends_on_package>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1128,9 +1128,9 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>3.1.20 pkg 2.1.3</version>
+		<version>3.1.20 pkg 2.1.4</version>
 		<status>beta</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
 		<depends_on_package>squid-3.1.20.tbz</depends_on_package>
@@ -1155,9 +1155,9 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Network</category>
-		<version>3.3.10 pkg 2.3.0</version>
+		<version>3.3.10 pkg 2.3.1</version>
 		<status>beta</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
 		<depends_on_package>squid-3.3.5.tbz</depends_on_package>


### PR DESCRIPTION
The config option used has not existed since pfSense 2.1 (config version 084).