### PR TITLE
sarg - XMLRPC sync fixes

### DIFF
--- a/config/sarg/sarg.inc
+++ b/config/sarg/sarg.inc
@@ -438,18 +438,20 @@ function sarg_validate_input($post, &$input_errors) {
 		}
 
 		# check squidguard
-		if (substr($key, 0, 10) == "proxy_server" && $value == "squidguard")
-			if (!is_array($config['installedpackages']['squidguardgeneral']))
+		if (substr($key, 0, 10) == "proxy_server" && $value == "squidguard") {
+			if (!is_array($config['installedpackages']['squidguardgeneral'])) {
 				$input_errors[]='squidguard package not detected';
+			}
+		}
 
 		# check squid
 		if (substr($key, 0, 5) == "proxy_server" && $value == "squid") {
 			if (is_array($config['installedpackages']['squid'])) {
 				if (!$config['installedpackages']['squid']['log_enabled']) {
-					$input_errors[]='squidlogs not enabled';
+					$input_errors[] = 'Squid logging not enabled';
 				}
 			} else {
-				$input_errors[]='squid package not installed';
+				$input_errors[] = 'Squid package not installed';
 			}
 		}
 
@@ -469,108 +471,113 @@ function sarg_validate_input($post, &$input_errors) {
 /* Uses XMLRPC to synchronize the changes to a remote node */
 function sarg_sync_on_changes() {
 	global $config, $g;
+
 	if (is_array($config['installedpackages']['sargsync']['config'])) {
 		$sarg_sync = $config['installedpackages']['sargsync']['config'][0];
 		$synconchanges = $sarg_sync['synconchanges'];
-		$synctimeout = $sarg_sync['synctimeout'];
+		$synctimeout = $sarg_sync['synctimeout'] ?: '250';
 		switch ($synconchanges) {
 			case "manual":
-				if (is_array($sarg_sync[row])) {
-					$rs = $sarg_sync[row];
+				if (is_array($sarg_sync['row'])) {
+					$rs = $sarg_sync['row'];
 				} else {
-					log_error("[sarg] xmlrpc sync is enabled but there is no hosts to push on sarg config.");
+					log_error("[sarg] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
 					return;
 				}
 				break;
 			case "auto":
-				if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])) {
-					$system_carp = $config['installedpackages']['carpsettings']['config'][0];
+				if (is_array($config['hasync'])) {
+					$system_carp = $config['hasync'];
 					$rs[0]['ipaddress'] = $system_carp['synchronizetoip'];
 					$rs[0]['username'] = $system_carp['username'];
 					$rs[0]['password'] = $system_carp['password'];
-					if ($system_carp['synchronizetoip'] == "" || $system_carp['username'] == "") {
-						log_error("[sarg] xmlrpc sync is enabled but there are no system backup hosts to push sarg config.");
-						return;
-					}
+					$rs[0]['syncdestinenable'] = FALSE;
 
+					// XMLRPC sync is currently only supported over connections using the same protocol and port as this system
+					if ($config['system']['webgui']['protocol'] == "http") {
+						$rs[0]['syncprotocol'] = "http";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '80';
+					} else {
+						$rs[0]['syncprotocol'] = "https";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '443';
+					}
+					if ($system_carp['synchronizetoip'] == "") {
+						log_error("[sarg] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+						return;
+					} else {
+						$rs[0]['syncdestinenable'] = TRUE;
+					}
 				} else {
-					log_error("[sarg] xmlrpc sync is enabled but there are no system backup hosts to push sarg config.");
+					log_error("[sarg] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 					return;
 				}
 				break;
 			default:
 				return;
-			break;
+				break;
 		}
 		if (is_array($rs)) {
-			log_error("[sarg] xmlrpc sync is starting.");
-			foreach($rs as $sh) {
-				$sync_to_ip = $sh['ipaddress'];
-				$password = $sh['password'];
-				if ($sh['username']) {
-					$username = $sh['username'];
-				} else {
-					$username = 'admin';
-				}
-				if ($password && $sync_to_ip) {
-					sarg_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout);
+			log_error("[sarg] XMLRPC sync is starting.");
+			foreach ($rs as $sh) {
+				// Only sync enabled replication targets
+				if ($sh['syncdestinenable']) {
+					$sync_to_ip = $sh['ipaddress'];
+					$port = $sh['syncport'];
+					$username = $sh['username'] ?: 'admin';
+					$password = $sh['password'];
+					$protocol = $sh['syncprotocol'];
+
+					$error = '';
+					$valid = TRUE;
+
+					if ($password == "") {
+						$error = "Password parameter is empty. ";
+						$valid = FALSE;
+					}
+					if (!is_ipaddr($sync_to_ip) && !is_hostname($sync_to_ip) && !is_domain($sync_to_ip)) {
+						$error .= "Misconfigured Replication Target IP Address or Hostname. ";
+						$valid = FALSE;
+					}
+					if (!is_port($port)) {
+						$error .= "Misconfigured Replication Target Port. ";
+						$valid = FALSE;
+					}
+					if ($valid) {
+						sarg_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout);
+					} else {
+						log_error("[sarg] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
+					}
 				}
 			}
-			log_error("[sarg] xmlrpc sync is ending.");
+			log_error("[sarg] XMLRPC sync completed.");
 		}
  	}
 }
 
 /* do the actual XMLRPC sync */
-function sarg_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout) {
+function sarg_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout) {
 	global $config, $g;
 
-	if (!$username) {
+	if ($username == "" || $password == "" || $sync_to_ip == "" || $port == "" || $protocol == "") {
+		log_error("[sarg] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
 	}
 
-	if (!$password) {
-		return;
+	// Take care of IPv6 literal address
+	if (is_ipaddrv6($sync_to_ip)) {
+		$sync_to_ip = "[{$sync_to_ip}]";
 	}
 
-	if (!$sync_to_ip) {
-		return;
-	}
+	$url = "{$protocol}://{$sync_to_ip}";
 
-	if (!$synctimeout) {
-		$synctimeout="250";
-	}
-
-	$xmlrpc_sync_neighbor = $sync_to_ip;
-
-	if ($config['system']['webgui']['protocol'] != "") {
-		$synchronizetoip = $config['system']['webgui']['protocol'];
-		$synchronizetoip .= "://";
-	}
-	$port = $config['system']['webgui']['port'];
-	/* if port is empty, let's rely on the protocol selection */
-	if ($port == "") {
-		if ($config['system']['webgui']['protocol'] == "http") {
-			$port = "80";
-		} else {
-			$port = "443";
-		}
-	}
-	$synchronizetoip .= $sync_to_ip;
-
-	/* xml will hold the sections to sync */
+	/* XML will hold the sections to sync. */
 	$xml = array();
 	$xml['sarg'] = $config['installedpackages']['sarg'];
 	$xml['sarguser'] = $config['installedpackages']['sarguser'];
-	/* assemble xmlrpc payload */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($xml)
-	);
+	/* Assemble XMLRPC payload. */
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($xml));
 
-	/* set a few variables needed for sync code */
-	$url = $synchronizetoip;
-	log_error("Beginning sarg XMLRPC sync to {$url}:{$port}.");
+	/* Set a few variables needed for sync code */
 	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
@@ -578,49 +585,45 @@ function sarg_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout) {
 	if ($g['debug']) {
 		$cli->setDebug(1);
 	}
-	/* send our XMLRPC message and timeout after $synctimeout seconds */
+	/* Send our XMLRPC message and timeout after defined sync timeout value */
 	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "A communications error occurred while attempting sarg XMLRPC sync with {$url}:{$port}.";
-		log_error($error);
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port}.";
+		log_error("[sarg] {$error}");
 		file_notice("sync_settings", $error, "sarg Settings Sync", "");
 	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, $synctimeout);
-		$error = "An error code was received while attempting sarg XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("[sarg] {$error}");
 		file_notice("sync_settings", $error, "sarg Settings Sync", "");
 	} else {
-		log_error("sarg XMLRPC sync successfully completed with {$url}:{$port}.");
+		log_error("[sarg] XMLRPC sync successfully completed with {$url}:{$port}.");
 	}
 
-	/* tell sarg to reload our settings on the destionation sync host. */
+	/* Tell sarg to reload our settings on the destionation sync host. */
 	$method = 'pfsense.exec_php';
 	$execcmd = "require_once('/usr/local/pkg/sarg.inc');\n";
 	$execcmd .= "sync_package_sarg();";
-	/* assemble xmlrpc payload */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($execcmd)
-	);
+	/* Assemble XMLRPC payload. */
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($execcmd));
 
-	log_error("sarg XMLRPC reload data {$url}:{$port}.");
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
 	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "A communications error occurred while attempting sarg XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-		log_error($error);
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
+		log_error("[sarg] {$error}");
 		file_notice("sync_settings", $error, "sarg Settings Sync", "");
 	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, $synctimeout);
-		$error = "An error code was received while attempting sarg XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("[sarg] {$error}");
 		file_notice("sync_settings", $error, "sarg Settings Sync", "");
 	} else {
-		log_error("sarg XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
+		log_error("[sarg] XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
 	}
 }
 

--- a/config/sarg/sarg_sync.xml
+++ b/config/sarg/sarg_sync.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>sargsync</name>
-	<version>0.6.5</version>
+	<version>0.6.6</version>
 	<title>Status: Sarg Sync</title>
 	<include_file>/usr/local/pkg/sarg.inc</include_file>
 	<tabs>
@@ -82,9 +82,15 @@
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Automatically Sync Sarg Configuration Changes.</fielddescr>
+			<fielddescr>Enable Sync</fielddescr>
 			<fieldname>synconchanges</fieldname>
-			<description>Select a sync method for Sarg.</description>
+			<description>
+				<![CDATA[
+				Select a sync method for Sarg.<br/><br/>
+				<strong>Important:</strong> While using "Sync to host(s) defined below", only sync from host A to B, A to C but <strong>do not</strong> enable XMLRPC sync <b>to</b> A.
+				This will result in a loop!
+				]]>
+			</description>
 			<type>select</type>
 			<required/>
 			<default_value>auto</default_value>
@@ -97,7 +103,7 @@
 		<field>
 			<fielddescr>Sync Timeout</fielddescr>
 			<fieldname>synctimeout</fieldname>
-			<description>Select sync max wait time</description>
+			<description>XMLRPC timeout in seconds.</description>
 			<type>select</type>
 			<required/>
 			<default_value>250</default_value>
@@ -110,21 +116,45 @@
 			</options>
 		</field>
 		<field>
-			<fielddescr>Remote Server</fielddescr>
+			<fielddescr>Replication Targets</fielddescr>
 			<fieldname>none</fieldname>
 			<type>rowhelper</type>
 			<rowhelper>
 				<rowhelperfield>
-					<fielddescr>IP Address</fielddescr>
-					<fieldname>ipaddress</fieldname>
-					<description>IP Address of remote server</description>
-					<type>input</type>
-					<size>20</size>
+					<fielddescr>Enable</fielddescr>
+					<fieldname>syncdestinenable</fieldname>
+					<description><![CDATA[Enable this host as a replication target]]></description>
+					<type>checkbox</type>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>Password</fielddescr>
+					<fielddescr>Protocol</fielddescr>
+					<fieldname>syncprotocol</fieldname>
+					<description><![CDATA[Choose the protocol used to sync with the destination host (HTTP or HTTPS).]]></description>
+					<type>select</type>
+					<default_value>HTTP</default_value>
+					<options>
+						<option><name>HTTP</name><value>http</value></option>
+						<option><name>HTTPS</name><value>https</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>IP Address/Hostname</fielddescr>
+					<fieldname>ipaddress</fieldname>
+					<description><![CDATA[IP address or hostname of the destination host.]]></description>
+					<type>input</type>
+					<size>40</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Port</fielddescr>
+					<fieldname>syncport</fieldname>
+					<description><![CDATA[Choose the sync port of the destination host.]]></description>
+					<type>input</type>
+					<size>3</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Admin Password</fielddescr>
 					<fieldname>password</fieldname>
-					<description>Password for remote server.</description>
+					<description><![CDATA[Password of the user "admin" on the destination host.]]></description>
 					<type>password</type>
 					<size>20</size>
 				</rowhelperfield>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -607,7 +607,7 @@
 		<config_file>https://packages.pfsense.org/packages/config/sarg/sarg.xml</config_file>
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,47765.0.html</pkginfolink>
 		<depends_on_package_pbi>sarg-2.3.9-##ARCH##.pbi</depends_on_package_pbi>
-		<version>0.6.6</version>
+		<version>0.6.7</version>
 		<status>Release</status>
 		<required_version>2.2</required_version>
 		<port_category>www</port_category>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -656,9 +656,9 @@
 		<depends_on_package>sarg-2.3.6_2.tbz</depends_on_package>
 		<depends_on_package>gd-2.0.35_8,1.tbz</depends_on_package>
 		<depends_on_package_pbi>sarg-2.3.6_2-i386.pbi</depends_on_package_pbi>
-		<version>2.3.6_2 pkg v.0.6.6</version>
+		<version>2.3.6_2 pkg v0.6.7</version>
 		<status>Release</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<configurationfile>sarg.xml</configurationfile>
 		<build_port_path>/usr/ports/www/sarg</build_port_path>
 		<build_options>sarg_UNSET_FORCE=PHP</build_options>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -643,9 +643,9 @@
 		<depends_on_package>sarg-2.3.6_2.tbz</depends_on_package>
 		<depends_on_package>gd-2.0.35_8,1.tbz</depends_on_package>
 		<depends_on_package_pbi>sarg-2.3.6_2-amd64.pbi</depends_on_package_pbi>
-		<version>2.3.6_2 pkg v.0.6.6</version>
+		<version>2.3.6_2 pkg v0.6.7</version>
 		<status>Release</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<configurationfile>sarg.xml</configurationfile>
 		<build_port_path>/usr/ports/www/sarg</build_port_path>
 		<build_options>sarg_UNSET_FORCE=PHP</build_options>


### PR DESCRIPTION
- CARP/HA (auto) option has never worked since pfSense 2.1 due to outdated system settings location being checked
- Also fix CARP/HA protocol/port selection
- Do some better validations (IP/hostname, port, password) before attempting to sync
- Handle IPv6 addresses for sync target