### PR TITLE
apache_mod_security-dev - XMLRPC sync fixes and improvements

### DIFF
--- a/config/apache_mod_security-dev/apache_mod_security.inc
+++ b/config/apache_mod_security-dev/apache_mod_security.inc
@@ -1,19 +1,20 @@
 <?php
 /*
 	apache_mod_security.inc
-	part of apache_mod_security package (http://www.pfSense.com)
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2009, 2010 Scott Ullrich
 	Copyright (C) 2012-2013 Marcello Coutinho
 	Copyright (C) 2013 Stephane Lapie <stephane.lapie@asahinet.com>
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:
 
-	1. Redistributions of source code MUST retain the above copyright notice,
+	1. Redistributions of source code must retain the above copyright notice,
 	   this list of conditions and the following disclaimer.
 
-	2. Redistributions in binary form MUST reproduce the above copyright
+	2. Redistributions in binary form must reproduce the above copyright
 	   notice, this list of conditions and the following disclaimer in the
 	   documentation and/or other materials provided with the distribution.
 
@@ -28,7 +29,6 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
 require_once("service-utils.inc");
 
 $shortcut_section = "apache";
@@ -157,27 +157,38 @@ function apache_mod_security_resync() {
 	if (is_array($config['installedpackages']['apachesync']['config'])){
 		$apache_sync = $config['installedpackages']['apachesync']['config'][0];
 		$synconchanges = $apache_sync['synconchanges'];
-		$synctimeout = $apache_sync['synctimeout'];
-		switch ($synconchanges){
+		$synctimeout = $apache_sync['synctimeout'] ?: '250';
+		switch ($synconchanges) {
 			case "manual":
-				if (is_array($apache_sync[row])){
-					$rs = $apache_sync[row];
+				if (is_array($apache_sync['row'])) {
+					$rs = $apache_sync['row'];
 				} else {
-					log_error("apache_mod_security_package: XMLRPC sync is enabled, but there is no local host to push on apache config.");
+					log_error("apache_mod_security_package:  XMLRPC sync is enabled but there are no hosts configured as replication targets.");
 					return;
 				}
 				break;
 			case "auto":
-				if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])){ // pfSense 2.0.x
-					$system_carp = $config['installedpackages']['carpsettings']['config'][0];
-					$rs[0]['ipaddress'] = $system_carp['synchronizetoip'];
-					$rs[0]['username'] = $system_carp['username'];
-					$rs[0]['password'] = $system_carp['password'];
-				} else if (is_array($config['hasync'])) { // pfSense 2.1
+				if (is_array($config['hasync'])) {
 					$system_carp = $config['hasync'];
 					$rs[0]['ipaddress'] = $system_carp['synchronizetoip'];
 					$rs[0]['username'] = $system_carp['username'];
 					$rs[0]['password'] = $system_carp['password'];
+					$rs[0]['syncdestinenable'] = FALSE;
+
+					// XMLRPC sync is currently only supported over connections using the same protocol and port as this system
+					if ($config['system']['webgui']['protocol'] == "http") {
+						$rs[0]['syncprotocol'] = "http";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '80';
+					} else {
+						$rs[0]['syncprotocol'] = "https";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '443';
+					}
+					if ($system_carp['synchronizetoip'] == "") {
+						log_error("apache_mod_security_package: XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+						return;
+					} else {
+						$rs[0]['syncdestinenable'] = TRUE;
+					}
 				} else {
 					log_error("apache_mod_security_package: XMLRPC sync is enabled, but there is no global backup host to push apache config.");
 					return;
@@ -185,55 +196,63 @@ function apache_mod_security_resync() {
 				break;
 			default:
 				return;
-			break;
+				break;
 		}
-	}
-	if (is_array($rs)){
-		foreach($rs as $sh){
-			$sync_to_ip = $sh['ipaddress'];
-			$password = $sh['password'];
-			if ($sh['username'])
-				$username = $sh['username'];
-			else
-				$username = 'admin';
-			if ($password && $sync_to_ip)
-				apache_mod_security_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout);
+		if (is_array($rs)) {
+			log_error("apache_mod_security_package: XMLRPC sync is starting.");
+			foreach ($rs as $sh) {
+				// Only sync enabled replication targets
+				if ($sh['syncdestinenable']) {
+					$sync_to_ip = $sh['ipaddress'];
+					$port = $sh['syncport'];
+					$username = $sh['username'] ?: 'admin';
+					$password = $sh['password'];
+					$protocol = $sh['syncprotocol'];
+
+					$error = '';
+					$valid = TRUE;
+
+					if ($password == "") {
+						$error = "Password parameter is empty. ";
+						$valid = FALSE;
+					}
+					if (!is_ipaddr($sync_to_ip) && !is_hostname($sync_to_ip) && !is_domain($sync_to_ip)) {
+						$error .= "Misconfigured Replication Target IP Address or Hostname. ";
+						$valid = FALSE;
+					}
+					if (!is_port($port)) {
+						$error .= "Misconfigured Replication Target Port. ";
+						$valid = FALSE;
+					}
+					if ($valid) {
+						apache_mod_security_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout);
+					} else {
+						log_error("apache_mod_security_package: XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
+					}
+				}
+			}
+			log_error("apache_mod_security_package: XMLRPC sync completed.");
 		}
 	}
 }
 
 // Do the actual XMLRPC Sync
-function apache_mod_security_do_xmlrpc_sync($sync_to_ip, $username, $password, $synctimeout) {
+function apache_mod_security_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout) {
         global $config, $g;
 
-	if(!$username)
+	if ($username == "" || $password == "" || $sync_to_ip == "" || $port == "" || $protocol == "") {
+		log_error("apache_mod_security_package: A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
-
-        if(!$password)
-		return;
-
-	if(!$sync_to_ip)
-		return;
-
-	if(!$synctimeout)
-		$synctimeout=25;
-
-	$xmlrpc_sync_neighbor = $sync_to_ip;
-	if($config['system']['webgui']['protocol'] != "") {
-		$synchronizetoip = $config['system']['webgui']['protocol'];
-		$synchronizetoip .= "://";
 	}
-	$port = $config['system']['webgui']['port'];
-	/* if port is empty lets rely on the protocol selection */
-	if($port == "") {
-		if($config['system']['webgui']['protocol'] == "http")
-			$port = "80";
-		else
-			$port = "443";
-	}
-	$synchronizetoip .= $sync_to_ip;
 
-	/* xml will hold the sections to sync */
+	// Take care of IPv6 literal address
+	if (is_ipaddrv6($sync_to_ip)) {
+		$sync_to_ip = "[{$sync_to_ip}]";
+	}
+
+	$url = "{$protocol}://{$sync_to_ip}";
+
+	/* XML will hold the sections to sync. */
 	$xml = array();
 	$xml['apachesettings'] = $config['installedpackages']['apachesettings'];
 	$xml['apachemodsecurity'] = $config['installedpackages']['apachemodsecurity'];
@@ -243,66 +262,57 @@ function apache_mod_security_do_xmlrpc_sync($sync_to_ip, $username, $password, $
 	$xml['apachevirtualhost'] = $config['installedpackages']['apachevirtualhost'];
 	$xml['apachelisten'] = $config['installedpackages']['apachelisten'];
 
-	/* assemble xmlrpc payload */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($xml)
-	);
+	/* Assemble XMLRPC payload. */
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($xml));
 
-	/* set a few variables needed for sync code borrowed from filter.inc */
-	$url = $synchronizetoip;
-	log_error("apache_mod_security_package: Beginning apache_mod_security XMLRPC sync to {$url}:{$port}.");
+	/* Set a few variables needed for sync code */
 	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
-	if($g['debug'])
+	if ($g['debug']) {
 		$cli->setDebug(1);
-	/* send our XMLRPC message and timeout after defined sync timeout value*/
+	}
+	/* Send our XMLRPC message and timeout after defined sync timeout value */
 	$resp = $cli->send($msg, $synctimeout);
-	if(!$resp) {
-		$error = "A communications error occurred while attempting apache_mod_security XMLRPC sync with {$url}:{$port}.";
-		log_error($error);
+	if (!$resp) {
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port}.";
+		log_error("apache_mod_security_package: {$error}");
 		file_notice("sync_settings", $error, "apache_mod_security Settings Sync", "");
-	} elseif($resp->faultCode()) {
+	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, $synctimeout);
-		$error = "An error code was received while attempting apache_mod_security XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("apache_mod_security_package: {$error}");
 		file_notice("sync_settings", $error, "apache_mod_security Settings Sync", "");
 	} else {
 		log_error("apache_mod_security_package: XMLRPC sync successfully completed with {$url}:{$port}.");
 	}
 
-	/* tell apache_mod_security to reload our settings on the destination sync host. */
+	/* Tell apache_mod_security to reload our settings on the destination sync host. */
 	$method = 'pfsense.exec_php';
 	$execcmd  = "require_once('/usr/local/pkg/apache_mod_security.inc');\n";
 	$execcmd .= "apache_mod_security_resync();";
-	/* assemble xmlrpc payload */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($execcmd)
-	);
+	/* Assemble XMLRPC payload. */
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($execcmd));
 
-	log_error("apache_mod_security_package: XMLRPC reload data {$url}:{$port}.");
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
 	$resp = $cli->send($msg, $synctimeout);
-	if(!$resp) {
-		$error = "A communications error occurred while attempting apache_mod_security XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-		log_error($error);
+	if (!$resp) {
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
+		log_error("apache_mod_security_package: {$error}");
 		file_notice("sync_settings", $error, "apache_mod_security Settings Sync", "");
-	} elseif($resp->faultCode()) {
+	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, $synctimeout);
-		$error = "An error code was received while attempting apache_mod_security XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("apache_mod_security_package: {$error}");
 		file_notice("sync_settings", $error, "apache_mod_security Settings Sync", "");
 	} else {
-		log_error("apache_mod_security XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
+		log_error("apache_mod_security_package: XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
 	}
-
 
 }
 

--- a/config/apache_mod_security-dev/apache_mod_security_sync.xml
+++ b/config/apache_mod_security-dev/apache_mod_security_sync.xml
@@ -1,46 +1,46 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
 	<copyright>
 	<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-    apache_sync.xml
-    part of the sarg package for pfSense
-    Copyright (C) 2012 Marcello Coutinho
-    All rights reserved.            
-                                                                  */
-/* ========================================================================== */
+	apache_sync.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2012 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+*/
+/* ====================================================================================== */
 /*
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-     1. Redistributions of source code MUST retain the above copyright notice,
-        this list of conditions and the following disclaimer.
 
-     2. Redistributions in binary form MUST reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-                                                                              */
-/* ========================================================================== */
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/* ====================================================================================== */
 	]]>
 	</copyright>
-	<description>Describe your package here</description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
 	<name>apachesync</name>
 	<version>1.0</version>
 	<title>Proxy server: XMLRPC Sync</title>
@@ -66,9 +66,15 @@
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Automatically sync apache configuration changes</fielddescr>
+			<fielddescr>Enable Sync</fielddescr>
 			<fieldname>synconchanges</fieldname>
-			<description>Select a sync method for Apache + ModSecurity.</description>
+			<description>
+				<![CDATA[
+				Select a sync method for Apache + ModSecurity.<br/><br/>
+				<strong>Important:</strong> While using "Sync to host(s) defined below", only sync from host A to B, A to C but <strong>do not</strong> enable XMLRPC sync <b>to</b> A.
+				This will result in a loop!
+				]]>
+			</description>
 			<type>select</type>
 			<required/>
 			<default_value>auto</default_value>
@@ -79,39 +85,70 @@
 			</options>
 		</field>
 		<field>
-		        <fielddescr>Sync timeout</fielddescr>
+			<fielddescr>Sync Timeout</fielddescr>
 			<fieldname>synctimeout</fieldname>
-			<description>Select sync max wait time</description>
+			<description>XMLRPC timeout in seconds.</description>
 			<type>select</type>
 			<required/>
 			<default_value>250</default_value>
 			<options>
-				<option><name>30 seconds(Default)</name><value>30</value></option>
-				<option><name>60 seconds</name><value>60</value></option>
-				<option><name>90 seconds</name><value>90</value></option>
+				<option><name>250 seconds (Default)</name><value>250</value></option>
 				<option><name>120 seconds</name><value>120</value></option>
-				<option><name>250 seconds</name><value>250</value></option>
+				<option><name>90 seconds</name><value>90</value></option>
+				<option><name>60 seconds</name><value>60</value></option>
+				<option><name>30 seconds</name><value>30</value></option>
 			</options>
 		</field>
 		<field>
-			<fielddescr>Remote Server</fielddescr>
+			<fielddescr>Replication Targets</fielddescr>
 			<fieldname>none</fieldname>
 			<type>rowhelper</type>
 			<rowhelper>
-			<rowhelperfield>
-				<fielddescr>IP Address</fielddescr>
-				<fieldname>ipaddress</fieldname>
-				<description>IP Address of remote server</description>
-				<type>input</type>
-				<size>20</size>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>Password</fielddescr>
-				<fieldname>password</fieldname>
-				<description>Password for remote server.</description>
-				<type>password</type>
-				<size>20</size>
-			</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Enable</fielddescr>
+					<fieldname>syncdestinenable</fieldname>
+					<description><![CDATA[Enable this host as a replication target]]></description>
+					<type>checkbox</type>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Protocol</fielddescr>
+					<fieldname>syncprotocol</fieldname>
+					<description><![CDATA[Choose the protocol used to sync with the destination host (HTTP or HTTPS).]]></description>
+					<type>select</type>
+					<default_value>HTTP</default_value>
+					<options>
+						<option><name>HTTP</name><value>http</value></option>
+						<option><name>HTTPS</name><value>https</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>IP Address/Hostname</fielddescr>
+					<fieldname>ipaddress</fieldname>
+					<description><![CDATA[IP address or hostname of the destination host.]]></description>
+					<type>input</type>
+					<size>40</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Port</fielddescr>
+					<fieldname>syncport</fieldname>
+					<description><![CDATA[Choose the sync port of the destination host.]]></description>
+					<type>input</type>
+					<size>3</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Username (admin)</fielddescr>
+					<fieldname>username</fieldname>
+					<description><![CDATA[Enter the username account for administration.]]></description>
+					<type>input</type>
+					<size>20</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Admin Password</fielddescr>
+					<fieldname>password</fieldname>
+					<description><![CDATA[Password of the user "admin" on the destination host.]]></description>
+					<type>password</type>
+					<size>20</size>
+				</rowhelperfield>
 			</rowhelper>
 		</field>
 	</fields>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -200,7 +200,7 @@
 			]]>
 		</descr>
 		<category>Network Management</category>
-		<version>0.44</version>
+		<version>0.45</version>
 		<status>ALPHA</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/apache_mod_security-dev/apache_virtualhost.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -215,9 +215,9 @@
 			In addition this package allows URL forwarding which can be convenient for hosting multiple websites behind pfSense using 1 IP address.<br>
 			<b>Backup your location config before updating from 0.2.x to 0.3 package version.</b>]]></descr>
 		<category>Network Management</category>
-		<version>2.4.9 pkg v0.43</version>
+		<version>2.4.9 pkg v0.45</version>
 		<status>ALPHA</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/apache_mod_security-dev/apache_virtualhost.xml</config_file>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
 		<depends_on_package>db42-4.2.52_5.tbz</depends_on_package>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -202,9 +202,9 @@
 			In addition this package allows URL forwarding which can be convenient for hosting multiple websites behind pfSense using 1 IP address.<br>
 			<b>Backup your location config before updating from 0.2.x to 0.3 package version.</b>]]></descr>
 		<category>Network Management</category>
-		<version>2.4.9 pkg v0.43</version>
+		<version>2.4.9 pkg v0.45</version>
 		<status>ALPHA</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/apache_mod_security-dev/apache_virtualhost.xml</config_file>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
 		<depends_on_package>db42-4.2.52_5.tbz</depends_on_package>


### PR DESCRIPTION
- Fix CARP/HA sync option (port/protocol)
- Add enable/disable checkbox per replication target
- Add protocol/port selection
- Fix literal IPv6 handling for sync targets
- Do settings validation and only try to sync when configuration is valid
- Nuke obsolete pfSense 2.0 cruft