### PR TITLE
ipguard - add privileges configuration, XMLRPC sync fixes and improvements

### DIFF
--- a/config/ipguard/ipguard.inc
+++ b/config/ipguard/ipguard.inc
@@ -31,7 +31,6 @@ require_once("config.inc");
 require_once("util.inc");
 
 function ipguard_custom_php_deinstall_command() {
-	stop_service('ipguard');
 	unlink_if_exists("/usr/local/etc/rc.d/ipguard.sh");
 	$files = glob("/usr/local/etc/ipguard_*.conf");
 	unlink_if_exists($files);
@@ -50,8 +49,7 @@ function ipguard_custom_php_write_config() {
 	}
 
 	if (is_array($config['installedpackages']['ipguard']['config'])) {
-		// Read config
-		$new_config=array();
+		$new_config = array();
 		foreach ($config['installedpackages']['ipguard']['config'] as $ipguard) {
 			if ($ipguard['enable'] && $ipguard['interface'] && $ipguard['mac'] && $ipguard['ip']) {
 				$new_config[$ipguard['interface']] .= "{$ipguard['mac']} {$ipguard['ip']} {$ipguard['description']}\n";
@@ -59,8 +57,8 @@ function ipguard_custom_php_write_config() {
 		}
 	}
 
-	$start="";
-	$stop="pkill -anx ipguard";
+	$start = "";
+	$stop = "/bin/pkill -anx ipguard";
 	conf_mount_rw();
 	/* Create rc script and restart service if ipguard is enabled */
 	if (count($new_config) > 0 && $ipguard['enable']) {
@@ -81,13 +79,8 @@ function ipguard_custom_php_write_config() {
 				$iface = convert_friendly_interface_to_real_interface_name($key);
 				$start .= "/usr/local/sbin/ipguard -l /var/log/ipguard_{$key}.log -p /var/run/ipguard_{$key}.pid -f {$conf_file} -u 300 -z {$iface}\n\t";
 			}
-			write_rcfile(array(
-					'file' => 'ipguard.sh',
-					'start' => $start,
-					'stop' => $stop
-					));
+			write_rcfile(array('file' => 'ipguard.sh', 'start' => $start, 'stop' => $stop));
 			restart_service('ipguard');
-
 	} else {
 		/* Otherwise, stop the service and remove rc script */
 		stop_service('ipguard');
@@ -96,7 +89,6 @@ function ipguard_custom_php_write_config() {
 	}
 	conf_mount_ro();
 
-	/* Sync config with other pfSense servers */
 	ipguard_sync_on_changes();
 }
 
@@ -104,64 +96,111 @@ function ipguard_custom_php_write_config() {
 function ipguard_sync_on_changes() {
 	global $config, $g;
 
-	if (is_array($config['installedpackages']['ipguardsync'])) {
-		if ($config['installedpackages']['ipguardsync']['config'][0]['synconchanges']) {
+	if (is_array($config['installedpackages']['ipguardsync']['config'])) {
+		$ipguard_sync = $config['installedpackages']['ipguardsync']['config'][0];
+		$synconchanges = $ipguard_sync['synconchanges'];
+		$synctimeout = $ipguard_sync['synctimeout'] ?: '250';
+		switch ($synconchanges) {
+			case "manual":
+				if (is_array($ipguard_sync['row'])) {
+					$rs = $ipguard_sync['row'];
+				} else {
+					log_error("[ipguard] XMLRPC sync is enabled but there are no hosts configured as replication targets.");
+					return;
+				}
+				break;
+			case "auto":
+				if (is_array($config['hasync'])) {
+					$system_carp = $config['hasync'];
+					$rs[0]['ipaddress'] = $system_carp['synchronizetoip'];
+					$rs[0]['username'] = $system_carp['username'];
+					$rs[0]['password'] = $system_carp['password'];
+					$rs[0]['syncdestinenable'] = FALSE;
+
+					// XMLRPC sync is currently only supported over connections using the same protocol and port as this system
+					if ($config['system']['webgui']['protocol'] == "http") {
+						$rs[0]['syncprotocol'] = "http";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '80';
+					} else {
+						$rs[0]['syncprotocol'] = "https";
+						$rs[0]['syncport'] = $config['system']['webgui']['port'] ?: '443';
+					}
+					if ($system_carp['synchronizetoip'] == "") {
+						log_error("[ipguard] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+						return;
+					} else {
+						$rs[0]['syncdestinenable'] = TRUE;
+					}
+				} else {
+					log_error("[ipguard] XMLRPC CARP/HA sync is enabled but there are no system backup hosts configured as replication targets.");
+					return;
+				}
+				break;
+			default:
+				return;
+				break;
+		}
+		if (is_array($rs)) {
 			log_error("[ipguard] XMLRPC sync is starting.");
-			foreach ($config['installedpackages']['ipguardsync']['config'] as $rs ) {
-				foreach ($rs['row'] as $sh) {
+			foreach ($rs as $sh) {
+				// Only sync enabled replication targets
+				if ($sh['syncdestinenable']) {
 					$sync_to_ip = $sh['ipaddress'];
+					$port = $sh['syncport'];
+					$username = $sh['username'] ?: 'admin';
 					$password = $sh['password'];
-					if ($password && $sync_to_ip) {
-						ipguard_do_xmlrpc_sync($sync_to_ip, $password);
+					$protocol = $sh['syncprotocol'];
+
+					$error = '';
+					$valid = TRUE;
+
+					if ($password == "") {
+						$error = "Password parameter is empty. ";
+						$valid = FALSE;
+					}
+					if (!is_ipaddr($sync_to_ip) && !is_hostname($sync_to_ip) && !is_domain($sync_to_ip)) {
+						$error .= "Misconfigured Replication Target IP Address or Hostname. ";
+						$valid = FALSE;
+					}
+					if (!is_port($port)) {
+						$error .= "Misconfigured Replication Target Port. ";
+						$valid = FALSE;
+					}
+					if ($valid) {
+						ipguard_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout);
+					} else {
+						log_error("[ipguard] XMLRPC sync with '{$sync_to_ip}' aborted due to the following error(s): {$error}");
 					}
 				}
 			}
-			log_error("[ipguard] XMLRPC sync is ending.");
+			log_error("[ipguard] XMLRPC sync completed.");
 		}
-	}
+ 	}
 }
 
 /* Do the actual XMLRPC sync */
-function ipguard_do_xmlrpc_sync($sync_to_ip, $password) {
-	global $config, $g;
+function ipguard_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout) {
+	global $config;
 
-	if (!$password) {
+	if ($username == "" || $password == "" || $sync_to_ip == "" || $port == "" || $protocol == "") {
+		log_error("[ipguard] A required XMLRPC sync parameter (username, password, replication target, port or protocol) is empty ... aborting pkg sync");
 		return;
 	}
 
-	if (!$sync_to_ip) {
-		return;
+	// Take care of IPv6 literal address
+	if (is_ipaddrv6($sync_to_ip)) {
+		$sync_to_ip = "[{$sync_to_ip}]";
 	}
 
-	$username = 'admin';
-	$xmlrpc_sync_neighbor = $sync_to_ip;
-	if ($config['system']['webgui']['protocol'] != "") {
-		$synchronizetoip = $config['system']['webgui']['protocol'];
-		$synchronizetoip .= "://";
-	}
-	$port = $config['system']['webgui']['port'];
-	/* If port is empty, let's rely on the protocol selection */
-	if ($port == "") {
-		if ($config['system']['webgui']['protocol'] == "http") {
-			$port = "80";
-		} else {
-			$port = "443";
-		}
-	}
-	$synchronizetoip .= $sync_to_ip;
+	$url = "{$protocol}://{$sync_to_ip}";
 
-	/* xml will hold the sections to sync */
+	/* XML will hold the sections to sync. */
 	$xml = array();
 	$xml['ipguard'] = $config['installedpackages']['ipguard'];
-	/* Assemble XMLRPC payload */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($xml)
-	);
+	/* Assemble XMLRPC payload. */
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($xml));
 
-	/* Set a few variables needed for sync code; borrowed from filter.inc */
-	$url = $synchronizetoip;
-	log_error("Beginning ipguard XMLRPC sync to {$url}:{$port}.");
+	/* Set a few variables needed for sync code */
 	$method = 'pfsense.merge_installedpackages_section_xmlrpc';
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
@@ -169,49 +208,45 @@ function ipguard_do_xmlrpc_sync($sync_to_ip, $password) {
 	if ($g['debug']) {
 		$cli->setDebug(1);
 	}
-	/* send our XMLRPC message and timeout after 250 seconds */
-	$resp = $cli->send($msg, "250");
+	/* Send our XMLRPC message and timeout after defined sync timeout value */
+	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "A communications error occurred while attempting ipguard XMLRPC sync with {$url}:{$port}.";
-		log_error($error);
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port}.";
+		log_error("[ipguard] {$error}");
 		file_notice("sync_settings", $error, "ipguard Settings Sync", "");
 	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
-		$resp = $cli->send($msg, "250");
-		$error = "An error code was received while attempting ipguard XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		$resp = $cli->send($msg, $synctimeout);
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("[ipguard] {$error}");
 		file_notice("sync_settings", $error, "ipguard Settings Sync", "");
 	} else {
-		log_error("ipguard XMLRPC sync successfully completed with {$url}:{$port}.");
+		log_error("[ipguard] XMLRPC sync successfully completed with {$url}:{$port}.");
 	}
 
-	/* tell ipguard to reload our settings on the destination sync host. */
+	/* Tell ipguard to reload our settings on the destination sync host. */
 	$method = 'pfsense.exec_php';
 	$execcmd = "require_once('/usr/local/pkg/ipguard.inc');\n";
 	$execcmd .= "ipguard_custom_php_write_config();";
-	/* assemble xmlrpc payload */
-	$params = array(
-		XML_RPC_encode($password),
-		XML_RPC_encode($execcmd)
-	);
+	/* Assemble XMLRPC payload. */
+	$params = array(XML_RPC_encode($password), XML_RPC_encode($execcmd));
 
-	log_error("ipguard XMLRPC reload data {$url}:{$port}.");
 	$msg = new XML_RPC_Message($method, $params);
 	$cli = new XML_RPC_Client('/xmlrpc.php', $url, $port);
 	$cli->setCredentials($username, $password);
-	$resp = $cli->send($msg, "250");
+	$resp = $cli->send($msg, $synctimeout);
 	if (!$resp) {
-		$error = "A communications error occurred while attempting ipguard XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
-		log_error($error);
+		$error = "A communications error occurred while attempting XMLRPC sync with {$url}:{$port} (pfsense.exec_php).";
+		log_error("[ipguard] {$error}");
 		file_notice("sync_settings", $error, "ipguard Settings Sync", "");
 	} elseif ($resp->faultCode()) {
 		$cli->setDebug(1);
-		$resp = $cli->send($msg, "250");
-		$error = "An error code was received while attempting ipguard XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
-		log_error($error);
+		$resp = $cli->send($msg, $synctimeout);
+		$error = "An error code was received while attempting XMLRPC sync with {$url}:{$port} - Code " . $resp->faultCode() . ": " . $resp->faultString();
+		log_error("[ipguard] {$error}");
 		file_notice("sync_settings", $error, "ipguard Settings Sync", "");
 	} else {
-		log_error("ipguard XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
+		log_error("[ipguard] XMLRPC reload data success with {$url}:{$port} (pfsense.exec_php).");
 	}
 }
 

--- a/config/ipguard/ipguard.priv.inc
+++ b/config/ipguard/ipguard.priv.inc
@@ -1,0 +1,41 @@
+<?php
+/*
+	ipguard.priv.inc
+	part of pfSense (http://www.pfSense.org/)
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+global $priv_list;
+
+$priv_list['page-firewall-ipguard'] = array();
+$priv_list['page-firewall-ipguard']['name'] = "WebCfg - Firewall: IPguard package";
+$priv_list['page-firewall-ipguard']['descr'] = "Allow access to IPguard package GUI";
+
+$priv_list['page-firewall-ipguard']['match'] = array();
+$priv_list['page-firewall-ipguard']['match'][] = "pkg.php?xml=ipguard.xml*";
+$priv_list['page-firewall-ipguard']['match'][] = "pkg.php?xml=ipguard_sync.xml*";
+$priv_list['page-firewall-ipguard']['match'][] = "pkg_edit.php?xml=ipguard.xml*";
+$priv_list['page-firewall-ipguard']['match'][] = "pkg_edit.php?xml=ipguard_sync.xml*";
+
+?>

--- a/config/ipguard/ipguard.xml
+++ b/config/ipguard/ipguard.xml
@@ -42,14 +42,12 @@
 	]]>
 	</copyright>
 	<name>ipguard</name>
-	<version>0.1.1</version>
+	<version>0.1.3</version>
 	<title>Firewall: IPguard</title>
-	<description>IPguard MACs/IP</description>
 	<savetext>Save</savetext>
 	<include_file>/usr/local/pkg/ipguard.inc</include_file>
 	<menu>
 		<name>IPguard</name>
-		<tooltiptext>Tool designed to protect LAN IP address space by ARP spoofing.</tooltiptext>
 		<section>Firewall</section>
 		<url>/pkg.php?xml=ipguard.xml</url>
 	</menu>
@@ -63,6 +61,10 @@
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>
 		<item>https://packages.pfsense.org/packages/config/ipguard/ipguard.inc</item>
+	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/etc/inc/priv/</prefix>
+		<item>https://packages.pfsense.org/packages/config/ipguard/ipguard.priv.inc</item>
 	</additional_files_needed>
 	<additional_files_needed>
 		<prefix>/usr/local/pkg/</prefix>

--- a/config/ipguard/ipguard_sync.xml
+++ b/config/ipguard/ipguard_sync.xml
@@ -42,8 +42,8 @@
 	]]>
 	</copyright>
 	<name>ipguardsync</name>
-	<version>0.1.1</version>
-	<title>IPguard - Sync</title>
+	<version>0.1.3</version>
+	<title>Firewall: IPguard: Sync</title>
 	<include_file>/usr/local/pkg/ipguard.inc</include_file>
 	<tabs>
 		<tab>
@@ -62,30 +62,89 @@
 			<type>listtopic</type>
 		</field>
 		<field>
-			<fielddescr>Automatically sync configuration changes</fielddescr>
+			<fielddescr>Enable Sync</fielddescr>
 			<fieldname>synconchanges</fieldname>
-			<description>Automatically sync changes to the hosts defined below.</description>
-			<type>checkbox</type>
+			<description>
+				<![CDATA[
+				Select a sync method for IPguard.<br/><br/>
+				<strong>Important:</strong> While using "Sync to host(s) defined below", only sync from host A to B, A to C but <strong>do not</strong> enable XMLRPC sync <b>to</b> A.
+				This will result in a loop!
+				]]>
+			</description>
+			<type>select</type>
+			<required/>
+			<default_value>disabled</default_value>
+			<options>
+				<option><name>Sync to configured system backup server</name><value>auto</value></option>
+				<option><name>Sync to host(s) defined below</name><value>manual</value></option>
+				<option><name>Do not sync this package configuration</name><value>disabled</value></option>
+			</options>
 		</field>
 		<field>
-			<fielddescr>Remote Server</fielddescr>
+			<fielddescr>Sync Timeout</fielddescr>
+			<fieldname>synctimeout</fieldname>
+			<description>XMLRPC timeout in seconds.</description>
+			<type>select</type>
+			<required/>
+			<default_value>250</default_value>
+			<options>
+				<option><name>250 seconds (Default)</name><value>250</value></option>
+				<option><name>120 seconds</name><value>120</value></option>
+				<option><name>90 seconds</name><value>90</value></option>
+				<option><name>60 seconds</name><value>60</value></option>
+				<option><name>30 seconds</name><value>30</value></option>
+			</options>
+		</field>
+		<field>
+			<fielddescr>Replication Targets</fielddescr>
 			<fieldname>none</fieldname>
 			<type>rowhelper</type>
 			<rowhelper>
-			<rowhelperfield>
-				<fielddescr>IP Address</fielddescr>
-				<fieldname>ipaddress</fieldname>
-				<description>IP Address of remote server</description>
-				<type>input</type>
-				<size>20</size>
-			</rowhelperfield>
-			<rowhelperfield>
-				<fielddescr>Password</fielddescr>
-				<fieldname>password</fieldname>
-				<description>Password for remote server.</description>
-				<type>password</type>
-				<size>20</size>
-			</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Enable</fielddescr>
+					<fieldname>syncdestinenable</fieldname>
+					<description><![CDATA[Enable this host as a replication target]]></description>
+					<type>checkbox</type>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Protocol</fielddescr>
+					<fieldname>syncprotocol</fieldname>
+					<description><![CDATA[Choose the protocol used to sync with the destination host (HTTP or HTTPS).]]></description>
+					<type>select</type>
+					<default_value>HTTP</default_value>
+					<options>
+						<option><name>HTTP</name><value>http</value></option>
+						<option><name>HTTPS</name><value>https</value></option>
+					</options>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>IP Address/Hostname</fielddescr>
+					<fieldname>ipaddress</fieldname>
+					<description><![CDATA[IP address or hostname of the destination host.]]></description>
+					<type>input</type>
+					<size>40</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Port</fielddescr>
+					<fieldname>syncport</fieldname>
+					<description><![CDATA[Choose the sync port of the destination host.]]></description>
+					<type>input</type>
+					<size>3</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Username (admin)</fielddescr>
+					<fieldname>username</fieldname>
+					<description><![CDATA[Enter the username account for administration.]]></description>
+					<type>input</type>
+					<size>20</size>
+				</rowhelperfield>
+				<rowhelperfield>
+					<fielddescr>Admin Password</fielddescr>
+					<fieldname>password</fieldname>
+					<description><![CDATA[Password of the user "admin" on the destination host.]]></description>
+					<type>password</type>
+					<size>20</size>
+				</rowhelperfield>
 			</rowhelper>
 		</field>
 	</fields>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -662,7 +662,7 @@
 		<config_file>https://packages.pfsense.org/packages/config/ipguard/ipguard.xml</config_file>
 		<pkginfolink>https://forum.pfsense.org/index.php/topic,49917.msg263664.html#msg263664</pkginfolink>
 		<depends_on_package_pbi>ipguard-1.04_2-##ARCH##.pbi</depends_on_package_pbi>
-		<version>0.1.2</version>
+		<version>0.1.3</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<configurationfile>ipguard.xml</configurationfile>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -677,9 +677,9 @@
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
 		<depends_on_package>ipguard-1.04.tbz</depends_on_package>
 		<depends_on_package_pbi>ipguard-1.04-i386.pbi</depends_on_package_pbi>
-		<version>1.0.4 pkg v.0.1.2</version>
+		<version>1.0.4 pkg v0.1.3</version>
 		<status>beta</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<configurationfile>ipguard.xml</configurationfile>
 		<build_port_path>/usr/ports/security/ipguard</build_port_path>
 		<after_install_info>Please visit ipguard settings on the Firewall Menu to configure.</after_install_info>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -664,9 +664,9 @@
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
  		<depends_on_package>ipguard-1.04.tbz</depends_on_package>
 		<depends_on_package_pbi>ipguard-1.04-amd64.pbi</depends_on_package_pbi>
-		<version>1.0.4 pkg v.0.1.2</version>
+		<version>1.0.4 pkg v0.1.3</version>
 		<status>beta</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<configurationfile>ipguard.xml</configurationfile>
 		<build_port_path>/usr/ports/security/ipguard</build_port_path>
 		<after_install_info>Please visit ipguard settings on the Firewall Menu to configure.</after_install_info>


### PR DESCRIPTION
- Add privileges configuration
- Add CARP/HA sync option
- Add enable/disable checkbox per replication target
- Add protocol/port selection
- Add timeout setting
- Fix literal IPv6 handling for sync targets
- Do settings validation and only try to sync when configuration is valid
- Some code style touches while here