### PR TITLE
ntop - package fixes and cleanups

### DIFF
--- a/config/ntop2/ntop.inc
+++ b/config/ntop2/ntop.inc
@@ -1,0 +1,157 @@
+<?php
+/*
+	ntop.inc
+	part of pfSense (http://www.pfSense.org/)
+	Copyright (C) 2011-2013 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+require_once("pkg-utils.inc");
+
+function ntop_php_install_command() {
+	safe_mkdir("/var/db/ntop/rrd/graphics", 0755);
+	mwexec("/bin/chmod -R 0755 /var/db/ntop");
+	mwexec("/usr/sbin/chown -R nobody:nobody /var/db/ntop");
+	mwexec("/bin/cp -Rp /usr/local/lib/X11/fonts/webfonts/ /usr/local/lib/X11/fonts/TTF/");
+	ntop_upgrade_config();
+}
+
+function ntop_php_deinstall_command() {
+	global $config;
+
+	/* Wipe data and settings if the user does not wish to keep them */
+	if (is_array($config['installedpackages']['ntop'])) {
+		$ntop_config = $config['installedpackages']['ntop']['config'][0];
+	} else {
+		$ntop_config = array();
+	}
+	if ($ntop_config['keepdata'] != "on") {
+		if (is_dir("/var/db/ntop/")) {
+			mwexec("rm -rf /var/db/ntop/");
+		}
+		unset($config['installedpackages']['ntop']);
+		write_config("[ntop] Removed package settings on uninstall.");
+		log_error(gettext("[ntop] Removed package data and settings since 'Keep Data/Settings' is disabled."));
+	}
+}
+
+function ntop_upgrade_config() {
+	global $config;
+	/* Fix flipped --no-interface-merge configuration meaning */
+	if (is_array($config['installedpackages']['ntop'])) {
+		if (isset($config['installedpackages']['ntop']['config'][0]['allowmerge'])) {
+			$config['installedpackages']['ntop']['config'][0]['disallowmerge'] = "on";
+			unset($config['installedpackages']['ntop']['config'][0]['allowmerge']);
+		}
+	}
+}
+
+function sync_package_ntop() {
+	global $config, $g;
+
+	if (is_array($config['installedpackages']['ntop'])) {
+		$ntop_config = $config['installedpackages']['ntop']['config'][0];
+	} else {
+		$ntop_config = array();
+	}
+	conf_mount_rw();
+
+	/* Just stop services and unlink rc script if disabled */
+	if ($ntop_config['enable'] != "on") {
+		ntop_stop_service();
+		unlink_if_exists("/usr/local/etc/rc.d/ntop.sh");
+		return;
+	}
+	
+	/* Set up ntop interfaces */
+	$ifaces_final = "";
+	$first = 0;
+	$mergeifs = ($ntop_config['disallowmerge'] == "on") ? "" : "-M";
+
+	foreach ($ntop_config['interface_array'] as $iface) {
+		$if = convert_friendly_interface_to_real_interface_name($iface);
+		if ($if) {
+			if ($first == 1) {
+				$ifaces_final .= ",";
+			}
+			$ifaces_final .= $if;
+			$first = 1;
+		}
+	}
+
+	$start = "/usr/local/bin/ntop -i {$ifaces_final} -u root -d -4 {$mergeifs} -x 8102 -X 8192 &";
+	write_rcfile(array("file" => "ntop.sh", "start" => $start, "stop" => "/usr/bin/killall ntop"));
+
+	/* Set up admin password and (re)start services if not booting */
+	if ((function_exists("platform_booting")) && (!platform_booting())) {
+		ntop_stop_service();
+		ntop_set_password();
+		start_service("ntop");
+	} elseif (!($g['booting'])) {
+		ntop_stop_service();
+		ntop_set_password();
+		start_service("ntop");
+	}
+		
+	conf_mount_ro();
+}
+
+function ntop_stop_service() {
+	if (is_service_running("ntop")) {
+		stop_service("ntop");
+		// Wait for ntop to shut down cleanly.
+		for ($i = 0; $i <= 10; $i++) {
+			if (!is_process_running("ntop")) {
+				break;
+			}
+			sleep(2);
+		}
+	}
+}
+
+function ntop_set_password() {
+	global $config;
+
+	if (is_array($config['installedpackages']['ntop'])) {
+		$ntop_config = $config['installedpackages']['ntop']['config'][0];
+	} else {
+		$ntop_config = array();
+	}
+	$ntop_password = $ntop_config['password'] ?: "admin";
+	unlink_if_exists("/var/db/ntop/ntop_pw.db");
+	mwexec("/usr/local/bin/ntop --set-admin-password={$ntop_password}");
+	sleep(2);
+}
+
+function ntop_validate_input($post, &$input_errors) {
+	if (empty($post['password']) || empty($post['passwordagain'])) {
+		$input_errors[] = "You must provide (and confirm) ntop's password.";
+	}
+	
+	if ($post['password'] != $post['passwordagain']) {
+		$input_errors[] = "The provided passwords did not match.";
+	}
+}
+
+?>

--- a/config/ntop2/ntop.inc
+++ b/config/ntop2/ntop.inc
@@ -87,7 +87,7 @@ function sync_package_ntop() {
 	/* Set up ntop interfaces */
 	$ifaces_final = "";
 	$first = 0;
-	$mergeifs = ($ntop_config['disallowmerge'] == "on") ? "" : "-M";
+	$mergeifs = $ntop_config['disallowmerge'] == "on" ? "-M" : "";
 
 	foreach ($ntop_config['interface_array'] as $iface) {
 		$if = convert_friendly_interface_to_real_interface_name($iface);

--- a/config/ntop2/ntop.priv.inc
+++ b/config/ntop2/ntop.priv.inc
@@ -1,0 +1,37 @@
+<?php
+/*
+	ntop.priv.inc
+	part of pfSense (http://www.pfSense.org/)
+	Copyright (C) 2015 ESF, LLC
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+global $priv_list;
+
+$priv_list['page-diagnostics-ntop'] = array();
+$priv_list['page-diagnostics-ntop']['name'] = "WebCfg - Diagnostics: ntop package";
+$priv_list['page-diagnostics-ntop']['descr'] = "Allow access to ntop package GUI";
+$priv_list['page-diagnostics-ntop']['match'] = array();
+$priv_list['page-diagnostics-ntop']['match'][] = "pkg_edit.php?xml=ntop.xml*";
+
+?>

--- a/config/ntop2/ntop.xml
+++ b/config/ntop2/ntop.xml
@@ -1,28 +1,31 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
-<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
 <packagegui>
 	<copyright>
 	<![CDATA[
 /* $Id$ */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
-	authng.xml
-	part of pfSense (http://www.pfSense.com)
-	Copyright (C) 2008 Scott Ullrich
+	ntop.xml
+	part of pfSense (https://www.pfSense.org/)
+	Copyright (C) 2011-2013 Jim Pingle
+	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 */
-/* ========================================================================== */
+/* ====================================================================================== */
 /*
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:
 
-	 1. Redistributions of source code must retain the above copyright notice,
-		this list of conditions and the following disclaimer.
 
-	 2. Redistributions in binary form must reproduce the above copyright
-		notice, this list of conditions and the following disclaimer in the
-		documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
 
 	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
 	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
@@ -35,19 +38,26 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-/* ========================================================================== */
+/* ====================================================================================== */
 	]]>
 	</copyright>
 	<name>ntop</name>
-	<version>3.0</version>
+	<version>2.3.2</version>
 	<title>Diagnostics: ntop Settings</title>
-	<savetext>Change</savetext>
-	<aftersaveredirect>pkg_edit.php?xml=ntop.xml&amp;id=0</aftersaveredirect>
+	<include_file>/usr/local/pkg/ntop.inc</include_file>
+	<additional_files_needed>
+		<prefix>/usr/local/pkg/</prefix>
+		<item>https://packages.pfsense.org/packages/config/ntop2/ntop.inc</item>
+	</additional_files_needed>
+	<additional_files_needed>
+		<prefix>/etc/inc/priv/</prefix>
+		<item>https://packages.pfsense.org/packages/config/ntop2/ntop.priv.inc</item>
+	</additional_files_needed>
+	<aftersaveredirect>pkg_edit.php?xml=ntop.xml</aftersaveredirect>
 	<menu>
 		<name>ntop Settings</name>
-		<tooltiptext>Set ntop settings such as password and port.</tooltiptext>
 		<section>Diagnostics</section>
-		<url>/pkg_edit.php?xml=ntop.xml&amp;id=0</url>
+		<url>/pkg_edit.php?xml=ntop.xml</url>
 	</menu>
 	<menu>
 		<name>ntop</name>
@@ -60,12 +70,12 @@
 		<name>ntop</name>
 		<rcfile>ntop.sh</rcfile>
 		<executable>ntop</executable>
-		<description>NTOP bandwidth monitoring/graphing</description>
+		<description>NTOP Network Traffic Monitor</description>
 	</service>
 	<tabs>
 		<tab>
-			<text>ntop Settings</text>
-			<url>/pkg_edit.php?xml=ntop.xml&amp;id=0</url>
+			<text>Settings</text>
+			<url>/pkg_edit.php?xml=ntop.xml</url>
 			<active/>
 		</tab>
 		<tab>
@@ -75,15 +85,37 @@
 	</tabs>
 	<fields>
 		<field>
-			<fielddescr>ntop Admin Password</fielddescr>
-			<fieldname>password</fieldname>
-			<description>Enter the password for the NTOP Web GUI.  Minimum 5 characters.</description>
-			<type>password</type>
+			<fielddescr>Enable ntop</fielddescr>
+			<fieldname>enable</fieldname>
+			<description>Check this to enable ntop.</description>
+			<type>checkbox</type>
 		</field>
 		<field>
-			<fielddescr>ntop Admin Password AGAIN</fielddescr>
+			<fielddescr>Keep Data/Settings</fielddescr>
+			<fieldname>keepdata</fieldname>
+			<description>
+				<![CDATA[
+				Check this to keep ntop settings, graphs and traffic data. (Default: on)<br />
+				<strong><span class="errmsg">Note:</span> If 'Keep Data/Settings' is disabled, all settings and data will be wiped on package uninstall/reinstall/upgrade!</strong>
+				]]>
+			</description>
+			<type>checkbox</type>
+			<default_value>on</default_value>
+		</field>
+		<field>
+			<fielddescr>ntop Admin Password</fielddescr>
+			<fieldname>password</fieldname>
+			<description>Enter the password for the NTOP Web GUI. Minimum 5 characters.</description>
+			<type>password</type>
+			<required>true</required>
+			<size>20</size>
+		</field>
+		<field>
+			<fielddescr>Confirm ntop Admin Password</fielddescr>
 			<fieldname>passwordagain</fieldname>
 			<type>password</type>
+			<required>true</required>
+			<size>20</size>
 		</field>
 		<field>
 			<fielddescr>Interface</fielddescr>
@@ -92,82 +124,30 @@
 			<size>3</size>
 			<value>lan</value>
 			<multiple>true</multiple>
+			<hideinterfaceregex>loopback</hideinterfaceregex>
 		</field>
 		<field>
-			<fielddescr>Allow merging interfaces&lt;br&gt;(Def: Do not merge)</fielddescr>
-			<fieldname>allowmerge</fieldname>
+			<fielddescr>Disallow merging interfaces</fielddescr>
+			<fieldname>disallowmerge</fieldname>
+			<description>
+				<![CDATA[
+				By default, traffic information obtained by all the interfaces is merged together as if the traffic was seen by only one interface.<br />
+				Use this option to keep traffic separate by interface. (Default: Disabled)
+				]]>
+			</description>
 			<type>checkbox</type>
 		</field>
 	</fields>
-	<custom_php_global_functions>
-	<![CDATA[
-	function sync_package_ntop() {
-		conf_mount_rw();
-		global $config;
-		global $input_errors;
-		if ($_POST) {
-			$config['installedpackages']['ntop']['config'] = array();
-			$config['installedpackages']['ntop']['config'][0] = $_POST;
-		}
-		$ntop_config =& $config['installedpackages']['ntop']['config'][0];
-		$if_final = "";
-		$ifaces_final = "";
-		system("/bin/mkdir -p /var/db/ntop");
-		system("/bin/mkdir -p /var/db/ntop/rrd");
-		system("/bin/mkdir -p /var/db/ntop/rrd/graphics");
-		system("/bin/chmod -R 755 /var/db/ntop");
-		system("/usr/sbin/chown -R nobody:nobody /var/db/ntop");
-		system("/bin/cp -Rp /usr/local/lib/X11/fonts/webfonts/ /usr/local/lib/X11/fonts/TTF/");
-		$first = 0;
-		$mergeifs = ($ntop_config['allowmerge'] == "on") ? "" : "-M";
-		foreach($ntop_config['interface_array'] as $iface) {
-		$if = convert_friendly_interface_to_real_interface_name($iface);
-		if($if) {
-			if($first == 1)
-			$ifaces_final .= ",";
-			$ifaces_final .= $if;
-			$first = 1;
-		}
-		}
-		$start = "/usr/local/bin/ntop -i {$ifaces_final} -u root -d -4 {$mergeifs} -x 8102 -X 8192 &";
-		write_rcfile(array(
-					"file" => "ntop.sh",
-					"start" => $start,
-					"stop" => "/usr/bin/killall ntop"
-				)
-		);
-		if (is_service_running("ntop")) {
-			stop_service("ntop");
-			// Wait for ntop to shut down cleanly.
-			sleep(20);
-		}
-		if (empty($ntop_config['password']))
-			$ntop_config['password'] = "admin";
-		unlink_if_exists("/var/db/ntop/ntop_pw.db");
-		exec("/usr/local/bin/ntop --set-admin-password={$ntop_config['password']}");
-		sleep(2);
-		start_service("ntop");
-		conf_mount_ro();
-	}
-	]]>
-	</custom_php_global_functions>
-	<custom_add_php_command>
-		sync_package_ntop();
-	</custom_add_php_command>
+	<custom_php_install_command>
+		ntop_php_install_command();
+	</custom_php_install_command>
+	<custom_php_deinstall_command>
+		ntop_php_deinstall_command();
+	</custom_php_deinstall_command>
 	<custom_php_resync_config_command>
 		sync_package_ntop();
 	</custom_php_resync_config_command>
-	<custom_php_install_command>
-		sync_package_ntop();
-	</custom_php_install_command>
 	<custom_php_validation_command>
-	<![CDATA[
-	if ($_POST) {
-		if (empty($_POST['password']) || empty($_POST['passwordagain']))
-			$input_errors[] = "You must provide (and confirm) ntop's password.";
-		if ($_POST['password'] != $_POST['passwordagain'])
-			$input_errors[] = "The provided passwords did not match.";
-	}
-	]]>
+		ntop_validate_input($_POST, $input_errors);
 	</custom_php_validation_command>
 </packagegui>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -290,7 +290,7 @@
 			<port>net/ntop</port>
 		</build_pbi>
 		<build_options>ntop_SET_FORCE=PCAP_PORT XMLDUMP MAKO;ntop_UNSET_FORCE=JUMBO_FRAMES;rrdtool_UNSET_FORCE=DEJAVU PERL_MODULE PYTHON_MODULE RUBY_MODULE;rrdtool_SET_FORCE=JSON MMAP NLS;graphviz_UNSET_FORCE=XPM DIGCOLA IPSEPCOLA PANGOCAIRO;graphviz_SET_FORCE=ICONV NLS;cairo_UNSET_FORCE=X11 XCB;libgd_UNSET_FORCE=FONTCONFIG XPM;libgd_SET_FORCE=ICONV;libpcap_UNSET_FORCE=DAG;libpcap_SET_FORCE=IPV6</build_options>
-		<version>2.3.1</version>
+		<version>2.3.2</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/ntop2/ntop.xml</config_file>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -350,9 +350,9 @@
 			<port>net/ntop</port>
 		</build_pbi>
 		<build_options>WITH_PCAP_PORT=true;WITH_XMLDUMP=true;WITHOUT_JUMBO_FRAMES=true;WITH_MAKO=true;WITHOUT_DEJAVU=true;WITH_JSON=true;WITH_MMAP=true;WITHOUT_PERL_MODULE=true;WITHOUT_PYTHON_MODULE=true;WITHOUT_RUBY_MODULE=true;WITHOUT_EXAMPLES=true;WITHOUT_FPECTL=true;WITH_IPV6=true;WITH_NLS=true;WITHOUT_PTH=true;WITH_PYMALLOC=true;WITHOUT_SEM=true;WITH_THREADS=true;WITHOUT_UCS2=true;WITH_UCS4=true;WITH_FONTCONFIG=true;WITH_ICONV=true;WITHOUT_XPM=true;WITHOUT_DAG=true;WITHOUT_DIGCOLA=true;WITHOUT_IPSEPCOLA=true;WITHOUT_PANGOCAIRO=true;WITHOUT_GTK=true;WITHOUT_XCB=true</build_options>
-		<version>5.0.1 v2.5</version>
+		<version>5.0.1 pkg v2.3.2</version>
 		<status>BETA</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/ntop2/ntop.xml</config_file>
 		<configurationfile>ntop.xml</configurationfile>
 		<noembedded>true</noembedded>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -337,9 +337,9 @@
 			<port>net/ntop</port>
 		</build_pbi>
 		<build_options>WITH_PCAP_PORT=true;WITH_XMLDUMP=true;WITHOUT_JUMBO_FRAMES=true;WITH_MAKO=true;WITHOUT_DEJAVU=true;WITH_JSON=true;WITH_MMAP=true;WITHOUT_PERL_MODULE=true;WITHOUT_PYTHON_MODULE=true;WITHOUT_RUBY_MODULE=true;WITHOUT_EXAMPLES=true;WITHOUT_FPECTL=true;WITH_IPV6=true;WITH_NLS=true;WITHOUT_PTH=true;WITH_PYMALLOC=true;WITHOUT_SEM=true;WITH_THREADS=true;WITHOUT_UCS2=true;WITH_UCS4=true;WITH_FONTCONFIG=true;WITH_ICONV=true;WITHOUT_XPM=true;WITHOUT_DAG=true;WITHOUT_DIGCOLA=true;WITHOUT_IPSEPCOLA=true;WITHOUT_PANGOCAIRO=true;WITHOUT_GTK=true;WITHOUT_XCB=true</build_options>
-		<version>5.0.1 v2.5</version>
+		<version>5.0.1 pkg v2.3.2</version>
 		<status>BETA</status>
-		<required_version>2.0</required_version>
+		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/ntop2/ntop.xml</config_file>
 		<configurationfile>ntop.xml</configurationfile>
 		<noembedded>true</noembedded>


### PR DESCRIPTION
- Split PHP code to a separate inc file
- Make it possible to disable ntop without uninstalling
- Add Keep Data/Settings feature
- Fix flipped 'Allow merging interfaces' meaning
- Add privileges configuration
- Code style cleanups