### PR TITLE
systempatches - make fetch work if pfsense is behind proxy (fixes bug #4369)

### DIFF
--- a/config/systempatches/patches.inc
+++ b/config/systempatches/patches.inc
@@ -29,6 +29,7 @@
 */
 require_once("globals.inc");
 require_once("util.inc");
+require_once("pfsense-utils.inc");
 
 global $git_root_url, $patch_suffix, $patch_dir, $patch_cmd;
 $git_root_url = "https://github.com/pfsense/pfsense/commit/";
@@ -88,8 +89,20 @@ function patch_test_revert($patch, $fulldetail=false) {
 
 /* Fetch a patch from a URL or github */
 function patch_fetch(& $patch) {
+	global $g;
 	$url = patch_fixup_url($patch['location']);
-	$text = @file_get_contents($url);
+	$temp_filename = tempnam("{$g['tmp_path']}/", "system_patches");
+	/*
+	 * Backwards compatibility with older 2.1.x pfSense versions
+	 * that did not contain download_file() function in pfsense-utils.inc
+	 */
+	if (!function_exists("download_file")) {
+		download_file_with_progress_bar($url, $temp_filename);
+	} else {
+		download_file($url, $temp_filename);
+	}
+	$text = @file_get_contents($temp_filename);
+	unlink($temp_filename);
 	if (empty($text)) {
 		return false;
 	} else {

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1438,7 +1438,7 @@
 		<internal_name>System_Patches</internal_name>
 		<descr>A package to apply and maintain custom system patches.</descr>
 		<maintainer>jimp@pfsense.org</maintainer>
-		<version>1.0.6</version>
+		<version>1.0.7</version>
 		<category>System</category>
 		<status>RELEASE</status>
 		<config_file>https://packages.pfsense.org/packages/config/systempatches/systempatches.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -1543,12 +1543,12 @@
 		<name>System Patches</name>
 		<descr>A package to apply and maintain custom system patches.</descr>
 		<maintainer>jimp@pfsense.org</maintainer>
-		<version>1.0.3</version>
+		<version>1.0.7</version>
 		<category>System</category>
 		<status>RELEASE</status>
 		<config_file>https://packages.pfsense.org/packages/config/systempatches/systempatches.xml</config_file>
 		<pkginfolink></pkginfolink>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<configurationfile>systempatches.xml</configurationfile>
 	</package>
 	<package>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -1530,12 +1530,12 @@
 		<name>System Patches</name>
 		<descr>A package to apply and maintain custom system patches.</descr>
 		<maintainer>jimp@pfsense.org</maintainer>
-		<version>1.0.3</version>
+		<version>1.0.7</version>
 		<category>System</category>
 		<status>RELEASE</status>
 		<config_file>https://packages.pfsense.org/packages/config/systempatches/systempatches.xml</config_file>
 		<pkginfolink></pkginfolink>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<configurationfile>systempatches.xml</configurationfile>
 	</package>
 	<package>


### PR DESCRIPTION
This should work both on 2.2+ using download_file() and on 2.1.x using download_file_with_progress_bar() instead (because the former did not exist in pfsense-utils.inc yet). Seems better to me than copying over the entire function.