### PR TITLE
checkmk-agent - fix inetd handling, improve XMLRPC sync, cleanup

### DIFF
--- a/config/checkmk-agent/checkmk.inc
+++ b/config/checkmk-agent/checkmk.inc
@@ -73,6 +73,7 @@ function checkmk_decrapify() {
 	if ($i > 0) {
 		log_error("[check_mk-agent] Inconsistent configuration files; possibly caused by previous check_mk package versions.");
 		log_error("[check_mk-agent] Please, compare those against default distribution files at https://github.com/pfsense/pfsense and fix as required manually.");
+		file_notice("check_mk-agent", "Inconsistent configuration files found, possibly caused by previous check_mk package versions. See Status - System Logs - General for details.", "Packages", "");
 	}
 }
 

--- a/config/checkmk-agent/checkmk.inc
+++ b/config/checkmk-agent/checkmk.inc
@@ -27,10 +27,11 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
+require_once("filter.inc");
+require_once("pfsense-utils.inc");
+require_once("util.inc");
+
 define('ETC_SERVICES', '/etc/services');
-define('ETC_INETD', '/etc/inetd.conf');
-define('ETC_HOSTS_ALLOW', '/etc/hosts.allow');
-define('ETC_RC_CONF', '/etc/rc.conf.local');
 
 function checkmk_install() {
 	/*
@@ -39,24 +40,61 @@ function checkmk_install() {
 	*/
 	$checkmk_bin = "/usr/local/bin/check_mk_agent";
 	$checkmk_url = 'http://git.mathias-kettner.de/git/?p=check_mk.git;a=blob_plain;f=agents/check_mk_agent.freebsd;hb=e13899bde8bdafe13780427811c8153c59be807f';
-	mwexec("fetch -o {$checkmk_bin} \"{$checkmk_url}\"");
+	mwexec("/usr/bin/fetch -o {$checkmk_bin} \"{$checkmk_url}\"");
 	chmod($checkmk_bin, 0755);
 
-	sync_package_checkmk();
+	/* Detect possible junk left over after previous bad package versions */
+	checkmk_decrapify();
+}
+
+function checkmk_deinstall() {
+	/* Remove entry from /etc/services file */
+	checkmk_cleanup_etc_services_file();
+	/* Remove check_mk_agent script fetched via checkmk_install() */
+	unlink_if_exists("/usr/local/bin/check_mk_agent");
+	/* Detect possible junk left over after previous bad package versions */
+	checkmk_decrapify();
+}
+
+function checkmk_decrapify() {
+	$i = 0;
+	if (exec("/usr/bin/wc -l /etc/hosts.allow | /usr/bin/awk '{ print $1 }'") > 5) {
+		log_error("[check_mk-agent] Possibly redundant lines found in /etc/hosts.allow.");
+		$i++;
+	}
+	if (exec("/usr/bin/wc -l /etc/inetd.conf | /usr/bin/awk '{ print $1 }'") > 1) {
+		log_error("[check_mk-agent] Possibly redundant lines found in /etc/inetd.conf.");
+		$i++;
+	}
+	if (file_exists("/etc/rc.conf.local")) {
+		log_error("[check_mk-agent] /etc/rc.conf.local file found; this file does not exist normally on pfSense.");
+		$i++;
+	}
+	if ($i > 0) {
+		log_error("[check_mk-agent] Inconsistent configuration files; possibly caused by previous check_mk package versions.");
+		log_error("[check_mk-agent] Please, compare those against default distribution files at https://github.com/pfsense/pfsense and fix as required manually.");
+	}
 }
 
 function checkmk_text_area_decode($text) {
 	return preg_replace('/\r\n/', "\n", base64_decode($text));
 }
 
+function checkmk_cleanup_etc_services_file() {
+	preg_match_all("/check_mk.*/", file_get_contents(ETC_SERVICES), $matches);
+	foreach ($matches[0] as $match => $value) {
+		if (!empty($value)) {
+			remove_text_from_file(ETC_SERVICES, "{$value}\n");
+		}
+	}
+}
+
 function sync_package_checkmk() {
 	global $config, $g, $mk_config;
-	$update_conf = 0;
 
 	if (!is_array($config['installedpackages']['checkmk']['config'])) {
 		return;
 	}
-
 	$mk_config = $config['installedpackages']['checkmk']['config'][0];
 
 	$checkmk_bin = "/usr/local/bin/check_mk_agent";
@@ -71,193 +109,200 @@ function sync_package_checkmk() {
 
 	conf_mount_rw();
 
-
-	/* Check services file. */
-	$mk_services = file(ETC_SERVICES);
+	/* Check /etc/services file; remove any previous entries first since port could have changed */
+	checkmk_cleanup_etc_services_file();
 	$port = ($mk_config['checkmkport'] ? $mk_config['checkmkport'] : "6556");
-	foreach ($mk_services as $mk_service) {
-		if (!preg_match("/check_mk/", $mk_service)) {
-			$mk_service_file.=chop($mk_service)."\n";
-		}
-	}
-	if ($mk_config['checkmkenable']=="on") {
-		$mk_service_file .= "check_mk	{$port}/tcp   #check_mk agent\n";
-		file_put_contents(ETC_SERVICES, $mk_service_file, LOCK_EX);
-	}
-
-	/* Check inetd file. */
-	$mk_inetds = file(ETC_INETD);
-	foreach ($mk_inetds as $mk_inetd) {
-		if (!preg_match("/check_mk/",$mk_inetd)) {
-			$mk_inetd_file.=chop($mk_inetd)."\n";
-		}
-	}
-	if ($mk_config['checkmkenable']=="on") {
-		$mk_inetd_file .= "check_mk	stream	tcp	nowait		root	/usr/local/bin/check_mk_agent check_mk\n";
-	}
-	file_put_contents(ETC_INETD, $mk_inetd_file, LOCK_EX);
-
-	/* Check hosts.allow file. */
-	$mk_hosts = file(ETC_HOSTS_ALLOW);
-	$inet_daemons_count = 0;
-	foreach ($mk_hosts as $mk_host) {
-		if (!preg_match("/check_mk/",$mk_host)) {
-			$mk_hosts_file .= chop($mk_host) . "\n";
-		}
-		if (preg_match("/^\w+/")) {
-			$inet_daemons_count++;
-		}
-	}
 	if ($mk_config['checkmkenable'] == "on") {
-		foreach (explode(',',$mk_config['checkmkhosts']) as $check_mk_host) {
-			$mk_hosts_file .= "check_mk : {$check_mk_host} : allow\n";
-			$inet_daemons_count++;
-		}
-	}
-	file_put_contents(ETC_HOSTS_ALLOW, $mk_hosts_file, LOCK_EX);
-
-	/* Check inetd daemon rc_conf option. */
-	$mk_rc_confs= file(ETC_RC_CONF);
-	foreach ($mk_rc_confs as $mk_rc_conf) {
-		if (!preg_match("/inetd_/",$mk_rc_conf)) {
-			$mk_rc_conf_file .= chop($mk_rc_conf)."\n";
-		}
-	}
-	if ($mk_config['checkmkenable']=="on") {
-		$mk_rc_conf_file .= 'inetd_enable="YES"' . "\n";
-		$mk_rc_conf_file .= 'inetd_flags="-wW"' . "\n";
-	}
-
-	file_put_contents(ETC_RC_CONF, $mk_rc_conf_file, LOCK_EX);
-	if ($inet_daemons_count > 0) {
-		mwexec("/etc/rc.d/inetd restart");
-	} else {
-		mwexec("/etc/rc.d/inetd stop");
-	}
-
-	/* Write config if any file from filesystem was loaded. */
-	if ($update_conf > 0) {
-		write_config();
+		$mk_service_file = "check_mk	{$port}/tcp   #check_mk agent\n";
+		add_text_to_file(ETC_SERVICES, $mk_service_file);
 	}
 
 	conf_mount_ro();
 
-	checkmk_sync_on_changes();
+	/* Run XMLRPC sync if not booting */
+	if (function_exists("platform_booting")) {
+		if (platform_booting()) {
+			return;
+		}
+	} elseif ($g['booting']) {
+		return;
+	} else {
+		checkmk_sync_on_changes();
+	}
+}
+
+function checkmk_generate_rules($type) {
+	global $config;
+
+	if (is_array($config['installedpackages']['checkmk']['config'])) {
+		$mk_config = $config['installedpackages']['checkmk']['config'][0];
+	} else {
+		$mk_config = array();
+	}
+	$mk_config = $config['installedpackages']['checkmk']['config'][0];
+	if ($mk_config['checkmkenable'] != "on") {
+		return;
+	}
+
+	if ($type != "nat") {
+		return;
+	}
+
+	/* Add checkmk daemon to inetd */
+	$inetd_fd = fopen("/var/etc/inetd.conf", "a+");
+	fwrite($inetd_fd, "check_mk\t\tstream\ttcp\tnowait\t\troot\t/usr/local/bin/check_mk_agent\tcheck_mk \n");
+	fclose($inetd_fd);
+
+	/* Generate NAT rules */
+	if (!empty($mk_config['checkmkifaces'])) {
+		$checkmkifs = explode(",", $mk_config['checkmkifaces']);
+		$checkmkhosts = $mk_config['checkmkhosts'] ?: "any";
+		$checkmkport = $mk_config['checkmkport'] ?: "6556";
+		foreach ($checkmkifs as $checkmkif) {
+			if (empty($checkmkif)) {
+				continue;
+			}
+			$interface = get_real_interface($checkmkif);
+			if (empty($interface)) {
+				continue;
+			}
+			$ip = find_interface_ip($interface);
+			if (!is_ipaddrv4($ip)) {
+				continue;
+			}
+		
+			if (is_subnetv4($checkmkhosts) || is_ipaddr($checkmkhosts) || $checkmkhosts == "any") {
+				$natrules .= "rdr on {$interface} proto tcp from {$checkmkhosts} to {$ip} port {$checkmkport} -> 127.0.0.1 port {$checkmkport}\n";
+			} elseif (is_alias($checkmkhosts)) {
+				$natrules .= "rdr on {$interface} proto tcp from \${$checkmkhosts} to {$ip} port {$checkmkport} -> 127.0.0.1 port {$checkmkport}\n";
+			}
+		}
+	}
+	return $natrules;
 }
 
 function checkmk_validate_input($post, &$input_errors) {
-	foreach ($post as $key => $value) {
-		if (empty($value)) {
-			continue;
-		}
-		if (substr($key, 0, 3) == "port" && !preg_match("/^\d+$/", $value)) {
-				$input_errors[] = "{$value} is no a valid port number";
-		}
-		if (substr($key, 0, 11) == "description" && !preg_match("@^[a-zA-Z0-9 _/.-]+$@", $value)) {
-				$input_errors[] = "Do not use special characters on description";
-		}
-		if (substr($key, 0, 8) == "fullfile" && !preg_match("@^[a-zA-Z0-9_/.-]+$@", $value)) {
-				$input_errors[] = "Do not use special characters on filename";
-		}
-
+	if (!empty($post["checkmkport"]) && !is_port($post["checkmkport"])) {
+		$input_errors[] = "You must specify a valid port in 'Listen Port' field.";
+		
+	}
+	if (empty($post["checkmkifaces"])) {
+		$input_errors[] = "One or more 'Listen Interface(s)' must be selected";
+	}
+	if (!empty($post["checkmkhosts"]) && !(is_alias($post["checkmkhosts"]) || is_subnetv4($post["checkmkhosts"]) || is_ipaddrv4($post["checkmkhosts"]))) {
+		$input_errors[] = "You must specify a valid IP address, subnet or alias in 'Hosts Allowed' field.";
 	}
 }
 
 /* Uses XMLRPC to synchronize the changes to a remote node. */
 function checkmk_sync_on_changes() {
-	global $config, $g;
+	global $config;
+
 	if (is_array($config['installedpackages']['checkmksync']['config'])) {
 		$checkmk_sync = $config['installedpackages']['checkmksync']['config'][0];
 		$synconchanges = $checkmk_sync['synconchanges'];
-		$synctimeout = $checkmk_sync['synctimeout'];
+		$synctimeout = $checkmk_sync['synctimeout'] ?: '250';
 		switch ($synconchanges) {
 			case "manual":
-				if (is_array($checkmk_sync[row])) {
-					$rs = $checkmksync[row];
+				if (is_array($checkmk_sync['row'])) {
+					$rs = $checkmksync['row'];
 				} else {
-					log_error("[check_mk-agent] XMLRPC sync is enabled but there is no hosts to push on squid config.");
+					log_error("[check_mk-agent] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
 					return;
 				}
 				break;
 			case "auto":
-				if (is_array($config['installedpackages']['carpsettings']) && is_array($config['installedpackages']['carpsettings']['config'])) {
-					$system_carp = $config['installedpackages']['carpsettings']['config'][0];
+				if (is_array($config['hasync'])) {
+					$system_carp = $config['hasync'];
 					$rs[0]['ipaddress'] = $system_carp['synchronizetoip'];
 					$rs[0]['username'] = $system_carp['username'];
 					$rs[0]['password'] = $system_carp['password'];
+					$rs[0]['syncdestinenable'] = FALSE;
+
+					// XMLRPC sync is currently only supported over connections using the same protocol and port as this system
+					if ($config['system']['webgui']['protocol'] == "http") {
+						$rs[0]['syncprotocol'] = "http";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '80';
+					} else {
+						$rs[0]['syncprotocol'] = "https";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '443';
+					}
+					if ($system_carp['synchronizetoip'] == "") {
+						log_error("[check_mk-agent] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+						return;
+					} else {
+						$rs[0]['syncdestinenable'] = TRUE;
+					}
 				} else {
-					log_error("[check_mk-agent] XMLRPC sync is enabled but there is no system backup hosts to push squid config.");
+					log_error("[check_mk-agent] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
 					return;
 				}
 				break;
 			default:
 				return;
-			break;
+				break;
 		}
 		if (is_array($rs)) {
 			log_error("[check_mk-agent] XMLRPC sync is starting.");
 			foreach ($rs as $sh) {
-				$sync_to_ip = $sh['ipaddress'];
-				$password = $sh['password'];
-				if ($sh['username']) {
-					$username = $sh['username'];
-				} else {
-					$username = 'admin';
+				// Only sync enabled replication targets
+				if ($sh['syncdestinenable']) {
+					$sync_to_ip = $sh['ipaddress'];
+					$port = $sh['syncport'];
+					$username = $sh['username'] ?: 'admin';
+					$password = $sh['password'];
+					$protocol = $sh['syncprotocol'];
+
+					$error = '';
+					$valid = TRUE;
+
+					if ($password == "") {
+						$error = "Password parameter is empty. ";
+						$valid = FALSE;
+					}
+					if (!is_ipaddr($sync_to_ip) && !is_hostname($sync_to_ip) && !is_domain($sync_to_ip)) {
+						$error .= "Misconfigured Replication Target IP Address or Hostname. ";
+						$valid = FALSE;
+					}
+					if (!is_port($port)) {
+						$error .= "Misconfigured Replication Target Port. ";
+						$valid = FALSE;
+					}
+					if ($valid) {
+						checkmk_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout);
+					} else {
+						log_error("[check_mk-agent] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
+					}
 				}
-				if ($password && $sync_to_ip) {
-					checkmk_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout);
-				}
-			log_error("[check_mk-agent] XMLRPC sync is ending.");
 			}
+			log_error("[check_mk-agent] XMLRPC sync completed.");
 		}
-	}
+ 	}
 }
 
 /* Do the actual XMLRPC sync. */
-function checkmk_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout) {
+function checkmk_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout) {
 	global $config, $g;
 
-	if (!$username) {
+	if ($username == "" || $password == "" || $sync_to_ip == "" || $port == "" || $protocol == "") {
+		log_error("[check_mk-agent] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
 	}
 
-	if (!$password) {
-		return;
+	// Take care of IPv6 literal address
+	if (is_ipaddrv6($sync_to_ip)) {
+		$sync_to_ip = "[{$sync_to_ip}]";
 	}
 
-	if (!$sync_to_ip) {
-		return;
-	}
+	$url = "{$protocol}://{$sync_to_ip}";
 
-	$xmlrpc_sync_neighbor = $sync_to_ip;
-	if($config['system']['webgui']['protocol'] != "") {
-		$synchronizetoip = $config['system']['webgui']['protocol'];
-		$synchronizetoip .= "://";
-	}
-	$port = $config['system']['webgui']['port'];
-	/* If port is empty, let's rely on the protocol selection. */
-	if ($port == "") {
-		if($config['system']['webgui']['protocol'] == "http") {
-			$port = "80";
-		} else {
-			$port = "443";
-		}
-	}
-	$synchronizetoip .= $sync_to_ip;
-
-	/* xml will hold the sections to sync. */
+	/* XML will hold the sections to sync. */
 	$xml = array();
 	$xml['checkmk'] = $config['installedpackages']['checkmk'];
-
 	/* Assemble XMLRPC payload. */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($xml)
-	);
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($xml));
 
-	/* Set a few variables needed for sync code; borrowed from filter.inc. */
-	$url = $synchronizetoip;
-	log_error("[check_mk-agent] Beginning checkmk XMLRPC sync to {$url}:{$port}.");
+	/* Set a few variables needed for sync code */
 	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
@@ -265,17 +310,17 @@ function checkmk_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout) 
 	if ($g['debug']) {
 		$cli->setDebug(1);
 	}
-	/* Send our XMLRPC message and timeout after 250 seconds. */
+	/* Send our XMLRPC message and timeout after defined sync timeout value */
 	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "[check_mk-agent] A communications error occurred while attempting checkmk XMLRPC sync with {$url}:{$port}.";
-		log_error($error);
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port}.";
+		log_error("[check_mk-agent] {$error}");
 		file_notice("sync_settings", $error, "checkmk Settings Sync", "");
 	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, $synctimeout);
-		$error = "[check_mk-agent] An error code was received while attempting checkmk XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("[check_mk-agent] {$error}");
 		file_notice("sync_settings", $error, "checkmk Settings Sync", "");
 	} else {
 		log_error("[check_mk-agent] XMLRPC sync successfully completed with {$url}:{$port}.");
@@ -286,25 +331,21 @@ function checkmk_do_xmlrpc_sync($sync_to_ip, $username, $password,$synctimeout) 
 	$execcmd = "require_once('/usr/local/pkg/checkmk.inc');\n";
 	$execcmd .= "sync_package_checkmk();";
 	/* Assemble XMLRPC payload. */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($execcmd)
-	);
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($execcmd));
 
-	log_error("[check_mk-agent] XMLRPC reload data {$url}:{$port}.");
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
 	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "[check_mk-agent] A communications error occurred while attempting checkmk XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-		log_error($error);
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
+		log_error("[check_mk-agent] {$error}");
 		file_notice("sync_settings", $error, "checkmk Settings Sync", "");
 	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
 		$resp = $cli->send($msg, $synctimeout);
-		$error = "[check_mk-agent] An error code was received while attempting checkmk XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("[check_mk-agent] {$error}");
 		file_notice("sync_settings", $error, "checkmk Settings Sync", "");
 	} else {
 		log_error("[check_mk-agent] XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");

--- a/config/checkmk-agent/checkmk.inc
+++ b/config/checkmk-agent/checkmk.inc
@@ -205,7 +205,7 @@ function checkmk_sync_on_changes() {
 		switch ($synconchanges) {
 			case "manual":
 				if (is_array($checkmk_sync['row'])) {
-					$rs = $checkmksync['row'];
+					$rs = $checkmk_sync['row'];
 				} else {
 					log_error("[check_mk-agent] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
 					return;

--- a/config/checkmk-agent/checkmk.xml
+++ b/config/checkmk-agent/checkmk.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>checkmk</name>
-	<version>0.1.5</version>
+	<version>0.1.6</version>
 	<title>check_mk Agent</title>
 	<include_file>/usr/local/pkg/checkmk.inc</include_file>
 	<additional_files_needed>
@@ -63,22 +63,26 @@
 		<section>Diagnostics</section>
 		<url>/pkg_edit.php?xml=checkmk.xml</url>
 	</menu>
+	<service>
+		<name>check_mk</name>
+		<executable>inetd</executable>
+		<description>check_mk Agent</description>
+	</service>
 	<tabs>
 		<tab>
-			<text>Config</text>
+			<text>Settings</text>
 			<url>/pkg_edit.php?xml=checkmk.xml</url>
 			<active/>
 		</tab>
 		<tab>
-			<text>XMLRPC Sync</text>
+			<text>Sync</text>
 			<url>/pkg_edit.php?xml=checkmk_sync.xml</url>
 		</tab>
 	</tabs>
 	<fields>
 		<field>
 			<type>listtopic</type>
-			<fieldname>temp</fieldname>
-			<name>check_mk Agent Configuration</name>
+			<name>General Settings</name>
 		</field>
 		<field>
 			<fielddescr>Enable check_mk Agent</fielddescr>
@@ -91,19 +95,29 @@
 				For reference, see <a href="https://github.com/sileht/check_mk/tree/master/doc">project documentation at GitHub</a>.
 				]]>
 			</description>
-			<required/>
 		</field>
 		<field>
 			<fielddescr>Listen Port</fielddescr>
 			<fieldname>checkmkport</fieldname>
 			<type>input</type>
 			<size>10</size>
-			<description>Enter port to listen on. Leave empty to use Default port 6556.</description>
+			<default_value>6556</default_value>
+			<description>Enter port to listen on. (Default: 6556)</description>
+			<required/>
 		</field>
 		<field>
-			<fielddescr>Hosts.allow</fielddescr>
+			<fielddescr>Listen Interface(s)</fielddescr>
+			<fieldname>checkmkifaces</fieldname>
+			<type>interfaces_selection</type>
+			<size>5</size>
+			<description>Select interface(s) to listen on.</description>
+			<hideinterfaceregex>loopback</hideinterfaceregex>
+			<required/>
+		</field>
+		<field>
+			<fielddescr>Hosts Allowed</fielddescr>
 			<fieldname>checkmkhosts</fieldname>
-			<description>Enter hosts (comma separated) that can communicate with this agent.</description>
+			<description>Enter an IP address, subnet or alias for host(s) that can communicate with this agent. (Leave empty to allow any host.)</description>
 			<type>input</type>
 			<size>60</size>
 		</field>
@@ -111,13 +125,16 @@
 	<custom_php_install_command>
 		checkmk_install();
 	</custom_php_install_command>
+	<custom_php_deinstall_command>
+		checkmk_deinstall();
+	</custom_php_deinstall_command>
 	<custom_php_validation_command>
 		checkmk_validate_input($_POST, $input_errors);
 	</custom_php_validation_command>
-	<custom_delete_php_command>
-		sync_package_checkmk();
-	</custom_delete_php_command>
 	<custom_php_resync_config_command>
 		sync_package_checkmk();
 	</custom_php_resync_config_command>
+	<filter_rules_needed>
+		checkmk_generate_rules
+	</filter_rules_needed>
 </packagegui>

--- a/config/checkmk-agent/checkmk_sync.xml
+++ b/config/checkmk-agent/checkmk_sync.xml
@@ -42,16 +42,16 @@
 	]]>
 	</copyright>
 	<name>checkmksync</name>
-	<version>0.1.4</version>
+	<version>0.1.6</version>
 	<title>check_mk Agent: Sync</title>
 	<include_file>/usr/local/pkg/checkmk.inc</include_file>
 	<tabs>
 		<tab>
-			<text>Config</text>
+			<text>Settings</text>
 			<url>/pkg_edit.php?xml=checkmk.xml</url>
 		</tab>
 		<tab>
-			<text>XMLRPC Sync</text>
+			<text>Sync</text>
 			<url>/pkg_edit.php?xml=checkmk_sync.xml</url>
 			<active/>
 		</tab>
@@ -59,88 +59,91 @@
 	<fields>
 		<field>
 			<type>listtopic</type>
-			<fieldname>temp</fieldname>
-			<name>Enable check_mk configuration sync</name>
+			<name>XMLRPC Sync</name>
 		</field>
 		<field>
-			<fielddescr>Sync Option</fielddescr>
+			<fielddescr>Enable Sync</fielddescr>
 			<fieldname>synconchanges</fieldname>
-			<description>Automatically sync check_mk configuration changes.</description>
+			<description>
+				<![CDATA[
+				Select a sync method for check_mk agent.<br/><br/>
+				<strong>Important:</strong> While using "Sync to host(s) defined below", only sync from host A to B, A to C but <strong>do not</strong> enable XMLRPC sync <b>to</b> A.
+				This will result in a loop!
+				]]>
+			</description>
 			<type>select</type>
 			<required/>
-			<default_value>auto</default_value>
+			<default_value>disabled</default_value>
 			<options>
-				<option>
-					<name>Sync to configured system backup server</name>
-					<value>auto</value>
-				</option>
-				<option>
-					<name>Sync to host(s) defined below</name>
-					<value>manual</value>
-				</option>
-				<option>
-					<name>Do not sync this package configuration</name>
-					<value>disabled</value>
-				</option>
+				<option><name>Sync to configured system backup server</name><value>auto</value></option>
+				<option><name>Sync to host(s) defined below</name><value>manual</value></option>
+				<option><name>Do not sync this package configuration</name><value>disabled</value></option>
 			</options>
 		</field>
 		<field>
 			<fielddescr>Sync Timeout</fielddescr>
 			<fieldname>synctimeout</fieldname>
-			<description>Select sync max wait time</description>
+			<description>XMLRPC timeout in seconds.</description>
 			<type>select</type>
 			<required/>
 			<default_value>250</default_value>
 			<options>
-				<option>
-					<name>250 seconds (Default)</name>
-					<value>250</value>
-				</option>
-				<option>
-					<name>120 seconds</name>
-					<value>120</value>
-				</option>
-				<option>
-					<name>90 seconds</name>
-					<value>90</value>
-				</option>
-				<option>
-					<name>60 seconds</name>
-					<value>60</value>
-				</option>
-				<option>
-					<name>30 seconds</name>
-					<value>30</value>
-				</option>
+				<option><name>250 seconds (Default)</name><value>250</value></option>
+				<option><name>120 seconds</name><value>120</value></option>
+				<option><name>90 seconds</name><value>90</value></option>
+				<option><name>60 seconds</name><value>60</value></option>
+				<option><name>30 seconds</name><value>30</value></option>
 			</options>
 		</field>
 		<field>
-			<fielddescr>Remote Servers</fielddescr>
+			<fielddescr>Replication Targets</fielddescr>
 			<fieldname>none</fieldname>
 			<type>rowhelper</type>
 			<rowhelper>
 				<rowhelperfield>
-					<fielddescr>IP Address</fielddescr>
+					<fielddescr>Enable</fielddescr>
+					<fieldname>syncdestinenable</fieldname>
+					<description><![CDATA[Enable this host as a replication target]]></description>
+					<type>checkbox</type>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Protocol</fielddescr>
+					<fieldname>syncprotocol</fieldname>
+					<description><![CDATA[Choose the protocol used to sync with the destination host (HTTP or HTTPS).]]></description>
+					<type>select</type>
+					<default_value>HTTP</default_value>
+					<options>
+						<option><name>HTTP</name><value>http</value></option>
+						<option><name>HTTPS</name><value>https</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>IP Address/Hostname</fielddescr>
 					<fieldname>ipaddress</fieldname>
-					<description>IP Address of remote server</description>
+					<description><![CDATA[IP address or hostname of the destination host.]]></description>
 					<type>input</type>
-					<size>20</size>
-					<required/>
+					<size>40</size>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>Username</fielddescr>
+					<fielddescr>Port</fielddescr>
+					<fieldname>syncport</fieldname>
+					<description><![CDATA[Choose the sync port of the destination host.]]></description>
+					<type>input</type>
+					<size>3</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Username (admin)</fielddescr>
 					<fieldname>username</fieldname>
-					<description>Username on remote server</description>
+					<description><![CDATA[Enter the username account for administration.]]></description>
 					<type>input</type>
 					<size>20</size>
 				</rowhelperfield>
 				<rowhelperfield>
-					<fielddescr>Password</fielddescr>
+					<fielddescr>Admin Password</fielddescr>
 					<fieldname>password</fieldname>
-					<description>Password for remote server</description>
+					<description><![CDATA[Password of the user "admin" on the destination host.]]></description>
 					<type>password</type>
 					<size>20</size>
-					<required/>
 				</rowhelperfield>
 			</rowhelper>
 		</field>
@@ -148,7 +151,4 @@
 	<custom_php_resync_config_command>
 		checkmk_sync_on_changes();
 	</custom_php_resync_config_command>
-	<custom_php_command_before_form>
-		unset($_POST['temp']);
-	</custom_php_command_before_form>
 </packagegui>


### PR DESCRIPTION
- Fix inetd handling which was completely broken on pfSense 2.2.x (Bug #4288)
- Detect junk left over by previous versions and log appropriate instructions if needed
- Fix completely broken input validations
- Some other cleanups
- Fix CARP/HA XMLRPC sync option
- Add enable/disable checkbox per XMLRPC replication target
- Add protocol/port selection to XMLRPC
- Fix literal IPv6 handling for XMLRPC sync targets