### PR TITLE
Squid3 - remove broken dynamic caching refresh_patterns

### DIFF
--- a/config/squid3/34/squid.inc
+++ b/config/squid3/34/squid.inc
@@ -642,6 +642,10 @@ function squid_upgrade_config() {
 		$settingscache['donotcache'] = base64_encode(implode("\n", explode(",", $settingscache['donotcache'])));
 		$config['installedpackages']['squidcache']['config'][0]['donotcache'] = $settingscache['donotcache'];
 	}
+	/* unset broken dynamic caching patterns removed since Squid3 package v0.4.3 */
+	if (!empty($config['installedpackages']['squidcache']['config']['refresh_patterns'])) {
+		unset($config['installedpackages']['squidcache']['config']['refresh_patterns']);
+	}
 
 	/* migrate nac settings */
 	if (!empty($settingsnac['allowed_subnets']) && strstr($settingsnac['allowed_subnets'], ",")) {
@@ -1303,61 +1307,13 @@ function squid_resync_cache() {
 	if (empty($settings['cache_dynamic_content'])) {
 		$conf .= 'acl dynamic urlpath_regex cgi-bin \?' . "\n";
 		$conf .= "cache deny dynamic\n";
-	} elseif (preg_match('/youtube/', $settings['refresh_patterns'])) {
-// Broken (Bug #3847) and not working (http://wiki.squid-cache.org/ConfigExamples/DynamicContent/YouTube#Discussion)
-/*		$conf .= <<< EOC
-# Break HTTP standard for flash videos. Keep them in cache even if asked not to.
-refresh_pattern -i \.flv$ 10080 90% 999999 ignore-no-cache override-expire ignore-private
-
-# Let the clients favorite video site through with full caching
-acl youtube dstdomain .youtube.com
-cache allow youtube
-
-EOC;
-*/
-	}
-	if (preg_match('/windows/', $settings['refresh_patterns'])) {
-		$conf .= <<< EOC
-
-# Windows Update refresh_pattern
-range_offset_limit -1
-refresh_pattern -i microsoft.com/.*\.(cab|exe|ms[i|u|f]|asf|wm[v|a]|dat|zip) 4320 80% 43200 reload-into-ims
-refresh_pattern -i windowsupdate.com/.*\.(cab|exe|ms[i|u|f]|asf|wm[v|a]|dat|zip) 4320 80% 43200 reload-into-ims
-refresh_pattern -i windows.com/.*\.(cab|exe|ms[i|u|f]|asf|wm[v|a]|dat|zip) 4320 80% 43200 reload-into-ims
-
-EOC;
+	} else {
+		if ($settings['custom_refresh_patterns'] != "") {
+			$conf .= sq_text_area_decode($settings['custom_refresh_patterns']) . "\n";
+		}
 	}
 
-	if (preg_match('/symantec/', $settings['refresh_patterns'])) {
-		$conf .= <<< EOC
-
-# Symantec refresh_pattern
-range_offset_limit -1
-refresh_pattern liveupdate.symantecliveupdate.com/.*\.(cab|exe|dll|msi) 10080 100% 43200 reload-into-ims
-refresh_pattern symantecliveupdate.com/.*\.(cab|exe|dll|msi) 10080 100% 43200 reload-into-ims
-
-EOC;
-	}
-	if (preg_match('/avast/', $settings['refresh_patterns'])) {
-		$conf .= <<< EOC
-
-# Avast refresh_pattern
-range_offset_limit -1
-refresh_pattern avast.com/.*\.(vpu|cab|stamp|exe) 10080 100% 43200 reload-into-ims
-
-EOC;
-	}
-	if (preg_match('/avira/', $settings['refresh_patterns'])) {
-		$conf.=<<< EOC
-
-# Avira refresh_pattern
-range_offset_limit -1
-refresh_pattern personal.avira-update.com/.*\.(cab|exe|dll|msi|gz) 10080 100% 43200 reload-into-ims
-
-EOC;
-	}
 	$refresh_conf = <<< EOC
-
 # Add any of your own refresh_pattern entries above these.
 refresh_pattern ^ftp:    1440  20%  10080
 refresh_pattern ^gopher:  1440  0%  1440
@@ -1365,10 +1321,6 @@ refresh_pattern -i (/cgi-bin/|\?) 0  0%  0
 refresh_pattern .    0  20%  4320
 
 EOC;
-
-	if ($settings['custom_refresh_patterns'] != "") {
-		$conf .= sq_text_area_decode($settings['custom_refresh_patterns']) . "\n";
-	}
 
 	$conf .= <<< EOD
 

--- a/config/squid3/34/squid_cache.xml
+++ b/config/squid3/34/squid_cache.xml
@@ -405,7 +405,7 @@
 		if ($cachedir_changed) {
 			// only delete directories under sane paths automatically
 			if (substr($oldcachedir, 0, 11) === "/var/squid/") {
-				log_error("Deleting Squid cache dir '{$oldcachedir}' since 'Hard Disk Cache Location' changed to '{$_POST['harddisk_cache_location']}'.");
+				log_error("[squid] Deleting Squid cache dir '{$oldcachedir}' since 'Hard Disk Cache Location' changed to '{$_POST['harddisk_cache_location']}'.");
 				// cannot nuke disk cache while Squid is running
 				squid_stop_monitor();
 				if (is_service_running('squid')) {
@@ -416,8 +416,8 @@
 				// new cachedir will be created on squid_resync() below which calls squid_dash_z()
 				// also the services will get restarted there
 			} else {
-				log_error("'Hard Disk Cache Location' changed to '{$_POST['harddisk_cache_location']}'.");
-				log_error("Will NOT delete Squid cache dir '{$oldcachedir}' since it is not located under /var/squid. Delete manually if required.");
+				log_error("[squid] 'Hard Disk Cache Location' changed to '{$_POST['harddisk_cache_location']}'.");
+				log_error("[squid] Will NOT delete Squid cache dir '{$oldcachedir}' since it is not located under /var/squid. Delete manually if required.");
 			}
 		}
 		squid_resync();

--- a/config/squid3/34/squid_cache.xml
+++ b/config/squid3/34/squid_cache.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidcache</name>
-	<version>0.4.1</version>
+	<version>0.4.3</version>
 	<title>Proxy Server: Cache Management</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<tabs>
@@ -361,33 +361,14 @@
 			<description>
 				<![CDATA[
 				Select to <a href="http://wiki.squid-cache.org/ConfigExamples/DynamicContent">enable caching of dynamic content.</a><br/>
-				]]>
-			</description>
-			<type>checkbox</type>
-			<size>10</size>
-		</field>
-		<field>
-			<fielddescr>Refresh Patterns</fielddescr>
-			<fieldname>refresh_patterns</fieldname>
-			<description>
-				<![CDATA[
 				With dynamic cache enabled, you can also apply refresh_patterns to sites like <a href="http://wiki.squid-cache.org/SquidFaq/WindowsUpdate">Windows Updates</a><br/><br/>
 				<strong>Notes:</strong><br/>
 				- Squid wiki suggests setting 'Finish transfer if less than x KB remaining' on 'Traffic Mgmt' tab to -1 (but you can apply your own values to control cache).<br/>
 				- Set 'Maximum Download Size' on 'Traffic Mgmt' tab to a value that fits patterns your are applying.
 				]]>
 			</description>
-			<type>select</type>
-			<default_value>none</default_value>
-			<options>
-				<!--<option><name>Youtube</name><value>youtube</value></option>-->
-				<option><name>Windows Update</name><value>windows</value></option>
-				<option><name>Symantec Antivirus</name><value>symantec</value></option>
-				<option><name>Avira</name><value>avira</value></option>
-				<option><name>Avast</name><value>avast</value></option>
-			</options>
-			<multiple/>
-			<size>05</size>
+			<type>checkbox</type>
+			<size>10</size>
 		</field>
 		<field>
 			<fielddescr>Custom refresh_patterns</fielddescr>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1088,7 +1088,7 @@
 			<strong>WARNING! This package bundles ClamAV that conflicts with 'Dansguardian', 'Mailscanner' and 'HAVP antivirus' packages! Installing these will result in a broken state.</strong>
 			]]>
 		</descr>
-		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
+		<pkginfolink>https://forum.pfsense.org/index.php?topic=100167.0</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Services</category>
 		<version>0.4.3</version>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1091,7 +1091,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,48347.0.html</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Services</category>
-		<version>0.4.2</version>
+		<version>0.4.3</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>


### PR DESCRIPTION
Avast/Symantec have been completely no-op and useless for years since AV updates for those are streamed to clients hundreds times every day. Suspect same story for Avira. The WU refresh_patterns was broken and don't work reliably anyway. People can define their own patterns if needed without maintenance burden for package maintainers.