### PR TITLE
Filer - XMLRPC sync fixes and improvements

### DIFF
--- a/config/filer/filer.inc
+++ b/config/filer/filer.inc
@@ -103,75 +103,113 @@ function filer_validate_input($post, &$input_errors) {
 
 /* Uses XMLRPC to synchronize the changes to a remote node. */
 function filer_sync_on_changes() {
-	global $config, $g;
+	global $config;
 
-	log_error("[filer] filer_xmlrpc_sync.php is starting.");
-	$synconchanges = $config['installedpackages']['filersync']['config'][0]['synconchanges'];
-	if (!$synconchanges) {
-		return;
-	}
-	foreach ($config['installedpackages']['filersync']['config'] as $rs) {
-		foreach ($rs['row'] as $sh) {
-			$sync_to_ip = $sh['ipaddress'];
-			$password = $sh['password'];
-			if ($sh['username']) {
-				$username = $sh['username'];
-			} else {
-				$username = 'admin';
-			}
-			if ($password && $sync_to_ip) {
-				filer_do_xmlrpc_sync($sync_to_ip, $username, $password);
-			}
+	if (is_array($config['installedpackages']['filersync']['config'])) {
+		$filer_sync = $config['installedpackages']['filersync']['config'][0];
+		$synconchanges = $filer_sync['synconchanges'];
+		$synctimeout = $filer_sync['synctimeout'] ?: '250';
+		switch ($synconchanges) {
+			case "manual":
+				if (is_array($filer_sync['row'])) {
+					$rs = $filer_sync['row'];
+				} else {
+					log_error("[filer] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
+					return;
+				}
+				break;
+			case "auto":
+				if (is_array($config['hasync'])) {
+					$system_carp = $config['hasync'];
+					$rs[0]['ipaddress'] = $system_carp['synchronizetoip'];
+					$rs[0]['username'] = $system_carp['username'];
+					$rs[0]['password'] = $system_carp['password'];
+					$rs[0]['syncdestinenable'] = FALSE;
+
+					// XMLRPC sync is currently only supported over connections using the same protocol and port as this system
+					if ($config['system']['webgui']['protocol'] == "http") {
+						$rs[0]['syncprotocol'] = "http";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '80';
+					} else {
+						$rs[0]['syncprotocol'] = "https";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '443';
+					}
+					if ($system_carp['synchronizetoip'] == "") {
+						log_error("[filer] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+						return;
+					} else {
+						$rs[0]['syncdestinenable'] = TRUE;
+					}
+				} else {
+					log_error("[filer] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+					return;
+				}
+				break;
+			default:
+				return;
+				break;
 		}
-	}
-	log_error("[filer] filer_xmlrpc_sync.php is ending.");
+		if (is_array($rs)) {
+			log_error("[filer] XMLRPC sync is starting.");
+			foreach ($rs as $sh) {
+				// Only sync enabled replication targets
+				if ($sh['syncdestinenable']) {
+					$sync_to_ip = $sh['ipaddress'];
+					$port = $sh['syncport'];
+					$username = $sh['username'] ?: 'admin';
+					$password = $sh['password'];
+					$protocol = $sh['syncprotocol'];
+
+					$error = '';
+					$valid = TRUE;
+
+					if ($password == "") {
+						$error = "Password parameter is empty. ";
+						$valid = FALSE;
+					}
+					if (!is_ipaddr($sync_to_ip) && !is_hostname($sync_to_ip) && !is_domain($sync_to_ip)) {
+						$error .= "Misconfigured Replication Target IP Address or Hostname. ";
+						$valid = FALSE;
+					}
+					if (!is_port($port)) {
+						$error .= "Misconfigured Replication Target Port. ";
+						$valid = FALSE;
+					}
+					if ($valid) {
+						filer_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout);
+					} else {
+						log_error("[filer] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
+					}
+				}
+			}
+			log_error("[filer] XMLRPC sync completed.");
+		}
+ 	}
 }
 
 /* Do the actual XMLRPC sync. */
-function filer_do_xmlrpc_sync($sync_to_ip, $username, $password) {
+function filer_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout) {
 	global $config, $g;
 
-	if (!$username) {
+	if ($username == "" || $password == "" || $sync_to_ip == "" || $port == "" || $protocol == "") {
+		log_error("[filer] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
 	}
 
-	if (!$password) {
-		return;
+	// Take care of IPv6 literal address
+	if (is_ipaddrv6($sync_to_ip)) {
+		$sync_to_ip = "[{$sync_to_ip}]";
 	}
 
-	if (!$sync_to_ip) {
-		return;
-	}
+	$url = "{$protocol}://{$sync_to_ip}";
 
-	$xmlrpc_sync_neighbor = $sync_to_ip;
-	if ($config['system']['webgui']['protocol'] != "") {
-		$synchronizetoip = $config['system']['webgui']['protocol'];
-		$synchronizetoip .= "://";
-	}
-	$port = $config['system']['webgui']['port'];
-	/* If port is empty, let's rely on the protocol selection. */
-	if ($port == "") {
-		if ($config['system']['webgui']['protocol'] == "http") {
-			$port = "80";
-		} else {
-			$port = "443";
-		}
-	}
-	$synchronizetoip .= $sync_to_ip;
-
-	/* xml will hold the sections to sync. */
+	/* XML will hold the sections to sync. */
 	$xml = array();
 	$xml['filer'] = $config['installedpackages']['filer'];
-
 	/* Assemble XMLRPC payload. */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($xml)
-	);
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($xml));
 
-	/* Set a few variables needed for sync; code borrowed from filter.inc. */
-	$url = $synchronizetoip;
-	log_error("Beginning Filer XMLRPC sync to {$url}:{$port}.");
+	/* Set a few variables needed for sync code */
 	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
@@ -180,19 +218,19 @@ function filer_do_xmlrpc_sync($sync_to_ip, $username, $password) {
 		$cli->setDebug(1);
 	}
 	/* Send our XMLRPC message and timeout after 250 seconds. */
-	$resp = $cli->send($msg, "250");
+	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "A communications error occurred while attempting filer XMLRPC sync with {$url}:{$port}.";
-		log_error($error);
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port}.";
+		log_error("[filer] {$error}");
 		file_notice("sync_settings", $error, "filer Settings Sync", "");
 	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
-		$resp = $cli->send($msg, "250");
-		$error = "An error code was received while attempting filer XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		$resp = $cli->send($msg, $synctimeout);
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("[filer] {$error}");
 		file_notice("sync_settings", $error, "filer Settings Sync", "");
 	} else {
-		log_error("filer XMLRPC sync successfully completed with {$url}:{$port}.");
+		log_error("[filer] XMLRPC sync successfully completed with {$url}:{$port}.");
 	}
 
 	/* Tell filer to reload our settings on the destination sync host. */
@@ -200,28 +238,25 @@ function filer_do_xmlrpc_sync($sync_to_ip, $username, $password) {
 	$execcmd = "require_once('/usr/local/pkg/filer.inc');\n";
 	$execcmd .= "sync_package_filer();";
 	/* Assemble XMLRPC payload. */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($execcmd)
-	);
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($execcmd));
 
-	log_error("filer XMLRPC reload data {$url}:{$port}.");
+	log_error("[filer] XMLRPC reload data {$url}:{$port}.");
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
-	$resp = $cli->send($msg, "250");
+	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "A communications error occurred while attempting filer XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-		log_error($error);
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
+		log_error("[filer] {$error}");
 		file_notice("sync_settings", $error, "filer Settings Sync", "");
 	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
-		$resp = $cli->send($msg, "250");
-		$error = "An error code was received while attempting filer XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		$resp = $cli->send($msg, $synctimeout);
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("[filer] {$error}");
 		file_notice("sync_settings", $error, "filer Settings Sync", "");
 	} else {
-		log_error("filer XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
+		log_error("[filer] XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
 	}
 }
 

--- a/config/filer/filer_sync.xml
+++ b/config/filer/filer_sync.xml
@@ -44,7 +44,7 @@
 	]]>
 	</copyright>
 	<name>filersync</name>
-	<version>1.2</version>
+	<version>0.60.6</version>
 	<title>Filer: Sync</title>
 	<include_file>/usr/local/pkg/filer.inc</include_file>
 	<tabs>
@@ -61,50 +61,96 @@
 	<fields>
 		<field>
 			<type>listtopic</type>
-			<fieldname>temp</fieldname>
-			<name>Enable Filer configuration sync</name>
+			<name>XMLRPC Sync</name>
 		</field>
 		<field>
-			<fielddescr>Automatically sync Filer configuration changes.</fielddescr>
+			<fielddescr>Enable Sync</fielddescr>
 			<fieldname>synconchanges</fieldname>
-			<description>pfSense will automatically sync changes to the hosts defined below. (Leave blank to use 'admin'.)</description>
-			<type>checkbox</type>
+			<description>
+				<![CDATA[
+				Select a sync method for Filer.<br/><br/>
+				<strong>Important:</strong> While using "Sync to host(s) defined below", only sync from host A to B, A to C but <strong>do not</strong> enable XMLRPC sync <b>to</b> A.
+				This will result in a loop!
+				]]>
+			</description>
+			<type>select</type>
+			<required/>
+			<default_value>disabled</default_value>
+			<options>
+				<option><name>Sync to configured system backup server</name><value>auto</value></option>
+				<option><name>Sync to host(s) defined below</name><value>manual</value></option>
+				<option><name>Do not sync this package configuration</name><value>disabled</value></option>
+			</options>
 		</field>
 		<field>
-			<fielddescr>Remote Servers</fielddescr>
+			<fielddescr>Sync Timeout</fielddescr>
+			<fieldname>synctimeout</fieldname>
+			<description>XMLRPC timeout in seconds.</description>
+			<type>select</type>
+			<required/>
+			<default_value>250</default_value>
+			<options>
+				<option><name>250 seconds (Default)</name><value>250</value></option>
+				<option><name>120 seconds</name><value>120</value></option>
+				<option><name>90 seconds</name><value>90</value></option>
+				<option><name>60 seconds</name><value>60</value></option>
+				<option><name>30 seconds</name><value>30</value></option>
+			</options>
+		</field>
+		<field>
+			<fielddescr>Replication Targets</fielddescr>
 			<fieldname>none</fieldname>
 			<type>rowhelper</type>
 			<rowhelper>
-			<rowhelperfield>
-				<fielddescr>IP Address</fielddescr>
-				<fieldname>ipaddress</fieldname>
-				<description>IP Address of remote server.</description>
-				<type>input</type>
-				<size>20</size>
-				<required/>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>User Name</fielddescr>
-				<fieldname>username</fieldname>
-				<description>user name of remote server.</description>
-				<type>input</type>
-				<size>20</size>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>Password</fielddescr>
-				<fieldname>password</fieldname>
-				<description>Password for remote server.</description>
-				<type>password</type>
-				<size>20</size>
-				<required/>
-			</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Enable</fielddescr>
+					<fieldname>syncdestinenable</fieldname>
+					<description><![CDATA[Enable this host as a replication target]]></description>
+					<type>checkbox</type>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Protocol</fielddescr>
+					<fieldname>syncprotocol</fieldname>
+					<description><![CDATA[Choose the protocol used to sync with the destination host (HTTP or HTTPS).]]></description>
+					<type>select</type>
+					<default_value>HTTP</default_value>
+					<options>
+						<option><name>HTTP</name><value>http</value></option>
+						<option><name>HTTPS</name><value>https</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>IP Address/Hostname</fielddescr>
+					<fieldname>ipaddress</fieldname>
+					<description><![CDATA[IP address or hostname of the destination host.]]></description>
+					<type>input</type>
+					<size>40</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Port</fielddescr>
+					<fieldname>syncport</fieldname>
+					<description><![CDATA[Choose the sync port of the destination host.]]></description>
+					<type>input</type>
+					<size>3</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Username (admin)</fielddescr>
+					<fieldname>username</fieldname>
+					<description><![CDATA[Enter the username account for administration.]]></description>
+					<type>input</type>
+					<size>20</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Admin Password</fielddescr>
+					<fieldname>password</fieldname>
+					<description><![CDATA[Password of the user "admin" on the destination host.]]></description>
+					<type>password</type>
+					<size>20</size>
+				</rowhelperfield>
 			</rowhelper>
 		</field>
 	</fields>
 	<custom_php_resync_config_command>
 		filer_sync_on_changes();
 	</custom_php_resync_config_command>
-	<custom_php_command_before_form>
-		unset($_POST['temp']);
-	</custom_php_command_before_form>
 </packagegui>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -82,7 +82,7 @@
 		<category>File Management</category>
 		<pkginfolink>https://doc.pfsense.org/index.php/Filer_package</pkginfolink>
 		<config_file>https://packages.pfsense.org/packages/config/filer/filer.xml</config_file>
-		<version>0.60.5</version>
+		<version>0.60.6</version>
 		<status>Beta</status>
 		<required_version>2.2</required_version>
 		<maintainer>bscholer@cshl.edu</maintainer>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -74,7 +74,7 @@
 		<category>File Management</category>
 		<pkginfolink>https://doc.pfsense.org/index.php/Filer_package</pkginfolink>
 		<config_file>https://packages.pfsense.org/packages/config/filer/filer.xml</config_file>
-		<version>0.60.5</version>
+		<version>0.60.6</version>
 		<status>Beta</status>
 		<required_version>2.0</required_version>
 		<maintainer>bscholer@cshl.edu</maintainer>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -74,7 +74,7 @@
 		<category>File Management</category>
 		<pkginfolink>https://doc.pfsense.org/index.php/Filer_package</pkginfolink>
 		<config_file>https://packages.pfsense.org/packages/config/filer/filer.xml</config_file>
-		<version>0.60.5</version>
+		<version>0.60.6</version>
 		<status>Beta</status>
 		<required_version>2.0</required_version>
 		<maintainer>bscholer@cshl.edu</maintainer>


### PR DESCRIPTION
- Add CARP/HA sync option
- Add enable/disable checkbox per replication target
- Add protocol/port selection
- Add timeout setting
- Fix literal IPv6 handling for sync targets
- Do settings validation and only try to sync when configuration is valid