### PR TITLE
Update Snort binary to v2.9.7.6 and GUI package to v3.2.9

### DIFF
--- a/config/snort/snort.inc
+++ b/config/snort/snort.inc
@@ -2934,6 +2934,7 @@ rc_start() {
 
 	### Remove the lock since we have started all interfaces
 	if [ -f {$g['varrun_path']}/snort_pkg_starting.lck ]; then
+		sleep 2
 		/bin/rm {$g['varrun_path']}/snort_pkg_starting.lck
 	fi
 }
@@ -2954,8 +2955,12 @@ case $1 in
 		rc_stop
 		;;
 	restart)
-		rc_stop
-		rc_start
+		if [ ! -f {$g['varrun_path']}/snort_pkg_starting.lck ]; then
+			rc_stop
+			rc_start
+		else
+			/usr/bin/logger -p daemon.info -i -t SnortRestart "Ignoring RESTART command since Snort is already starting..."
+		fi
 		;;
 esac
 

--- a/config/snort/snort.xml
+++ b/config/snort/snort.xml
@@ -45,7 +45,7 @@
 	</copyright>
 	<description>Snort IDS/IPS Package</description>
 	<name>Snort</name>
-	<version>3.2.8.2</version>
+	<version>3.2.9</version>
 	<title>Services: Snort IDS</title>
 	<include_file>/usr/local/pkg/snort/snort.inc</include_file>
 	<menu>

--- a/config/snort/snort_check_for_rule_updates.php
+++ b/config/snort/snort_check_for_rule_updates.php
@@ -580,6 +580,11 @@ if ($openappid_detectors == 'on') {
 			update_status(gettext("Copying md5 signature to snort directory..."));
 			@copy("{$tmpfname}/{$snort_openappid_filename_md5}", "{$snortdir}/{$snort_openappid_filename_md5}");
 		}
+		if (!is_dir("{$snort_openappid_path}custom")) {
+			safe_mkdir("{$snort_openappid_path}custom");
+			safe_mkdir("{$snort_openappid_path}custom/lua");
+			touch("{$snort_openappid_path}custom/userappid.conf");
+		}
 		update_status(gettext("Extraction of Snort OpenAppID detectors completed..."));
 		$static_output .= gettext(" done.\n");
 		update_output_window($static_output);

--- a/config/snort/snort_check_for_rule_updates.php
+++ b/config/snort/snort_check_for_rule_updates.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2006 Scott Ullrich
  * Copyright (C) 2009 Robert Zelaya
  * Copyright (C) 2011-2012 Ermal Luci
- * Copyright (C) 2013-2014 Bill Meeks
+ * Copyright (C) 2013-2015 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,7 @@ require_once("service-utils.inc");
 require_once("/usr/local/pkg/snort/snort.inc");
 require("/usr/local/pkg/snort/snort_defs.inc");
 
-global $g, $config, $pkg_interface, $snort_gui_include, $rebuild_rules;
+global $g, $config, $pkg_interface, $snort_gui_include, $rebuild_rules, $static_output;
 
 $snortdir = SNORTDIR;
 $snortlibdir = SNORT_PBI_BASEDIR . "lib";
@@ -266,45 +266,56 @@ function snort_check_rule_md5($file_url, $file_dst, $desc = "") {
 	/*           error occurred.                              */
 	/**********************************************************/
 
-	global $pkg_interface, $last_curl_error, $update_errors;
+	global $last_curl_error, $update_errors, $static_output;
 
 	$snortdir = SNORTDIR;
 	$filename_md5 = basename($file_dst);
 
-	if ($pkg_interface <> "console")
-		update_status(gettext("Downloading {$desc} md5 file..."));
+	update_status(gettext("Downloading {$desc} md5 file..."));
+	$static_output .= gettext("Downloading {$desc} md5 file...");
+	update_output_window($static_output);
 	error_log(gettext("\tDownloading {$desc} md5 file {$filename_md5}...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 	$rc = snort_download_file_url($file_url, $file_dst);
 
 	// See if download from URL was successful
 	if ($rc === true) {
-		if ($pkg_interface <> "console")
-			update_status(gettext("Done downloading {$filename_md5}."));
+		update_status(gettext("Done downloading {$filename_md5}."));
+		$static_output .= gettext(" done.\n");
+		update_output_window($static_output);
 		error_log("\tChecking {$desc} md5 file...\n", 3, SNORT_RULES_UPD_LOGFILE);
+		$static_output .= gettext("Checking {$desc} md5 file...");
+		update_output_window($static_output);
 
 		// check md5 hash in new file against current file to see if new download is posted
 		if (file_exists("{$snortdir}/{$filename_md5}")) {
 			$md5_check_new = file_get_contents($file_dst);
 			$md5_check_old = file_get_contents("{$snortdir}/{$filename_md5}");
+			$static_output .= gettext(" done.\n");
+			update_output_window($static_output);
 			if ($md5_check_new == $md5_check_old) {
-				if ($pkg_interface <> "console")
-					update_status(gettext("{$desc} are up to date..."));
+				update_status(gettext("{$desc} are up to date..."));
 				log_error(gettext("[Snort] {$desc} are up to date..."));
 				error_log(gettext("\t{$desc} are up to date.\n"), 3, SNORT_RULES_UPD_LOGFILE);
+				$static_output .= gettext("{$desc} are current. No update required.\n");
+				update_output_window($static_output);
 				return false;
 			}
-			else
+			else {
 				return true;
+			}
 		}
+		$static_output .= gettext(" done.\n");
+		update_output_window($static_output);
 		return true;
 	}
 	else {
 		error_log(gettext("\t{$desc} md5 download failed.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		$snort_err_msg = gettext("Server returned error code {$rc}.");
-		if ($pkg_interface <> "console") {
-			update_status(gettext("{$desc} md5 error ... Server returned error code {$rc} ..."));
-			update_output_window(gettext("{$desc} will not be updated.\n\t{$snort_err_msg}")); 
-		}
+		update_status(gettext("{$desc} md5 error ... Server returned error code {$rc} ..."));
+		$static_output .= gettext(" FAILED!\n");
+		update_output_window($static_output);
+		$static_output .= gettext("{$desc} will not be updated.\n{$snort_err_msg}\n");
+		update_output_window($static_output); 
 		log_error(gettext("[Snort] {$desc} md5 download failed..."));
 		log_error(gettext("[Snort] Server returned error code {$rc}..."));
 		error_log(gettext("\t{$snort_err_msg}\n"), 3, SNORT_RULES_UPD_LOGFILE);
@@ -334,29 +345,31 @@ function snort_fetch_new_rules($file_url, $file_dst, $file_md5, $desc = "") {
 	/*           FALSE if download was not successful.        */
 	/**********************************************************/
 
-	global $pkg_interface, $last_curl_error, $update_errors;
+	global $last_curl_error, $update_errors, $static_output;
 
 	$snortdir = SNORTDIR;
 	$filename = basename($file_dst);
 
-	if ($pkg_interface <> "console")
-		update_status(gettext("There is a new set of {$desc} posted. Downloading..."));
+	update_status(gettext("There is a new set of {$desc} posted. Downloading..."));
 	log_error(gettext("[Snort] There is a new set of {$desc} posted. Downloading {$filename}..."));
 	error_log(gettext("\tThere is a new set of {$desc} posted.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 	error_log(gettext("\tDownloading file '{$filename}'...\n"), 3, SNORT_RULES_UPD_LOGFILE);
+	$static_output .= gettext("There is a new set of {$desc} posted.\nDownloading {$filename}...");
+	update_output_window($static_output); 
        	$rc = snort_download_file_url($file_url, $file_dst);
 
 	// See if the download from the URL was successful
 	if ($rc === true) {
-		if ($pkg_interface <> "console")
-			update_status(gettext("Done downloading {$desc} file."));
+		update_status(gettext("Done downloading {$desc} file."));
 		log_error("[Snort] {$desc} file update downloaded successfully");
 		error_log(gettext("\tDone downloading rules file.\n"),3, SNORT_RULES_UPD_LOGFILE);
+		$static_output .= gettext(" done.\n");
+		update_output_window($static_output);
 	
 		// Test integrity of the rules file.  Turn off update if file has wrong md5 hash
 		if ($file_md5 != trim(md5_file($file_dst))){
-			if ($pkg_interface <> "console")
-				update_output_window(gettext("{$desc} file MD5 checksum failed..."));
+			$static_output .= gettext("{$desc} file MD5 checksum failed...\n");
+			update_output_window($static_output);
 			log_error(gettext("[Snort] {$desc} file download failed.  Bad MD5 checksum..."));
         	        log_error(gettext("[Snort] Downloaded File MD5: " . md5_file($file_dst)));
 			log_error(gettext("[Snort] Expected File MD5: {$file_md5}"));
@@ -370,12 +383,16 @@ function snort_fetch_new_rules($file_url, $file_dst, $file_md5, $desc = "") {
 		return true;
 	}
 	else {
-		if ($pkg_interface <> "console")
-			update_output_window(gettext("{$desc} file download failed..."));
+		$static_output .= gettext(" FAILED!\n");
+		update_output_window($static_output);
+		$static_output .= gettext("{$desc} file download failed... server returned error '{$rc}'.\n");
+		update_output_window($static_output); 
 		log_error(gettext("[Snort] {$desc} file download failed... server returned error '{$rc}'..."));
 		error_log(gettext("\t{$desc} file download failed.  Server returned error {$rc}.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		error_log(gettext("\tThe error text was: {$last_curl_error}\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		error_log(gettext("\t{$desc} will not be updated.\n"), 3, SNORT_RULES_UPD_LOGFILE);
+		$static_output .= gettext("{$desc} will not be updated.\n");
+		update_output_window($static_output);
 		$update_errors = true;
 		return false;
 	}
@@ -462,6 +479,9 @@ if ($emergingthreats == 'on') {
 /* Untar Snort rules file to tmp and install the rules */
 if ($snortdownload == 'on') {
 	if (file_exists("{$tmpfname}/{$snort_filename}")) {
+		$static_output .= gettext("Installing Sourcefire VRT rules...");
+		update_output_window($static_output);
+
 		/* Currently, only FreeBSD-8-1, FreeBSD-9-0 and FreeBSD-10-0 precompiled SO rules exist from Snort.org */
 		/* Default to FreeBSD 8.1, and then test for FreeBSD 9.x  or FreeBSD 10.x */
 		$freebsd_version_so = 'FreeBSD-8-1';
@@ -471,13 +491,11 @@ if ($snortdownload == 'on') {
 			$freebsd_version_so = 'FreeBSD-10-0';
 
 		/* Remove the old Snort rules files */
+		update_status(gettext("Removing old Snort VRT rules..."));
 		$vrt_prefix = VRT_FILE_PREFIX;
 		unlink_if_exists("{$snortdir}/rules/{$vrt_prefix}*.rules");
 
-		if ($pkg_interface <> "console") {
-			update_status(gettext("Extracting Snort VRT rules..."));
-			update_output_window(gettext("Installing Sourcefire VRT rules..."));
-		}
+		update_status(gettext("Extracting new Snort VRT rules..."));
 		error_log(gettext("\tExtracting and installing Snort VRT rules...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		/* extract snort.org rules and add VRT_FILE_PREFIX prefix to all snort.org files */
 		safe_mkdir("{$tmpfname}/snortrules");
@@ -495,8 +513,7 @@ if ($snortdownload == 'on') {
 		}
 		rmdir_recursive("{$tmpfname}/snortrules");
 		/* Extract the Snort preprocessor rules */
-		if ($pkg_interface <> "console")
-			update_output_window(gettext("Extracting preprocessor rules files..."));
+		update_status(gettext("Extracting preprocessor rules files..."));
 		exec("/usr/bin/tar xzf {$tmpfname}/{$snort_filename} -C {$tmpfname} preproc_rules/");
 		$files = glob("{$tmpfname}/preproc_rules/*.rules");
 		foreach ($files as $file) {
@@ -505,10 +522,7 @@ if ($snortdownload == 'on') {
 		}
 		rmdir_recursive("{$tmpfname}/preproc_rules");
 		/* extract so rules */
-		if ($pkg_interface <> "console") {
-			update_status(gettext("Extracting Snort VRT Shared Objects rules..."));
-			update_output_window(gettext("Installing precompiled Shared Objects rules for {$freebsd_version_so}..."));
-		}
+		update_status(gettext("Extracting Snort VRT Shared Objects rules..."));
 		error_log(gettext("\tUsing Snort VRT precompiled SO rules for {$freebsd_version_so} ...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		$snort_arch = php_uname("m");
 		$nosorules = false;
@@ -523,8 +537,7 @@ if ($snortdownload == 'on') {
 		rmdir_recursive("{$tmpfname}/so_rules/");
 		if ($nosorules == false) {
 			/* extract Shared Object stub rules, rename and copy to the rules folder. */
-			if ($pkg_interface <> "console")
-			        update_status(gettext("Copying Snort VRT Shared Objects rules..."));
+		        update_status(gettext("Copying Snort VRT Shared Objects rules..."));
 			exec("/usr/bin/tar xzf {$tmpfname}/{$snort_filename} -C {$tmpfname} --exclude precompiled/ --exclude src/ so_rules/");
 			$files = glob("{$tmpfname}/so_rules/*.rules");
 			foreach ($files as $file) {
@@ -534,10 +547,7 @@ if ($snortdownload == 'on') {
 			rmdir_recursive("{$tmpfname}/so_rules/");
 		}
 		/* extract base etc files */
-		if ($pkg_interface <> "console") {
-		        update_status(gettext("Extracting Snort VRT config and map files..."));
-			update_output_window(gettext("Copying config and map files..."));
-		}
+	        update_status(gettext("Extracting Snort VRT config and map files..."));
 		exec("/usr/bin/tar xzf {$tmpfname}/{$snort_filename} -C {$tmpfname} etc/");
 		foreach (array("classification.config", "reference.config", "gen-msg.map", "unicode.map") as $file) {
 			if (file_exists("{$tmpfname}/etc/{$file}"))
@@ -545,14 +555,12 @@ if ($snortdownload == 'on') {
 		}
 		rmdir_recursive("{$tmpfname}/etc");
 		if (file_exists("{$tmpfname}/{$snort_filename_md5}")) {
-			if ($pkg_interface <> "console")
-				update_status(gettext("Copying md5 signature to snort directory..."));
+			update_status(gettext("Copying md5 signature to snort directory..."));
 			@copy("{$tmpfname}/{$snort_filename_md5}", "{$snortdir}/{$snort_filename_md5}");
 		}
-		if ($pkg_interface <> "console") {
-			update_status(gettext("Extraction of Snort VRT rules completed..."));
-			update_output_window(gettext("Installation of Sourcefire VRT rules completed..."));
-		}
+		update_status(gettext("Extraction of Snort VRT rules completed..."));
+		$static_output .= gettext(" done.\n");
+		update_output_window($static_output);
 		error_log(gettext("\tInstallation of Snort VRT rules completed.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 	}
 }
@@ -561,20 +569,20 @@ if ($snortdownload == 'on') {
 if ($openappid_detectors == 'on') {
 	// If we have a valid downloaded file, then first cleanup the old directory
 	if (file_exists("{$tmpfname}/{$snort_openappid_filename}")) {
+		update_status(gettext("Extracting Snort OpenAppID detectors..."));
+		$static_output .= gettext("Installing Snort OpenAppID detectors...");
 		$snort_openappid_path = SNORT_APPID_ODP_PATH;
 		rmdir_recursive("{$snort_openappid_path}odp");
 		error_log(gettext("\tExtracting and installing Snort OpenAppID detectors...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		safe_mkdir(SNORT_APPID_ODP_PATH);
 		exec("/usr/bin/tar oxzf {$tmpfname}/{$snort_openappid_filename} -C {$snort_openappid_path}");
 		if (file_exists("{$tmpfname}/{$snort_openappid_filename_md5}")) {
-			if ($pkg_interface <> "console")
-				update_status(gettext("Copying md5 signature to snort directory..."));
+			update_status(gettext("Copying md5 signature to snort directory..."));
 			@copy("{$tmpfname}/{$snort_openappid_filename_md5}", "{$snortdir}/{$snort_openappid_filename_md5}");
 		}
-		if ($pkg_interface <> "console") {
-			update_status(gettext("Extraction of Snort OpenAppID detectors completed..."));
-			update_output_window(gettext("Installation of Snort OpenAppID detectors completed..."));
-		}
+		update_status(gettext("Extraction of Snort OpenAppID detectors completed..."));
+		$static_output .= gettext(" done.\n");
+		update_output_window($static_output);
 		unlink_if_exists("{$tmpfname}/{$snort_openappid_filename}");
 		error_log(gettext("\tInstallation of Snort OpenAppID detectors completed.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 	}
@@ -584,10 +592,9 @@ if ($openappid_detectors == 'on') {
 if ($snortcommunityrules == 'on') {
 	safe_mkdir("{$tmpfname}/community");
 	if (file_exists("{$tmpfname}/{$snort_community_rules_filename}")) {
-		if ($pkg_interface <> "console") {
-			update_status(gettext("Extracting Snort GPLv2 Community Rules..."));
-			update_output_window(gettext("Installing Snort GPLv2 Community Rules..."));
-		}
+		update_status(gettext("Extracting Snort GPLv2 Community Rules..."));
+		$static_output .= gettext("Installing Snort GPLv2 Community Rules...\n");
+		update_output_window($static_output);
 		error_log(gettext("\tExtracting and installing Snort GPLv2 Community Rules...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		exec("/usr/bin/tar xzf {$tmpfname}/{$snort_community_rules_filename} -C {$tmpfname}/community/");
 
@@ -603,14 +610,12 @@ if ($snortcommunityrules == 'on') {
 		}
 		/*  Copy snort community md5 sig to snort dir */
 		if (file_exists("{$tmpfname}/{$snort_community_rules_filename_md5}")) {
-			if ($pkg_interface <> "console")
-				update_status(gettext("Copying md5 signature to snort directory..."));
+			update_status(gettext("Copying md5 signature to snort directory..."));
 			@copy("{$tmpfname}/{$snort_community_rules_filename_md5}", "{$snortdir}/{$snort_community_rules_filename_md5}");
 		}
-		if ($pkg_interface <> "console") {
-			update_status(gettext("Extraction of Snort GPLv2 Community Rules completed..."));
-			update_output_window(gettext("Installation of Snort GPLv2 Community Rules file completed..."));
-		}
+		update_status(gettext("Extraction of Snort GPLv2 Community Rules completed..."));
+		$static_output .= gettext(" done.\n");
+		update_output_window($static_output);
 		error_log(gettext("\tInstallation of Snort GPLv2 Community Rules completed.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		rmdir_recursive("{$tmpfname}/community/");
 	}
@@ -620,22 +625,23 @@ if ($snortcommunityrules == 'on') {
 if ($emergingthreats == 'on') {
 	safe_mkdir("{$tmpfname}/emerging");
 	if (file_exists("{$tmpfname}/{$emergingthreats_filename}")) {
-		if ($pkg_interface <> "console") {
-			update_status(gettext("Extracting {$et_name} rules..."));
-			update_output_window(gettext("Installing {$et_name} rules..."));
-		}
+		update_status(gettext("Extracting {$et_name} rules..."));
+		$static_output .= gettext("Installing {$et_name} rules...");
+		update_output_window($static_output);
 		error_log(gettext("\tExtracting and installing {$et_name} rules...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		exec("/usr/bin/tar xzf {$tmpfname}/{$emergingthreats_filename} -C {$tmpfname}/emerging rules/");
 
 		/* Remove the old Emerging Threats rules files */
 		$eto_prefix = ET_OPEN_FILE_PREFIX;
 		$etpro_prefix = ET_PRO_FILE_PREFIX;
+		update_status(gettext("Removing old {$et_name} files..."));
 		unlink_if_exists("{$snortdir}/rules/{$eto_prefix}*.rules");
 		unlink_if_exists("{$snortdir}/rules/{$etpro_prefix}*.rules");
 		unlink_if_exists("{$snortdir}/rules/{$eto_prefix}*ips.txt");
 		unlink_if_exists("{$snortdir}/rules/{$etpro_prefix}*ips.txt");
 
 		$files = glob("{$tmpfname}/emerging/rules/*.rules");
+		update_status(gettext("Copying new {$et_name} files..."));
 		foreach ($files as $file) {
 			$newfile = basename($file);
 			if ($etpro == "on")
@@ -664,14 +670,12 @@ if ($emergingthreats == 'on') {
 
 		/*  Copy emergingthreats md5 sig to snort dir */
 		if (file_exists("{$tmpfname}/{$emergingthreats_filename_md5}")) {
-			if ($pkg_interface <> "console")
-				update_status(gettext("Copying md5 signature to snort directory..."));
+			update_status(gettext("Copying md5 signature to snort directory..."));
 			@copy("{$tmpfname}/{$emergingthreats_filename_md5}", "{$snortdir}/{$emergingthreats_filename_md5}");
 		}
-		if ($pkg_interface <> "console") {
-			update_status(gettext("Extraction of {$et_name} rules completed..."));
-			update_output_window(gettext("Installation of {$et_name} rules completed..."));
-		}
+		update_status(gettext("Extraction of {$et_name} rules completed..."));
+		$static_output .= gettext(" done.\n");
+		update_output_window($static_output);
 		error_log(gettext("\tInstallation of {$et_name} rules completed.\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		rmdir_recursive("{$tmpfname}/emerging/");
 	}
@@ -710,8 +714,7 @@ function snort_apply_customizations($snortcfg, $if_real) {
 
 if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules == 'on') {
 
-	if ($pkg_interface <> "console")
-		update_status(gettext('Copying new config and map files...'));
+	update_status(gettext('Copying new config and map files...'));
 	error_log(gettext("\tCopying new config and map files...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 
 	/******************************************************************/
@@ -757,10 +760,9 @@ if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules =
 		foreach ($config['installedpackages']['snortglobal']['rule'] as $id => $value) {
 			$if_real = get_real_interface($value['interface']);
 			$tmp = "Updating rules configuration for: " . convert_friendly_interface_to_friendly_descr($value['interface']) . " ...";
-			if ($pkg_interface <> "console"){
-				update_status(gettext($tmp));
-				update_output_window(gettext("Please wait while Snort interface files are updated..."));
-			}
+			update_status(gettext($tmp));
+			$static_output .= gettext($tmp . "...");
+			update_output_window($static_output);
 
 			// Make sure the interface subdirectory and required sub-directories exists.
 			// We need to re-create them during a pkg reinstall for the intial rules set
@@ -783,13 +785,14 @@ if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules =
 				$tmp .= convert_friendly_interface_to_friendly_descr($value['interface']) . "...\n";
 			}
 			error_log($tmp, 3, SNORT_RULES_UPD_LOGFILE);
+			$static_output .= gettext(" done.\n");
+			update_output_window($static_output);
 		}
 	}
 	else {
-		if ($pkg_interface <> "console") {
-		        update_output_window(gettext("Warning:  No interfaces configured for Snort were found..."));
-			update_output_window(gettext("No interfaces currently have Snort configured and enabled on them..."));
-		}
+		$static_output .= gettext("Warning:  No interfaces configured for Snort were found...\n");
+		$static_output .= gettext("No interfaces currently have Snort configured and enabled on them.\n");
+	        update_output_window($static_output);
 		error_log(gettext("\tWarning:  No interfaces configured for Snort were found...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 	}
 
@@ -798,23 +801,18 @@ if ($snortdownload == 'on' || $emergingthreats == 'on' || $snortcommunityrules =
 
 	/* Restart snort if running, and not in post-install, so as to pick up the new rules. */
        	if (!$g['snort_postinstall'] && is_service_running("snort") && count($config['installedpackages']['snortglobal']['rule']) > 0) {
-		if ($pkg_interface <> "console") {
-			update_status(gettext('Restarting Snort to activate the new set of rules...'));
-			update_output_window(gettext("Please wait ... restarting Snort will take some time..."));
-		}
+		update_status(gettext('Restarting Snort to activate the new set of rules...'));
+		$static_output .= gettext("Restarting Snort...");
+		update_output_window($static_output);
 		error_log(gettext("\tRestarting Snort to activate the new set of rules...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		touch("{$g['varrun_path']}/snort_pkg_starting.lck");
 		snort_restart_all_interfaces(TRUE);
 		sleep(3);
 		unlink_if_exists("{$g['varrun_path']}/snort_pkg_starting.lck");
-		if ($pkg_interface <> "console")
-		        update_output_window(gettext("Snort has restarted with your new set of rules..."));
+		$static_output .= gettext(" done.\n");
+	        update_output_window($static_output);
        		log_error(gettext("[Snort] Snort has restarted with your new set of rules..."));
 		error_log(gettext("\tSnort has restarted with your new set of rules.\n"), 3, SNORT_RULES_UPD_LOGFILE);
-	}
-	else {
-		if ($pkg_interface <> "console")
-			update_output_window(gettext("The rules update task is complete..."));
 	}
 }
 elseif ($openappid_detectors == 'on') {
@@ -823,33 +821,31 @@ elseif ($openappid_detectors == 'on') {
 	/* Restart snort if running, and not in post-install, so as to pick up the detectors. */
 	/**************************************************************************************/
        	if (!$g['snort_postinstall'] && is_service_running("snort") && count($config['installedpackages']['snortglobal']['rule']) > 0) {
-		if ($pkg_interface <> "console") {
-			update_status(gettext('Restarting Snort to activate the new OpenAppID detectors...'));
-			update_output_window(gettext("Please wait ... restarting Snort will take some time..."));
-		}
+		update_status(gettext('Restarting Snort to activate the new OpenAppID detectors...'));
+		$static_output .= gettext("Restarting Snort...");
+		update_output_window($static_output);
 		error_log(gettext("\tRestarting Snort to activate the new OpenAppID detectors...\n"), 3, SNORT_RULES_UPD_LOGFILE);
 		touch("{$g['varrun_path']}/snort_pkg_starting.lck");
 		snort_restart_all_interfaces(TRUE);
 		sleep(2);
 		unlink_if_exists("{$g['varrun_path']}/snort_pkg_starting.lck");
-		if ($pkg_interface <> "console")
-		        update_output_window(gettext("Snort has restarted with your new set of OpenAppID detectors..."));
+		$static_output .= gettext(" done.\n");
+	        update_output_window($static_output);
        		log_error(gettext("[Snort] Snort has restarted with your new set of OpenAppID detectors..."));
 		error_log(gettext("\tSnort has restarted with your new set of OpenAppID detectors.\n"), 3, SNORT_RULES_UPD_LOGFILE);
-	}
-	else {
-		if ($pkg_interface <> "console")
-			update_output_window(gettext("The rules update task is complete..."));
 	}
 }
 
 /*  remove $tmpfname files */
 if (is_dir("{$tmpfname}")) {
+	$static_output .= gettext("Cleaning up temp dirs and files...");
+        update_output_window($static_output);
 	rmdir_recursive($tmpfname);
+	$static_output .= gettext(" done.\n");
+        update_output_window($static_output);
 }
 
-if ($pkg_interface <> "console")
-	update_status(gettext("The Rules update has finished..."));
+update_status(gettext("The Rules update has finished."));
 log_error(gettext("[Snort] The Rules update has finished."));
 error_log(gettext("The Rules update has finished.  Time: " . date("Y-m-d H:i:s"). "\n\n"), 3, SNORT_RULES_UPD_LOGFILE);
 

--- a/config/snort/snort_conf_template.inc
+++ b/config/snort/snort_conf_template.inc
@@ -48,6 +48,9 @@ config event_queue: max_queue 8 log 5 order_events content_length
 # Configure to show year in timestamps
 config show_year
 
+# Configure IPv6 address logging in unified2 extra data
+config log_ipv6_extra_data
+
 # Configure protocol aware flushing #
 # For more information see README.stream5 #
 {$paf_max_pdu_config}

--- a/config/snort/snort_defs.inc
+++ b/config/snort/snort_defs.inc
@@ -54,7 +54,7 @@ if (!defined("SNORT_BIN_VERSION")) {
 	if (!empty($snortver))
 		define("SNORT_BIN_VERSION", $snortver);
 	else
-		define("SNORT_BIN_VERSION", "2.9.7.5");
+		define("SNORT_BIN_VERSION", "2.9.7.6");
 }
 if (!defined("SNORT_SID_MODS_PATH"))
 	define('SNORT_SID_MODS_PATH', "{$g['vardb_path']}/snort/sidmods/");

--- a/config/snort/snort_frag3_engine.php
+++ b/config/snort/snort_frag3_engine.php
@@ -187,6 +187,9 @@ if ($_POST['save']) {
 		/* Now write the new engine array to conf */
 		write_config("Snort pkg: modified frag3 engine settings.");
 
+		// We have saved a preproc config change, so set "dirty" flag
+		mark_subsystem_dirty('snort_preprocessors');
+
 		header("Location: /snort/snort_preprocessors.php?id={$id}#frag3_row");
 		exit;
 	}

--- a/config/snort/snort_ftp_client_engine.php
+++ b/config/snort/snort_ftp_client_engine.php
@@ -218,6 +218,9 @@ if ($_POST['save']) {
 		/* Now write the new engine array to conf */
 		write_config("Snort pkg: modified ftp_telnet_client engine settings.");
 
+		// We have saved a preproc config change, so set "dirty" flag
+		mark_subsystem_dirty('snort_preprocessors');
+
 		header("Location: /snort/snort_preprocessors.php?id={$id}#ftp_telnet_row_ftp_proto_opts");
 		exit;
 	}

--- a/config/snort/snort_ftp_server_engine.php
+++ b/config/snort/snort_ftp_server_engine.php
@@ -189,6 +189,9 @@ if ($_POST['save']) {
 		/* Now write the new engine array to conf */
 		write_config("Snort pkg: modified ftp_telnet_server engine settings.");
 
+		// We have saved a preproc config change, so set "dirty" flag
+		mark_subsystem_dirty('snort_preprocessors');
+
 		header("Location: /snort/snort_preprocessors.php?id={$id}#ftp_telnet_row_ftp_proto_opts");
 		exit;
 	}

--- a/config/snort/snort_generate_conf.php
+++ b/config/snort/snort_generate_conf.php
@@ -896,6 +896,9 @@ EOD;
 $appid_memcap = $snortcfg['sf_appid_mem_cap'] * 1024 * 1024;
 $appid_params = "app_detector_dir " . rtrim(SNORT_APPID_ODP_PATH, '/') . ", \\\n\tmemcap {$appid_memcap}";
 if ($snortcfg['sf_appid_statslog'] == "on") {
+	if (!file_exists("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/app-stats.log")) {
+		touch("{$snortlogdir}/snort_{$if_real}{$snort_uuid}/app-stats.log");
+	}
 	$appid_params .= ", \\\n\tapp_stats_filename app-stats.log";
 	$appid_params .= ", \\\n\tapp_stats_period {$snortcfg['sf_appid_stats_period']}";
 	$appid_params .= ", \\\n\tapp_stats_rollover_size " . strval($config['installedpackages']['snortglobal']['appid_stats_log_limit_size'] * 1024);
@@ -1271,7 +1274,7 @@ if ($snortcfg['host_attribute_table'] == "on" && !empty($snortcfg['host_attribut
 $http_inspect_global = "preprocessor http_inspect: global ";
 if ($snortcfg['http_inspect'] == "off")
 	$http_inspect_global .= "disabled ";
-$http_inspect_global .= "\\\n\tiis_unicode_map unicode.map 1252 \\\n";
+$http_inspect_global .= "\\\n\tiis_unicode_map {$snortdir}/unicode.map 1252 \\\n";
 $http_inspect_global .= "\tcompress_depth 65535 \\\n";
 $http_inspect_global .= "\tdecompress_depth 65535 \\\n";
 if (!empty($snortcfg['http_inspect_memcap']))

--- a/config/snort/snort_generate_conf.php
+++ b/config/snort/snort_generate_conf.php
@@ -1291,7 +1291,7 @@ $http_inspect_default_engine = array( "name" => "default", "bind_to" => "all", "
 				      "unlimited_decompress" => "on", "inspect_gzip" => "on", "normalize_cookies" =>"on", "normalize_headers" => "on", 
 				      "normalize_utf" => "on", "normalize_javascript" => "on", "allow_proxy_use" => "off", "inspect_uri_only" => "off", 
 				      "max_javascript_whitespaces" => 200, "post_depth" => -1, "max_headers" => 0, "max_spaces" => 0, 
-				      "max_header_length" => 0, "ports" => "default" );
+				      "max_header_length" => 0, "ports" => "default", "decompress_swf" => "off", "decompress_pdf" => "off" );
 $http_ports = str_replace(",", " ", snort_expand_port_range($snort_ports['http_ports']));
 $http_inspect_servers = "";
 
@@ -1385,6 +1385,10 @@ if ($snortcfg['http_inspect'] <> "off") {
 			$http_inspect_servers .= " \\\n\tlog_uri";
 		if ($v['log_hostname'] == "on")
 			$http_inspect_servers .= " \\\n\tlog_hostname";
+		if ($v['decompress_swf'] == "on")
+			$http_inspect_servers .= " \\\n\tdecompress_swf";
+		if ($v['decompress_pdf'] == "on")
+			$http_inspect_servers .= " \\\n\tdecompress_pdf";
 
 		// Add a pair of trailing newlines to terminate this server config
 		$http_inspect_servers .= "\n\n";

--- a/config/snort/snort_httpinspect_engine.php
+++ b/config/snort/snort_httpinspect_engine.php
@@ -304,6 +304,9 @@ if ($_POST['save']) {
 		// Now write the new engine array to conf
 		write_config("Snort pkg: modified http_inspect engine settings.");
 
+		// We have saved a preproc config change, so set "dirty" flag
+		mark_subsystem_dirty('snort_preprocessors');
+
 		header("Location: /snort/snort_preprocessors.php?id={$id}#httpinspect_row");
 		exit;
 	}

--- a/config/snort/snort_httpinspect_engine.php
+++ b/config/snort/snort_httpinspect_engine.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * snort_httpinspect_engine.php
- * Copyright (C) 2013-2014 Bill Meeks
+ * Copyright (C) 2013-2015 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -66,7 +66,7 @@ if (empty($a_nat[$eng_id])) {
 		      "unlimited_decompress" => "on", "inspect_gzip" => "on", "normalize_cookies" =>"on", "normalize_headers" => "on", 
 		      "normalize_utf" => "on", "normalize_javascript" => "on", "allow_proxy_use" => "off", "inspect_uri_only" => "off", 
 		      "max_javascript_whitespaces" => 200, "post_depth" => -1, "max_headers" => 0, "max_spaces" => 0, 
-		      "max_header_length" => 0, "ports" => "default" );
+		      "max_header_length" => 0, "ports" => "default", "decompress_swf" => "off", "decompress_pdf" => "off" );
 	// See if this is initial entry and set to "default" if true
 	if ($eng_id < 1) {
 		$def['name'] = "default";
@@ -124,6 +124,10 @@ else {
 		$pconfig['max_spaces'] = 0;
 	if (empty($pconfig['max_header_length']))
 		$pconfig['max_header_length'] = 0;
+	if (empty($pconfig['decompress_swf']))
+		$pconfig['decompress_swf'] = "off";
+	if (empty($pconfig['decompress_pdf']))
+		$pconfig['decompress_pdf'] = "off";
 }
 
 if ($_POST['Cancel']) {
@@ -259,6 +263,8 @@ if ($_POST['save']) {
 	$engine['normalize_javascript'] = $_POST['httpinspect_normalize_javascript'] ? 'on' : 'off';
 	$engine['allow_proxy_use'] = $_POST['httpinspect_allow_proxy_use'] ? 'on' : 'off';
 	$engine['inspect_uri_only'] = $_POST['httpinspect_inspect_uri_only'] ? 'on' : 'off';
+	$engine['decompress_swf'] = $_POST['httpinspect_decompress_swf'] ? 'on' : 'off';
+	$engine['decompress_pdf'] = $_POST['httpinspect_decompress_pdf'] ? 'on' : 'off';
 
 	// Can only have one "all" Bind_To address
 	if ($engine['bind_to'] == "all" && $engine['name'] <> "default") {
@@ -526,6 +532,24 @@ if ($savemsg)
 			<?php if ($pconfig['unlimited_decompress']=="on") echo "checked";?>>
 			<?php echo gettext("Decompress unlimited gzip data (across multiple packets). Default is ");?> 
 			<strong><?php echo gettext("Checked");?></strong>.</td>
+	</tr>
+	<tr>
+		<td width="22%" valign="top" class="vncell"><?php echo gettext("Decompress SWF");?></td>
+		<td width="78%" class="vtable"><input name="httpinspect_decompress_swf" 
+			type="checkbox" value="on" id="httpinspect_decompress_swf" 
+			<?php if ($pconfig['decompress_swf']=="on") echo "checked";?>>
+			<?php echo gettext("Uncompress and inspect Shockwave Flash data in HTTP response. " .
+				"Default is ");?>
+			<strong><?php echo gettext("Not Checked");?></strong>.</td>
+	</tr>
+	<tr>
+		<td width="22%" valign="top" class="vncell"><?php echo gettext("Decompress PDF");?></td>
+		<td width="78%" class="vtable"><input name="httpinspect_decompress_pdf" 
+			type="checkbox" value="on" id="httpinspect_decompress_pdf" 
+			<?php if ($pconfig['decompress_pdf']=="on") echo "checked";?>>
+			<?php echo gettext("Uncompress and inspect PDF data in HTTP response. " .
+				"Default is ");?>
+			<strong><?php echo gettext("Not Checked");?></strong>.</td>
 	</tr>
 	<tr>
 		<td width="22%" valign="top" class="vncell"><?php echo gettext("Normalize Cookies");?></td>

--- a/config/snort/snort_interfaces_edit.php
+++ b/config/snort/snort_interfaces_edit.php
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2008-2009 Robert Zelaya.
  * Copyright (C) 2011-2012 Ermal Luci
- * Copyright (C) 2014 Bill Meeks
+ * Copyright (C) 2015 Bill Meeks
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -269,7 +269,8 @@ if ($_POST["save"] && !$input_errors) {
 					   "unlimited_decompress" => "on", "inspect_gzip" => "on", "normalize_cookies" =>"on", 
 					   "normalize_headers" => "on", "normalize_utf" => "on", "normalize_javascript" => "on", 
 					   "allow_proxy_use" => "off", "inspect_uri_only" => "off", "max_javascript_whitespaces" => 200,
-					   "post_depth" => -1, "max_headers" => 0, "max_spaces" => 0, "max_header_length" => 0, "ports" => "default" );
+					   "post_depth" => -1, "max_headers" => 0, "max_spaces" => 0, "max_header_length" => 0, "ports" => "default",
+					   "decompress_swf" => "off", "decompress_pdf" => "off" );
 
 			$ftp_client_eng = array( "name" => "default", "bind_to" => "all", "max_resp_len" => 256, 
 						 "telnet_cmds" => "no", "ignore_telnet_erase_cmds" => "yes", 

--- a/config/snort/snort_migrate_config.php
+++ b/config/snort/snort_migrate_config.php
@@ -254,7 +254,8 @@ foreach ($rule as &$r) {
 				"unlimited_decompress" => "on", "inspect_gzip" => "on", "normalize_cookies" =>"on", 
 				"normalize_headers" => "on", "normalize_utf" => "on", "normalize_javascript" => "on", 
 				"allow_proxy_use" => "off", "inspect_uri_only" => "off", "max_javascript_whitespaces" => 200,
-				"post_depth" => -1, "max_headers" => 0, "max_spaces" => 0, "max_header_length" => 0, "ports" => "default" );
+				"post_depth" => -1, "max_headers" => 0, "max_spaces" => 0, "max_header_length" => 0, "ports" => "default",
+				"decompress_swf" => "off", "decompress_pdf" => "off" );
 
 		// Ensure sensible default values exist for global HTTP_INSPECT parameters
 		if (empty($pconfig['http_inspect']))

--- a/config/snort/snort_post_install.php
+++ b/config/snort/snort_post_install.php
@@ -43,7 +43,7 @@ require_once("functions.inc");
 require_once("/usr/local/pkg/snort/snort.inc");
 require("/usr/local/pkg/snort/snort_defs.inc");
 
-global $config, $g, $rebuild_rules, $pkg_interface, $snort_gui_include;
+global $config, $g, $rebuild_rules, $pkg_interface, $snort_gui_include, $static_output;
 
 $snortdir = SNORTDIR;
 $snortlogdir = SNORTLOGDIR;
@@ -180,11 +180,12 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 	/****************************************************************/
 
 	/* Do one-time settings migration for new multi-engine configurations */
-	update_output_window(gettext("Please wait... migrating settings to new configuration..."));
+	$static_output .= gettext("\nMigrating settings to new configuration...");
+	update_output_window($static_output);
 	include('/usr/local/pkg/snort/snort_migrate_config.php');
-	update_output_window(gettext("Please wait... rebuilding installation with saved settings..."));
-	log_error(gettext("[Snort] Downloading and updating configured rule types..."));
-	update_output_window(gettext("Please wait... downloading and updating configured rule sets..."));
+	$static_output .= gettext(" done.\n");
+	update_output_window($static_output);
+	log_error(gettext("[Snort] Downloading and updating configured rule sets..."));
 	if ($pkg_interface <> "console")
 		$snort_gui_include = true;
 	include('/usr/local/pkg/snort/snort_check_for_rule_updates.php');
@@ -198,7 +199,8 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 		$if_real = get_real_interface($snortcfg['interface']);
 		$snort_uuid = $snortcfg['uuid'];
 		$snortcfgdir = "{$snortdir}/snort_{$snort_uuid}_{$if_real}";
-		update_output_window(gettext("Generating configuration for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . "..."));
+		$static_output .= gettext("Generating configuration for " . convert_friendly_interface_to_friendly_descr($snortcfg['interface']) . "...");
+		update_output_window($static_output);
 
 		// Pull in the PHP code that generates the snort.conf file
 		// variables that will be substituted further down below.
@@ -224,10 +226,17 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 		// Create barnyard2.conf file for interface
 		if ($snortcfg['barnyard_enable'] == 'on')
 			snort_generate_barnyard2_conf($snortcfg, $if_real);
+
+		$static_output .= gettext(" done.\n");
+		update_output_window($static_output);
 	}
 
 	/* create snort bootup file snort.sh */
+	$static_output .= gettext("Generating snort.sh script in {$rcdir}...");
+	update_output_window($static_output);
 	snort_create_rc();
+	$static_output .= gettext(" done.\n");
+	update_output_window($static_output);
 
 	/* Set Log Limit, Block Hosts Time and Rules Update Time */
 	snort_snortloglimit_install_cron(true);
@@ -248,12 +257,14 @@ if ($config['installedpackages']['snortglobal']['forcekeepsettings'] == 'on') {
 	if (!($g['booting'])) {
 		if ($pkg_interface <> "console") {
 			update_status(gettext("Starting Snort using rebuilt configuration..."));
+			$static_output .= gettext("Starting Snort as a background task using the rebuilt configuration... ");
 			mwexec_bg("{$rcdir}snort.sh start");
-			update_output_window(gettext("Snort is starting as a background task using the rebuilt configuration..."));
+			update_output_window($static_output);
 		}
 		else
 			mwexec_bg("{$rcdir}snort.sh start");
 	}
+	update_status("");
 }
 
 /* We're finished with conf partition mods, return to read-only */

--- a/config/snort/snort_preprocessors.php
+++ b/config/snort/snort_preprocessors.php
@@ -263,6 +263,9 @@ if ($_GET['act'] == "import" && isset($_GET['varname']) && !empty($_GET['varvalu
 
 	// Now retrieve the "selected alias" returned from SELECT ALIAS page
 	$pconfig[$_GET['varname']] = htmlspecialchars($_GET['varvalue']);
+
+	// We have made a preproc config change, so set "dirty" flag
+	mark_subsystem_dirty('snort_preprocessors');
 }
 
 // Handle deleting of any of the multiple configuration engines
@@ -397,7 +400,7 @@ if ($_POST['ResetAll']) {
 	$savemsg = gettext("All preprocessor settings have been reset to their defaults.");
 }
 
-if ($_POST['save']) {
+if ($_POST['save'] || $_POST['apply']) {
 	$natent = array();
 	$natent = $pconfig;
 
@@ -590,6 +593,9 @@ if ($_POST['save']) {
 		/* Sync to configured CARP slaves if any are enabled */
 		snort_sync_on_changes();
 
+		// We have saved changes, so clear "dirty" flag
+		clear_subsystem_dirty('snort_preprocessors');
+
 		/* after click go to this page */
 		header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
@@ -619,6 +625,10 @@ if ($_POST['btn_import']) {
 				$a_nat[$id]['max_attribute_services_per_host'] = $pconfig['max_attribute_services_per_host'];
 				write_config("Snort pkg: imported Host Attribute Table data for {$a_nat[$id]['interface']}.");
 			}
+
+			// We have made a preproc config change, so set "dirty" flag
+			mark_subsystem_dirty('snort_preprocessors');
+
 			header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -675,6 +685,11 @@ if ($savemsg) {
 <form action="snort_preprocessors.php" method="post" enctype="multipart/form-data" name="iform" id="iform">
 <input name="id" type="hidden" value="<?=$id;?>"/>
 <input name="eng_id" id="eng_id" type="hidden" value=""/>
+
+<?php if (is_subsystem_dirty('snort_preprocessors')): ?><p>
+<?php print_info_box_np(gettext("A change has been made to the preprocessors configuration.") . "<br/>" . gettext("Click SAVE when finished to apply the change to the Snort configuration."));?>
+<?php endif; ?>
+
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <tr><td>
 <?php

--- a/config/snort/snort_stream5_engine.php
+++ b/config/snort/snort_stream5_engine.php
@@ -330,6 +330,9 @@ if ($_POST['save']) {
 		/* Now write the new engine array to conf */
 		write_config("Snort pkg: save modified stream5 engine.");
 
+		// We have saved a preproc config change, so set "dirty" flag
+		mark_subsystem_dirty('snort_preprocessors');
+
 		header("Location: /snort/snort_preprocessors.php?id={$id}#stream5_row");
 		exit;
 	}

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -403,14 +403,14 @@
 		<category>Security</category>
 		<run_depends>bin/snort:security/snort</run_depends>
 		<port_category>security</port_category>
-		<depends_on_package_pbi>snort-2.9.7.5-##ARCH##.pbi</depends_on_package_pbi>
+		<depends_on_package_pbi>snort-2.9.7.6-##ARCH##.pbi</depends_on_package_pbi>
 		<build_pbi>
 			<port>security/snort</port>
 			<ports_after>security/barnyard2</ports_after>
 		</build_pbi>
-		<build_options>barnyard2_UNSET_FORCE=ODBC PGSQL PRELUDE;barnyard2_SET_FORCE=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;snort_SET_FORCE=BARNYARD PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;snort_UNSET_FORCE=PULLEDPORK FILEINSPECT HA</build_options>
+		<build_options>security_barnyard2_UNSET_FORCE=ODBC PGSQL PRELUDE;security_barnyard2_SET_FORCE=GRE IPV6 MPLS MYSQL PORT_PCAP BRO;security_snort_SET_FORCE=BARNYARD PERFPROFILE SOURCEFIRE GRE IPV6 NORMALIZER APPID;security_snort_UNSET_FORCE=PULLEDPORK FILEINSPECT HA</build_options>
 		<config_file>https://packages.pfsense.org/packages/config/snort/snort.xml</config_file>
-		<version>3.2.8.3</version>
+		<version>3.2.9</version>
 		<required_version>2.2</required_version>
 		<status>RELEASE</status>
 		<configurationfile>/snort.xml</configurationfile>


### PR DESCRIPTION
Snort 2.9.7.6 pkg v3.2.9
==================
This updates the Snort binary to v2.9.7.6 and the pfSense GUI package to v3.2.9.  This update adds support for two new HTTP_INSPECT options and enables logging of IPv6 address in Unified2 logs as extra-data.  There are four minor bug fixes included with this update.

New Features
------------------
1.  Added support for the *decompress_swf* and *decompress_pdf* options for the HTTP_INSPECT preprocessor.  These options decompress Shockwave Flash and Adobe PDF files so they can be further inspected.  The new settings are available on the HTTP_INSPECT Engines dialog on the PREPROCESSORS tab.

2.  IPv6 addresses are now logged as extra-data when Unified2 log output is enabled with Barnyard2.

Bug Fixes
-------------
1.  Tidy up output messages displayed during package installation and during rule updates.

2.  Add two missing OpenAppID folders and a default file to prevent warning messages when starting up with OpenAppID enabled.

3.  When editing HTTP_INSPECT, FRAG3, STREAM5, FTP_SERVER or FTP_CLIENT engines on the PREPROCESSORS tab, there is no prompt to apply the change on the PREPROCESSOR tab to the running configuration when returning from the engine dialog page.

4.  Add code to prevent the rc.d shell script for Snort from processing a RESTART command while a package START command is still in progress.
