### PR TITLE
squidGuard -  XMLRPC fixes; add checks for ramdisks, force disable blacklists usage on nanobsd (Bug #4608)

### DIFF
--- a/config/squidGuard/squidguard.inc
+++ b/config/squidGuard/squidguard.inc
@@ -1,36 +1,34 @@
 <?php
-# ------------------------------------------------------------------------------
-/*  squidguard.inc
-
+/*
+	squidguard.inc
+	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2006-2011 Serg Dvoriancev
 	Copyright (C) 2013 Alexander Wilke <nachtfalkeaw@web.de>
 	Copyright (C) 2013 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 
-    part of pfSense (www.pfSense.com)
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    1. Redistributions of source code MUST retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    2. Redistributions in binary form MUST reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
-
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
-# ------------------------------------------------------------------------------
-
 require_once('globals.inc');
 require_once('config.inc');
 require_once('util.inc');
@@ -1482,100 +1480,114 @@ function squidguard_blacklist_list()
     return $res;
 }
 
-// ##### The following part is based on the code of pfblocker #####
-
 /* Uses XMLRPC to synchronize the changes to a remote node */
 function squidguard_sync_on_changes() {
 	global $config, $g;
-	if (is_array($config['installedpackages']['squidguardsync'])){
+
+	if (is_array($config['installedpackages']['squidguardsync'])) {
 		$synconchanges = $config['installedpackages']['squidguardsync']['config'][0]['varsyncenablexmlrpc'];
-		$varsynctimeout = $config['installedpackages']['squidguardsync']['config'][0]['varsynctimeout'];
-		}
-	else
-	{
+		$varsynctimeout = $config['installedpackages']['squidguardsync']['config'][0]['varsynctimeout'] ?: '150';
+	} else {
 		return;
 	}
 
-	// if checkbox is NOT checked do nothing
-	switch ($synconchanges){
+	switch ($synconchanges) {
 		case "manual":
-			if (is_array($config['installedpackages']['squidguardsync']['config'][0]['row'])){
-				$rs=$config['installedpackages']['squidguardsync']['config'][0]['row'];
-				}
-			else{
-				log_error("[Squidguard] xmlrpc sync is enabled but there is no hosts to push on Squidguard config.");
+			if (is_array($config['installedpackages']['squidguardsync']['config'][0]['row'])) {
+				$rs = $config['installedpackages']['squidguardsync']['config'][0]['row'];
+			} else {
+				log_error("[Squidguard]  XMLRPC sync is enabled but there are no hosts configured as replication targets.");
 				return;
-				}
+			}
 			break;
 		case "auto":
-				if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])){
-					$system_carp=$config['installedpackages']['carpsettings']['config'][0];
-					$rs[0]['varsyncdestinenable']="on";
-					$rs[0]['varsyncprotocol']=($config['system']['webgui']['protocol']!=""?$config['system']['webgui']['protocol']:"https");
-					$rs[0]['varsyncipaddress']=$system_carp['synchronizetoip'];
-					$rs[0]['varsyncpassword']=$system_carp['password'];
-					$rs[0]['varsyncport']=($config['system']['webgui']['port']!=""?$config['system']['webgui']['port']:"443");
-					if (! is_ipaddr($system_carp['synchronizetoip'])){
-						log_error("[Squidguard] xmlrpc sync is enabled but there is no system backup hosts to push squid config.");
-						return;
-						}
+			if (is_array($config['hasync'])) {
+				$system_carp = $config['hasync'];
+				$rs[0]['varsyncipaddress'] = $system_carp['synchronizetoip'];
+				$rs[0]['varsyncusername'] = $system_carp['username'];
+				$rs[0]['varsyncpassword'] = $system_carp['password'];
+				$rs[0]['varsyncdestinenable'] = FALSE;
+
+				// XMLRPC sync is currently only supported over connections using the same protocol and port as this system
+				if ($config['system']['webgui']['protocol'] == 'http') {
+					$rs[0]['varsyncprotocol'] = 'http';
+					$rs[0]['varsyncport'] = $config['system']['webgui']['port'] ?: '80';
+				} else {
+					$rs[0]['varsyncprotocol'] = 'https';
+					$rs[0]['varsyncport'] = $config['system']['webgui']['port'] ?: '443';
 				}
-				else{
-					log_error("[Squidguard] xmlrpc sync is enabled but there is no system backup hosts to push squid config.");
+				if ($system_carp['synchronizetoip'] == "") {
+					log_error("[Squidguard] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 					return;
+				} else {
+					$rs[0]['varsyncdestinenable'] = TRUE;
 				}
-			break;		
+			} else {
+				log_error("[Squidguard] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+				return;
+			}
+			break;
 		default:
 			return;
-		break;
+			break;
+	}
+	if (is_array($rs)) {
+		log_error("[SquidGuard] XMLRPC sync is starting with timeout {$varsynctimeout} seconds.");
+		foreach ($rs as $sh) {
+			// Only sync enabled replication targets
+			if ($sh['varsyncdestinenable']) {
+				$varsyncprotocol = $sh['varsyncprotocol'];
+				$sync_to_ip = $sh['varsyncipaddress'];
+				$username = $sh['varsyncusername'] ?: 'admin';
+				$password = $sh['varsyncpassword'];
+				$varsyncport = $sh['varsyncport'];
+
+				$error = '';
+				$valid = TRUE;
+
+				if ($password == "") {
+					$error = "Password parameter is empty. ";
+					$valid = FALSE;
+				}
+				if (!is_ipaddr($sync_to_ip) && !is_hostname($sync_to_ip) && !is_domain($sync_to_ip)) {
+					$error .= "Misconfigured Replication Target IP Address or Hostname. ";
+					$valid = FALSE;
+				}
+				if (!is_port($varsyncport)) {
+					$error .= "Misconfigured Replication Target Port. ";
+					$valid = FALSE;
+				}
+				if ($valid) {
+					squidguard_do_xmlrpc_sync($sync_to_ip, $varsyncport, $varsyncprotocol, $username, $password, $varsynctimeout);
+				} else {
+					log_error("[SquidGuard] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
+				}
+			} else {
+				log_error("[SquidGuard] XMLRPC Sync with {$sh['varsyncipaddress']} is disabled");
+			}
 		}
-		if (is_array($rs)){
-			log_error("[SquidGuard] xmlrpc sync is starting with timeout {$varsynctimeout} seconds.");
-			foreach($rs as $sh){
-				if($sh['varsyncdestinenable']){
-					$varsyncprotocol 	= $sh['varsyncprotocol'];
-					$sync_to_ip 		= $sh['varsyncipaddress'];
-					$password   		= $sh['varsyncpassword'];
-					$varsyncport 		= $sh['varsyncport'];
-					if($password && $sync_to_ip)
-						squidguard_do_xmlrpc_sync($sync_to_ip, $password, $varsyncport, $varsyncprotocol,$varsynctimeout);
-					else
-						log_error("SquidGuard: XMLRPC Sync with {$sh['varsyncipaddress']} has incomplete credentials. No XMLRPC Sync done!");
-				}
-				else {
-				log_error("SquidGuard: XMLRPC Sync with {$sh['varsyncipaddress']} is disabled");
-				}
-			}
-			log_error("[SquidGuard] xmlrpc sync is ending.");
-			}
+		log_error("[SquidGuard] XMLRPC sync is ending.");
+	}
 }
 
 /* Do the actual XMLRPC sync */
-function squidguard_do_xmlrpc_sync($sync_to_ip, $password, $varsyncport, $varsyncprotocol,$varsynctimeout) {
+function squidguard_do_xmlrpc_sync($sync_to_ip, $varsyncport, $varsyncprotocol, $username, $password, $varsynctimeout) {
 	global $config, $g;
 
-	if($varsynctimeout == '' || $varsynctimeout == 0)
-		$varsynctimeout = 150;
-
-	if(!$password)
+	if ($username == "" || $password == "" || $sync_to_ip == "" || $varsyncport == "" || $varsyncprotocol == "") {
+		log_error("[SquidGuard] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
+	}
 
-	if(!$sync_to_ip)
-		return;
-	
-	if(!$varsyncport)
-		return;
+	// Take care of IPv6 literal address
+	if (is_ipaddrv6($sync_to_ip)) {
+		$sync_to_ip = "[{$sync_to_ip}]";
+	}
 
-	if(!$varsyncprotocol)
-		return;
-	
-	// Check and choose correct protocol type, port number and IP address
-	$synchronizetoip .= "$varsyncprotocol" . '://';
-	$port = "$varsyncport";
+	$url = "{$varsyncprotocol}://{$sync_to_ip}";
+	$port = $varsyncport;
 
-	$synchronizetoip .= $sync_to_ip;
-
-	/* xml will hold the sections to sync */
+	/* XML will hold the sections to sync. */
 	$xml = array();
 	$xml['squidguardgeneral'] = $config['installedpackages']['squidguardgeneral'];
 	$xml['squidguardacl'] = $config['installedpackages']['squidguardacl'];
@@ -1583,82 +1595,74 @@ function squidguard_do_xmlrpc_sync($sync_to_ip, $password, $varsyncport, $varsyn
 	$xml['squidguarddest'] = $config['installedpackages']['squidguarddest'];
 	$xml['squidguardrewrite'] = $config['installedpackages']['squidguardrewrite'];
 	$xml['squidguardtime'] = $config['installedpackages']['squidguardtime'];
-	
-	/* assemble xmlrpc payload */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($xml)
-	);
 
-	/* set a few variables needed for sync code borrowed from filter.inc */
-	$url = $synchronizetoip;
-	log_error("SquidGuard: Beginning squidguard XMLRPC sync with {$url}:{$port}.");
+	/* Assemble XMLRPC payload. */
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($xml));
+
+	/* Set a few variables needed for sync code */
+	log_error("[SquidGuard] Beginning XMLRPC sync with {$url}:{$port}.");
 	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
-	$cli->setCredentials('admin', $password);
-		if($g['debug'])
-			$cli->setDebug(1);
-		/* send our XMLRPC message and timeout after $varsynctimeout seconds */
+	$cli->setCredentials($username, $password);
+	if ($g['debug']) {
+		$cli->setDebug(1);
+	}
+	/* Send our XMLRPC message and timeout after $varsynctimeout seconds */
+	$resp = $cli->send($msg, $varsynctimeout);
+	if (!$resp) {
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port}.";
+		log_error("[SquidGuard] {$error}");
+		file_notice("sync_settings", $error, "squidguard Settings Sync", "");
+	} elseif ($resp->faultCode()) {
+		$cli->setDebug(1);
 		$resp = $cli->send($msg, $varsynctimeout);
-		if(!$resp) {
-			$error = "A communications error occurred while squidguard was attempting XMLRPC sync with {$url}:{$port}.";
-			log_error("SquidGuard: $error");
-			file_notice("sync_settings", $error, "squidguard Settings Sync", "");
-		} elseif($resp->faultCode()) {
-			$cli->setDebug(1);
-			$resp = $cli->send($msg, $varsynctimeout);
-			$error = "An error code was received while squidguard XMLRPC was attempting to sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error("SquidGuard: $error");
-			file_notice("sync_settings", $error, "squidguard Settings Sync", "");
-		} else {
-			log_error("SquidGuard: XMLRPC has synced data successfully with {$url}:{$port}.");
-		}
-	
-	/* tell squidguard to reload our settings on the destionation sync host. */
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("[SquidGuard] {$error}");
+		file_notice("sync_settings", $error, "squidguard Settings Sync", "");
+	} else {
+		log_error("[SquidGuard] XMLRPC sync successfully completed with {$url}:{$port}.");
+	}
+
+	/* Tell Squidguard to reload our settings on the destionation sync host. */
 	$method = 'pfsense.exec_php';
 	$execcmd  = "require_once('/usr/local/pkg/squidguard.inc');\n";
-	// pfblocker just needed one fuction to reload after XMLRPC. squidguard needs more so we point to a fuction below which contains all fuctions
+	// Squidguard needs more functions; we point to a function below which contains all the required functions
 	$execcmd .= "squidguard_all_after_XMLRPC_resync();";
-	
-	/* assemble xmlrpc payload */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($execcmd)
-	);
 
-	log_error("SquidGuard XMLRPC is reloading data on {$url}:{$port}.");
+	/* Assemble XMLRPC payload. */
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($execcmd));
+
+	log_error("[SquidGuard] XMLRPC is reloading data on {$url}:{$port}.");
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
-	$cli->setCredentials('admin', $password);
+	$cli->setCredentials($username, $password);
+	$resp = $cli->send($msg, $varsynctimeout);
+	if (!$resp) {
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port} (exec_php).";
+		log_error("[SquidGuard] {$error}");
+		file_notice("sync_settings", $error, "squidguard Settings Sync", "");
+	} elseif ($resp->faultCode()) {
+		$cli->setDebug(1);
 		$resp = $cli->send($msg, $varsynctimeout);
-		if(!$resp) {
-			$error = "A communications error occurred while squidguard was attempting XMLRPC sync with {$url}:{$port} (exec_php).";
-			log_error($error);
-			file_notice("sync_settings", $error, "squidguard Settings Sync", "");
-		} elseif($resp->faultCode()) {
-			$cli->setDebug(1);
-			$resp = $cli->send($msg, $varsynctimeout);
-			$error = "An error code was received while squidguard XMLRPC was attempting to sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-			log_error($error);
-			file_notice("sync_settings", $error, "squidguard Settings Sync", "");
-		} else {
-			log_error("SquidGuard: XMLRPC has reloaded data successfully on {$url}:{$port} (exec_php).");
-		}
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("[SquidGuard] {$error}");
+		file_notice("sync_settings", $error, "squidguard Settings Sync", "");
+	} else {
+		log_error("[SquidGuard] XMLRPC has reloaded data successfully on {$url}:{$port} (exec_php).");
+	}
 
 }
 
-// ##### The part above is based on the code of pfblocker #####
-
-// This function restarts all other needed functions after XMLRPC so that the content of .XML + .INC will be written in the files
+// This function restarts all other needed functions after XMLRPC sync so that the content of .XML + .INC will be written in the files
 // Adding more functions will increase the time to sync
 function squidguard_all_after_XMLRPC_resync() {
-	
+
 	squidguard_resync_acl();
 	squidguard_resync_dest();
 	squidguard_resync();
-	
-	log_error("SquidGuard: Finished XMLRPC process. It should be OK. For more information look at the host which started sync.");
+
+	log_error("[SquidGuard] Finished XMLRPC process. It should be OK. For more information look at the host which started sync.");
 }
 
 ?>

--- a/config/squidGuard/squidguard.inc
+++ b/config/squidGuard/squidguard.inc
@@ -103,10 +103,17 @@ sg_init(convert_pfxml_to_sgxml());
 # ==============================================================================
 function squidguard_validate(&$post, &$input_errors)
 {
+    global $config, $g;
     $submit = isset($_GET['submit']) ? $_GET['submit'] : $_POST['submit'];
 
     # check config if 'Apply'
-    if ($submit === APPLY_BTN)  sg_check_config_data($input_errors);
+    if ($submit === APPLY_BTN) {
+    	// XXX:Bug #4608
+    	if (($g['platform'] == "pfSense") && isset($config['system']['use_mfs_tmpvar'])) {
+    		$input_errors[] = "Please, disable 'Use RAM Disks' under System: Advanced: Miscellaneous to avoid SquidGuard configuration breakage on reboot.";
+    	}
+    	sg_check_config_data($input_errors);
+    }
 }
 
 # ------------------------------------------------------------------------------

--- a/config/squidGuard/squidguard.inc
+++ b/config/squidGuard/squidguard.inc
@@ -112,6 +112,11 @@ function squidguard_validate(&$post, &$input_errors)
     	if (($g['platform'] == "pfSense") && isset($config['system']['use_mfs_tmpvar'])) {
     		$input_errors[] = "Please, disable 'Use RAM Disks' under System: Advanced: Miscellaneous to avoid SquidGuard configuration breakage on reboot.";
     	}
+	if ($g['platform'] != "pfSense") {
+		if ($post['blacklist'] != "" || $post['blacklist_proxy'] != "" || $post['blacklist_url'] != "") {
+			$input_errors[] = "Blacklists usage is NOT supported on NanoBSD. Disable 'Blacklist' option in 'General settings'.";
+		}
+	}
     	sg_check_config_data($input_errors);
     }
 }

--- a/config/squidGuard/squidguard.xml
+++ b/config/squidGuard/squidguard.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidguardgeneral</name>
-	<version>1.9.16</version>
+	<version>1.9.17</version>
 	<title>Proxy filter SquidGuard: General settings</title>
 	<include_file>/usr/local/pkg/squidguard.inc</include_file>
 	<!-- Installation -->
@@ -148,7 +148,13 @@
                 <field>
                         <fielddescr>Enable</fielddescr>
                         <fieldname>squidguard_enable</fieldname>
-                        <description><![CDATA[Check this option to enable squidGuard]]></description>
+                        <description>
+                        	<![CDATA[
+                        	Check this option to enable squidGuard.<br />
+                        	<strong><span class="errmsg">Important: </span></strong>Please set up at least one category on the 'Target Categories' tab before enabling.
+                        	See <a href="https://forum.pfsense.org/index.php?topic=94312.0">this link for details</a>.
+                        	]]>
+                        </description>
                         <type>checkbox</type>
                 </field>
                 <field>

--- a/config/squidGuard/squidguard.xml
+++ b/config/squidGuard/squidguard.xml
@@ -244,8 +244,14 @@
                 <field>
                         <fielddescr>Blacklist</fielddescr>
                         <fieldname>blacklist</fieldname>
-                        <description><![CDATA[Check this option to enable blacklist]]></description>
+                        <description>
+                        	<![CDATA[
+                        	Check this option to enable blacklist.<br />
+                        	<strong><span class="errmsg">Do NOT enable this on NanoBSD installs!</span></strong>
+                        	]]>
+                        </description>
                         <type>checkbox</type>
+                        <enablefields>blacklist_proxy,blacklist_url</enablefields>
                 </field>
                 <field>
                         <fielddescr>Blacklist proxy</fielddescr>

--- a/config/squidGuard/squidguard_sync.xml
+++ b/config/squidGuard/squidguard_sync.xml
@@ -1,54 +1,50 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
-  <copyright>
+	<copyright>
 <![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-squidguardsync.xml
-part of pfSense (http://www.pfSense.com)
-Copyright (C) 2013 Alexander Wilke <nachtfalkeaw@web.de>
-Copyright (C) 2013 Marcello Coutinho
-based on pfblocker_sync.xml
-All rights reserved.
-
-Based on m0n0wall (http://m0n0.ch/wall)
-Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-All rights reserved.
+	squidguardsync.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2013 Alexander Wilke <nachtfalkeaw@web.de>
+	Copyright (C) 2013 Marcello Coutinho
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
 */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
-/* ========================================================================== */
-]]></copyright>
-	<description><![CDATA[Describe your package here]]></description>
-	<requirements>Describe your package requirements here</requirements>
-	<faq>Currently there are no FAQ items provided.</faq>
+/* ====================================================================================== */
+	]]>
+	</copyright>
 	<name>squidguardsync</name>
-	<version>1.3_1 pkg v.1.9</version>
-	<title>Proxy filter SquidGuard: XMLRPC Sync</title>
+	<version>1.9.17</version>
+	<title>SquidGuard Proxy Filter: XMLRPC Sync</title>
 	<include_file>/usr/local/pkg/squidguard.inc</include_file>
 	<tabs>
 		<tab>
@@ -97,11 +93,16 @@ POSSIBILITY OF SUCH DAMAGE.
 		<field>
 			<fielddescr>Enable Sync</fielddescr>
 			<fieldname>varsyncenablexmlrpc</fieldname>
-			<description><![CDATA[All changes will be synced immediately to the IPs listed below if this option is checked.<br>
-						<b>Important:</b> While using "Sync to hosts defined below", only sync from host A to B, A to C but <b>do not</B> enable XMLRPC sync <b>to</b> A. This will result in a loop!]]></description>
+			<description>
+				<![CDATA[
+				Select a sync method for SquidGuard.<br/><br/>
+				<strong>Important:</strong> While using "Sync to host(s) defined below", only sync from host A to B, A to C but <strong>do not</strong> enable XMLRPC sync <b>to</b> A.
+				This will result in a loop!
+				]]>
+			</description>
 			<type>select</type>
 			<required/>
-			<default_value>auto</default_value>
+			<default_value>disabled</default_value>
 			<options>
 				<option><name>Sync to configured system backup server</name><value>auto</value></option>
 				<option><name>Sync to host(s) defined below</name><value>manual</value></option>
@@ -109,28 +110,28 @@ POSSIBILITY OF SUCH DAMAGE.
 			</options>
 		</field>
 		<field>
-						<fielddescr>XMLRPC timeout</fielddescr>
+			<fielddescr>XMLRPC Timeout</fielddescr>
 			<fieldname>varsynctimeout</fieldname>
-			<description><![CDATA[Timeout in seconds for the XMLRPC timeout. Default: 150]]></description>
+			<description>XMLRPC timeout in seconds. (Default: 150)</description>
 			<type>input</type>
-						<default_value>150</default_value>
+			<default_value>150</default_value>
 			<size>5</size>
 		</field>
-
 		<field>
-			<fielddescr>Destination Server</fielddescr>
+			<fielddescr>Replication Targets</fielddescr>
 			<fieldname>none</fieldname>
 			<type>rowhelper</type>
 			<rowhelper>
 				<rowhelperfield>
 					<fielddescr>Enable</fielddescr>
 					<fieldname>varsyncdestinenable</fieldname>
+					<description><![CDATA[Enable this host as a replication target]]></description>
 					<type>checkbox</type>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>GUI Protocol</fielddescr>
+					<fielddescr>Protocol</fielddescr>
 					<fieldname>varsyncprotocol</fieldname>
-					<description><![CDATA[Choose the protocol of the destination host. Probably <b>http</b> or <b>https</b>]]></description>
+					<description><![CDATA[Choose the protocol used to sync with the destination host (HTTP or HTTPS).]]></description>
 					<type>select</type>
 					<default_value>HTTP</default_value>
 					<options>
@@ -139,21 +140,21 @@ POSSIBILITY OF SUCH DAMAGE.
 					</options>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>GUI IP-Address</fielddescr>
+					<fielddescr>IP Address/Hostname</fielddescr>
 					<fieldname>varsyncipaddress</fieldname>
-					<description><![CDATA[IP Address of the destination host.]]></description>
+					<description><![CDATA[IP address or hostname of the destination host.]]></description>
 					<type>input</type>
-					<size>15</size>
+					<size>40</size>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>GUI Port</fielddescr>
+					<fielddescr>Port</fielddescr>
 					<fieldname>varsyncport</fieldname>
-					<description><![CDATA[Choose the port of the destination host.]]></description>
+					<description><![CDATA[Choose the sync port of the destination host.]]></description>
 					<type>input</type>
 					<size>3</size>
 				</rowhelperfield>
-								<rowhelperfield>
-					<fielddescr>GUI Admin Password</fielddescr>
+				<rowhelperfield>
+					<fielddescr>Admin Password</fielddescr>
 					<fieldname>varsyncpassword</fieldname>
 					<description><![CDATA[Password of the user "admin" on the destination host.]]></description>
 					<type>password</type>
@@ -162,9 +163,6 @@ POSSIBILITY OF SUCH DAMAGE.
 			</rowhelper>
 		</field>
 	</fields>
-	<custom_delete_php_command>
-		squidguard_sync_on_changes();
-	</custom_delete_php_command>	
 	<custom_php_resync_config_command>
 		squidguard_sync_on_changes();
 	</custom_php_resync_config_command>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1184,7 +1184,7 @@
 		<website>http://www.squidGuard.org/</website>
 		<maintainer>dv_serg@mail.ru</maintainer>
 		<category>Network Management</category>
-		<version>1.9.16</version>
+		<version>1.9.17</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<depends_on_package_pbi>squidguard-1.4_7-##ARCH##.pbi</depends_on_package_pbi>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1252,7 +1252,7 @@
 		<website>http://www.squidGuard.org/</website>
 		<maintainer>dv_serg@mail.ru</maintainer>
 		<category>Network Management</category>
-		<version>1.4_4 pkg v1.9.16</version>
+		<version>1.4_4 pkg v1.9.17</version>
 		<status>Beta</status>
 		<required_version>1.1</required_version>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1239,7 +1239,7 @@
 		<website>http://www.squidGuard.org/</website>
 		<maintainer>dv_serg@mail.ru</maintainer>
 		<category>Network Management</category>
-		<version>1.4_4 pkg v1.9.16</version>
+		<version>1.4_4 pkg v1.9.17</version>
 		<status>Beta</status>
 		<required_version>1.1</required_version>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>


### PR DESCRIPTION
**RAM disks handling**
- force users to disable any ramdisks on full installs (even from a quick look, there are definitely more issues with this than just blacklists DB)
- force users to disable blacklists feature on nanobsd (still a whole lot better than marking the package as noembedded)

This has been broken for years (Bug #4608) and got nowhere.

**XMLRPC sync**
- Fix CARP/HA sync option (port/protocol)
- Honor enable/disable checkboxes
- Fix literal IPv6 handling for sync targets
- Do settings validation and only try to sync when configuration is valid
