### PR TITLE
haproxy-legacy - Fix XMLRPC sync with CARP/HA

### DIFF
--- a/config/haproxy-legacy/haproxy.inc
+++ b/config/haproxy-legacy/haproxy.inc
@@ -345,8 +345,8 @@ function haproxy_sync_on_changes() {
 					}
 				break;
 			case "auto":
-					if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])){
-						$system_carp=$config['installedpackages']['carpsettings']['config'][0];
+					if (is_array($config['hasync'])) {
+						$system_carp = $config['hasync'];
 						$rs[0]['ipaddress']=$system_carp['synchronizetoip'];
 						$rs[0]['username']=$system_carp['username'];
 						$rs[0]['password']=$system_carp['password'];

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -151,7 +151,7 @@
 		<category>Services</category>
 		<version>1.4.24 pkg v 1.1.3</version>
 		<status>Release</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-legacy/haproxy.xml</config_file>
 		<configurationfile>haproxy.xml</configurationfile>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -149,7 +149,7 @@
 				(Legacy version)]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.4.24 pkg v 1.1.2</version>
+		<version>1.4.24 pkg v 1.1.3</version>
 		<status>Release</status>
 		<required_version>2.0</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-legacy/haproxy.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -136,9 +136,9 @@
 				(Legacy version)]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.4.24 pkg v 1.1.2</version>
+		<version>1.4.24 pkg v 1.1.3</version>
 		<status>Release</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-legacy/haproxy.xml</config_file>
 		<configurationfile>haproxy.xml</configurationfile>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>


### PR DESCRIPTION
The config option used has not existed since pfSense 2.1 (config version 084).