### PR TITLE
haproxy1_5: add the option 'log global' for all backends.

### DIFF
--- a/config/haproxy1_5/pkg/haproxy.inc
+++ b/config/haproxy1_5/pkg/haproxy.inc
@@ -512,6 +512,7 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 		$backend_mode = $frontendtype;
 	}
 	fwrite ($fd, "\tmode\t\t\t" . $backend_mode . "\n");
+	fwrite ($fd, "\tlog\t\t\tglobal\n");
 	if ($pool['log-health-checks'] == 'yes')
 		fwrite ($fd, "\toption\t\t\tlog-health-checks\n");
 		


### PR DESCRIPTION
Add the haproxy option `log global` to all backends sections in configuration.
Without this, the logs emitted by the backends will never end up in the logs.

For example I have a config like this :

```
global
    log     10.10.20.1:5514 local0  info
    ...
backend myBackend
    mode    http
    log     global
    option  httpchk
    server  myServer 10.10.20.11:443 check inter 1000 port 9200
```

Without the `log global` parameter in the backend, I would never get the following logs in my log server :

```
Server myBackend/myServer is UP. 1 active and 0 backup servers online.
or
Server myBackend/myServer is DOWN. 0 active and 0 backup servers online.
```

This parameter is already applied blindly to all the frontend sections.
