### PR TITLE
Update Suricata GUI package to 2.1.9 and PBI binary to 2.0.9

### DIFF
--- a/config/suricata/suricata.xml
+++ b/config/suricata/suricata.xml
@@ -42,7 +42,7 @@
 	</copyright>
 	<description>Suricata IDS/IPS Package</description>
 	<name>suricata</name>
-	<version>2.0.8 pkg v2.1.6</version>
+	<version>2.1.9</version>
 	<title>Services: Suricata IDS</title>
 	<include_file>/usr/local/pkg/suricata/suricata.inc</include_file>
 	<menu>

--- a/config/suricata/suricata_flow_stream.php
+++ b/config/suricata/suricata_flow_stream.php
@@ -14,7 +14,7 @@
  * All rights reserved.
  *
  * Adapted for Suricata by:
- * Copyright (C) 2014 Bill Meeks
+ * Copyright (C) 2015 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -250,8 +250,11 @@ elseif ($_POST['ResetAll']) {
 	$pconfig['flow_icmp_emerg_new_timeout'] = '10';
 	$pconfig['flow_icmp_emerg_established_timeout'] = '100';
 
-	$pconfig['stream_memcap'] = '33554432';
+	// The default 'stream_memcap' value must be calculated as follows:
+	// 216 * prealloc_sessions * number of threads = memory use in bytes
+	// 64 MB is a decent all-around default, but some setups need more. 
 	$pconfig['stream_prealloc_sessions'] = '32768';
+	$pconfig['stream_memcap'] = '67108864';
 	$pconfig['reassembly_memcap'] = '67108864';
 	$pconfig['reassembly_depth'] = '1048576';
 	$pconfig['reassembly_to_server_chunk'] = '2560';
@@ -298,7 +301,7 @@ elseif ($_POST['save'] || $_POST['apply']) {
 		if ($_POST['flow_icmp_emerg_new_timeout'] != "") { $natent['flow_icmp_emerg_new_timeout'] = $_POST['flow_icmp_emerg_new_timeout']; }else{ $natent['flow_icmp_emerg_new_timeout'] = "10"; }
 		if ($_POST['flow_icmp_emerg_established_timeout'] != "") { $natent['flow_icmp_emerg_established_timeout'] = $_POST['flow_icmp_emerg_established_timeout']; }else{ $natent['flow_icmp_emerg_established_timeout'] = "100"; }
 
-		if ($_POST['stream_memcap'] != "") { $natent['stream_memcap'] = $_POST['stream_memcap']; }else{ $natent['stream_memcap'] = "33554432"; }
+		if ($_POST['stream_memcap'] != "") { $natent['stream_memcap'] = $_POST['stream_memcap']; }else{ $natent['stream_memcap'] = "67108864"; }
 		if ($_POST['stream_prealloc_sessions'] != "") { $natent['stream_prealloc_sessions'] = $_POST['stream_prealloc_sessions']; }else{ $natent['stream_prealloc_sessions'] = "32768"; }
 		if ($_POST['enable_midstream_sessions'] == "on") { $natent['enable_midstream_sessions'] = 'on'; }else{ $natent['enable_midstream_sessions'] = 'off'; }
 		if ($_POST['enable_async_sessions'] == "on") { $natent['enable_async_sessions'] = 'on'; }else{ $natent['enable_async_sessions'] = 'off'; }
@@ -764,8 +767,11 @@ if ($savemsg) {
 			<input name="stream_memcap" type="text" class="formfld unknown" id="stream_memcap" size="9"
 			value="<?=htmlspecialchars($pconfig['stream_memcap']);?>">&nbsp;
 			<?php echo gettext("Max memory to be used by stream engine.  Default is ") . 
-			"<strong>" . gettext("33,554,432") . "</strong>" . gettext(" bytes (32MB)"); ?><br/><br/>
-			<?php echo gettext("Sets the maximum amount of memory, in bytes, to be used by the stream engine."); ?>
+			"<strong>" . gettext("67,108,864") . "</strong>" . gettext(" bytes (64MB)"); ?><br/><br/>
+			<?php echo gettext("Sets the maximum amount of memory, in bytes, to be used by the stream engine.  ");?><br/>
+			<span class="red"><strong><?php echo gettext("Note: ") . "</strong></span>" . 
+			gettext("This number will likely need to be increased beyond the default value in systems with more than 4 processor cores.  " . 
+			"If Suricata fails to start and logs a memory allocation error, increase this value in 4 MB chunks until Suricata starts successfully."); ?>
 		</td>
 	</tr>
 	<tr>

--- a/config/suricata/suricata_generate_yaml.php
+++ b/config/suricata/suricata_generate_yaml.php
@@ -494,7 +494,7 @@ else
 if (!empty($suricatacfg['stream_memcap']))
 	$stream_memcap = $suricatacfg['stream_memcap'];
 else
-	$stream_memcap = "33554432";
+	$stream_memcap = "67108864";
 
 if (!empty($suricatacfg['stream_prealloc_sessions']))
 	$stream_prealloc_sessions = $suricatacfg['stream_prealloc_sessions'];

--- a/config/suricata/suricata_generate_yaml.php
+++ b/config/suricata/suricata_generate_yaml.php
@@ -292,6 +292,7 @@ if (!empty($suricatacfg['max_pcap_log_files']))
 else
 	$pcap_log_max_files = "1000";
 
+// Unified2 Alert Log Settings
 if ($suricatacfg['barnyard_enable'] == 'on')
 	$barnyard2_enabled = "yes";
 else
@@ -306,6 +307,28 @@ if (isset($suricatacfg['barnyard_sensor_id']))
 	$unified2_sensor_id = $suricatacfg['barnyard_sensor_id'];
 else
 	$unified2_sensor_id = "0";
+
+// Unified2 X-Forwarded-For logging options
+if ($suricatacfg['barnyard_xff_logging'] == 'on') {
+	$unified2_xff_output = "xff:";
+	$unified2_xff_output .= "\n        enabled: yes";
+	if (!empty($suricatacfg['barnyard_xff_mode']))
+		$unified2_xff_output .= "\n        mode: {$suricatacfg['barnyard_xff_mode']}";
+	else
+		$unified2_xff_output .= "\n        mode: extra-data";
+	if (!empty($suricatacfg['barnyard_xff_deployment']))
+		$unified2_xff_output .= "\n        deployment: {$suricatacfg['barnyard_xff_deployment']}";
+	else
+		$unified2_xff_output .= "\n        deployment: reverse";
+	if (!empty($suricatacfg['barnyard_xff_header']))
+		$unified2_xff_output .= "\n        header: {$suricatacfg['barnyard_xff_header']}";
+	else
+		$unified2_xff_output .= "\n        header: X-Forwarded-For";
+}
+else {
+	$unified2_xff_output = "xff:";
+	$unified2_xff_output .= "\n        enabled: no";
+}
 
 // EVE JSON log output settings
 if ($suricatacfg['enable_eve_log'] == 'on')

--- a/config/suricata/suricata_global.php
+++ b/config/suricata/suricata_global.php
@@ -308,7 +308,7 @@ if ($input_errors)
 			<td><input name="snort_rules_file" type="text" class="formfld unknown" id="snort_rules_file" size="52" 
 			value="<?=htmlspecialchars($pconfig['snort_rules_file']);?>"/><br/>
 			<?php echo gettext("Enter the rules tarball filename (filename only, do not include the URL.)"); ?>
-			<br/><span class="red"><strong><?php echo gettext("Example: ") . "</strong></span>" . gettext("snortrules-snapshot-2962.tar.gz");?><br/><br/></td>
+			<br/><span class="red"><strong><?php echo gettext("Example: ") . "</strong></span>" . gettext("snortrules-snapshot-2976.tar.gz");?><br/><br/></td>
 		</tr>
 		<tr>
 			<td valign="top" align="right"><span class="vexpl"><strong><?php echo gettext("Oinkmaster Code:"); ?></strong></span>&nbsp;</td>

--- a/config/suricata/suricata_interfaces_edit.php
+++ b/config/suricata/suricata_interfaces_edit.php
@@ -372,7 +372,7 @@ if ($_POST["save"] && !$input_errors) {
 			$natent['flow_icmp_emerg_new_timeout'] = '10';
 			$natent['flow_icmp_emerg_established_timeout'] = '100';
 
-			$natent['stream_memcap'] = '33554432';
+			$natent['stream_memcap'] = '67108864';
 			$natent['stream_prealloc_sessions'] = '32768';
 			$natent['reassembly_memcap'] = '67108864';
 			$natent['reassembly_depth'] = '1048576';

--- a/config/suricata/suricata_migrate_config.php
+++ b/config/suricata/suricata_migrate_config.php
@@ -474,8 +474,8 @@ foreach ($rule as &$r) {
 	/**********************************************************/
 	/* Create interface Unified2 XFF log settings if not set  */
 	/**********************************************************/
-	if (!isset($pconfig['barnyard_log_xff'])) {
-		$pconfig['barnyard_log_xff'] = "off";
+	if (!isset($pconfig['barnyard_xff_logging'])) {
+		$pconfig['barnyard_xff_logging'] = "off";
 		$updated_cfg = true;
 	}
 	if (!isset($pconfig['barnyard_xff_mode'])) {

--- a/config/suricata/suricata_migrate_config.php
+++ b/config/suricata/suricata_migrate_config.php
@@ -471,6 +471,26 @@ foreach ($rule as &$r) {
 		$updated_cfg = true;
 	}
 
+	/**********************************************************/
+	/* Create interface Unified2 XFF log settings if not set  */
+	/**********************************************************/
+	if (!isset($pconfig['barnyard_log_xff'])) {
+		$pconfig['barnyard_log_xff'] = "off";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['barnyard_xff_mode'])) {
+		$pconfig['barnyard_xff_mode'] = "extra-data";
+		$updated_cfg = true;
+	}
+	if (!isset($pconfig['barnyard_xff_deployment'])) {
+		$pconfig['barnyard_xff_deployment'] = "reverse";
+		$updated_cfg = true;
+	}
+	if (empty($pconfig['barnyard_xff_header'])) {
+		$pconfig['barnyard_xff_header'] = "X-Forwarded-For";
+		$updated_cfg = true;
+	}
+
 	// Save the new configuration data into the $config array pointer
 	$r = $pconfig;
 }

--- a/config/suricata/suricata_yaml_template.inc
+++ b/config/suricata/suricata_yaml_template.inc
@@ -54,6 +54,7 @@ outputs:
       filename: unified2.alert
       limit: {$unified2_log_limit}
       sensor-id: {$unified2_sensor_id}
+      {$unified2_xff_output}
 
   - http-log:
       enabled: {$http_log_enabled}

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1707,7 +1707,7 @@
 		<website>http://suricata-ids.org/</website>
 		<descr>High Performance Network IDS, IPS and Security Monitoring engine by OISF.</descr>
 		<category>Security</category>
-		<version>2.1.8</version>
+		<version>2.1.9</version>
 		<status>Stable</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/suricata/suricata.xml</config_file>
@@ -1719,7 +1719,7 @@
 			<ports_after>security/barnyard2</ports_after>
 		</build_pbi>
 		<build_options>barnyard2_UNSET_FORCE=ODBC PGSQL PRELUDE;barnyard2_SET_FORCE=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;suricata_SET_FORCE=IPFW PORTS_PCAP GEOIP JSON NSS LUAJIT HTP_PORT;suricata_UNSET_FORCE=PRELUDE TESTS SC LUA</build_options>
-		<depends_on_package_pbi>suricata-2.0.8_1-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>suricata-2.0.9-##ARCH##.pbi</depends_on_package_pbi>
 	</package>
 	<package>
 		<name>FTP Client Proxy</name>


### PR DESCRIPTION
Suricata 2.0.9 pkg v2.1.9
===================
This updates the Suricata GUI package to v2.1.9 and the binary PBI package to v2.0.9.  The [Change Log for Suricata 2.0.9 is here](http://suricata-ids.org/2015/09/25/suricata-2-0-9-available/).  In addition to the upstream changes, the custom *alert-pf* blocking module sports a new automatic whitelisting feature for all firewall interface IP addresses.  During initialization of the *alert-pf* module, an interface monitoring thread is started to subscribe to and monitor FreeBSD kernel routing messages for changes to interface IP addresses.  An internal in-memory whitelist is maintained of all firewall interface IP addresses to prevent blocking of interface IP addresses.  This feature is particularly helpful to users with frequently changing WAN IP addresses.  Information about auto-whitelisted IP addresses is logged to the *suricata.log* file which can be viewed from the LOGS VIEW tab in the GUI.

The GUI package update includes one bug fix and one new feature as described below.

New Features
------------------
1.  Added *X-Forwarded-For* option settings for Unified2 logging on the BARNYARD tab.  These new settings enable support for *HTTP X-Forwarded-For*  IP addresses.

Bug Fixes
-------------
1.  Increase STREAM MEMORY CAP setting to prevent memory allocation errors during startup.  [See Forum post here](https://forum.pfsense.org/index.php?topic=93926.msg521334#msg521334)
