### PR TITLE
pfBlockerNG - Improve download failure function

### DIFF
--- a/config/pfblockerng/pfblockerng.inc
+++ b/config/pfblockerng/pfblockerng.inc
@@ -1315,14 +1315,21 @@ function pfb_download_failure($alias, $header, $pfbfolder, $vtype, $list_url) {
 		$log = "   Local File Failure\n";
 		pfb_logger("{$log}", 2);
 	} else {
-		// Determine if Firewall/IDS is blocking download.
-		$ip = @gethostbyname($host);
+		// Determine if Firewall/IDS/DNSBL is blocking download.
+		$ip = @gethostbyname($host['host']);
 
 		if (!empty($ip)) {
 			// Query Firewall aliastables
 			$result = find_reported_header($ip, "{$pfbfolder}/*", TRUE);
 			if (!empty($result)) {
 				$log = " [ {$ip} ] Firewall IP block found in: [ {$result} ]\n";
+				pfb_logger("{$log}", 2);
+				$pfbfound = TRUE;
+			}
+
+			// Determine if Host is listed in DNSBL
+			if ($ip == $pfb['dnsbl_vip']) {
+				$log = " [ {$host['host']} ] Domain listed in DNSBL\n";
 				pfb_logger("{$log}", 2);
 				$pfbfound = TRUE;
 			}

--- a/config/pfblockerng/pfblockerng.inc
+++ b/config/pfblockerng/pfblockerng.inc
@@ -1315,7 +1315,7 @@ function pfb_download_failure($alias, $header, $pfbfolder, $vtype, $list_url) {
 		$log = "   Local File Failure\n";
 		pfb_logger("{$log}", 2);
 	} else {
-		// Determine if Firewall/IDS/DNSBL is blocking download.
+		// Determine if Firewall/IPS/DNSBL is blocking download.
 		$ip = @gethostbyname($host['host']);
 
 		if (!empty($ip)) {

--- a/config/pfblockerng/pfblockerng.inc
+++ b/config/pfblockerng/pfblockerng.inc
@@ -2360,7 +2360,7 @@ function sync_package_pfblockerng($cron='') {
 					}
 
 					if (!empty($list['custom'])) {
-						$list['row'][] = array( 'header'	=> "{$list['aliasname']}_custom",
+						$list['row'][] = array( 'header'	=> preg_replace("/\W/", '', $list['aliasname']) . '_custom',
 									'custom'	=> $list['custom'],
 									'state'		=> 'Enabled',
 									'update'	=> $list['custom_update'],
@@ -2433,9 +2433,9 @@ function sync_package_pfblockerng($cron='') {
 
 							if (file_exists("{$pfbfolder}/{$header}.txt") && $pfbreuse == '') {
 								if ($row['state'] == 'Hold') {
-									$log = "\n[ {$header} ]{$logtab} Static Hold [ NOW ]";
+									$log = "\n[ {$header} ]{$logtab} static hold. [ NOW ]";
 								} else {
-									$log = "\n[ {$header} ]{$logtab} exists, Reloading [ NOW ]";
+									$log = "\n[ {$header} ]{$logtab} exists. [ NOW ]";
 								}
 								pfb_logger("{$log}", 1);
 
@@ -3135,7 +3135,7 @@ function sync_package_pfblockerng($cron='') {
 						if ($continent === $continent_ex && !empty($pfctlck) &&
 						    file_exists("{$pfbfolder}/{$ccfile}.txt") && $pfb['reuse'] == '') {
 							if (!$pfb['save']) {
-								$log = "\n[ {$pfb_alias}{$vtype} ]{$logtab} exists, Reloading [ NOW ]";
+								$log = "\n[ {$pfb_alias}{$vtype} ]{$logtab} exists. [ NOW ]";
 								pfb_logger("{$log}", 1);
 							}
 						} else {
@@ -3252,7 +3252,7 @@ function sync_package_pfblockerng($cron='') {
 					}
 
 					if (!empty($list['custom'])) {
-						$list['row'][] = array(	'header'	=> "{$list['aliasname']}_custom",
+						$list['row'][] = array(	'header'	=> preg_replace("/\W/", '', $list['aliasname']) . '_custom',
 									'custom'	=> $list['custom'],
 									'state'		=> 'Enabled',
 									'update'	=> $list['custom_update'],
@@ -3307,9 +3307,9 @@ function sync_package_pfblockerng($cron='') {
 
 						if (file_exists("{$pfbfolder}/{$header}.txt") && $pfbreuse == '') {
 							if ($row['state'] == 'Hold') {
-								$log = "\n[ {$header} ]{$logtab} Static Hold [ NOW ]";
+								$log = "\n[ {$header} ]{$logtab} static hold. [ NOW ]";
 							} else {
-								$log = "\n[ {$header} ]{$logtab} exists, Reloading [ NOW ]";
+								$log = "\n[ {$header} ]{$logtab} exists. [ NOW ]";
 							}
 							pfb_logger("{$log}", 1);
 						} else {

--- a/config/pfblockerng/pfblockerng.php
+++ b/config/pfblockerng/pfblockerng.php
@@ -55,30 +55,30 @@ $pfb['extras'][0]['file_dwn']	= 'GeoIP.dat.gz';
 $pfb['extras'][0]['file']	= 'GeoIP.dat';
 $pfb['extras'][0]['folder']	= "{$pfb['geoipshare']}";
 
-$pfb['extras'][1]['url']	= "http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz";
+$pfb['extras'][1]['url']	= 'http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz';
 $pfb['extras'][1]['file_dwn']	= 'GeoIPv6.dat.gz';
 $pfb['extras'][1]['file']	= 'GeoIPv6.dat';
 $pfb['extras'][1]['folder']	= "{$pfb['geoipshare']}";
 
-$pfb['extras'][2]['url']	= "http://geolite.maxmind.com/download/geoip/database/GeoIPCountryCSV.zip";
+$pfb['extras'][2]['url']	= 'http://geolite.maxmind.com/download/geoip/database/GeoIPCountryCSV.zip';
 $pfb['extras'][2]['file_dwn']	= 'GeoIPCountryCSV.zip';
 $pfb['extras'][2]['file']	= 'GeoIPCountryWhois.csv';
 $pfb['extras'][2]['folder']	= "{$pfb['geoipshare']}";
 $pfb['extras'][2]['install']	= TRUE;		// Flag for package installation
 
-$pfb['extras'][3]['url']	= "http://dev.maxmind.com/static/csv/codes/country_continent.csv";
+$pfb['extras'][3]['url']	= 'http://dev.maxmind.com/static/csv/codes/country_continent.csv';
 $pfb['extras'][3]['file_dwn']	= 'country_continent.csv';
 $pfb['extras'][3]['file']	= 'country_continent.csv';
 $pfb['extras'][3]['folder']	= "{$pfb['geoipshare']}";
 $pfb['extras'][3]['install']	= TRUE;		// Flag for package installation
 
-$pfb['extras'][4]['url']	= "http://geolite.maxmind.com/download/geoip/database/GeoIPv6.csv.gz";
+$pfb['extras'][4]['url']	= 'http://geolite.maxmind.com/download/geoip/database/GeoIPv6.csv.gz';
 $pfb['extras'][4]['file_dwn']	= 'GeoIPv6.csv.gz';
 $pfb['extras'][4]['file']	= 'GeoIPv6.csv';
 $pfb['extras'][4]['folder']	= "{$pfb['geoipshare']}";
 $pfb['extras'][4]['install']	= TRUE;		// Flag for package installation
 
-$pfb['extras'][5]['url']	= "https://s3.amazonaws.com/alexa-static/top-1m.csv.zip";
+$pfb['extras'][5]['url']	= 'https://s3.amazonaws.com/alexa-static/top-1m.csv.zip';
 $pfb['extras'][5]['file_dwn']	= 'top-1m.csv.zip';
 $pfb['extras'][5]['file']	= 'top-1m.csv';
 $pfb['extras'][5]['folder']	= "{$pfb['dbdir']}";
@@ -171,7 +171,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 
 	// Check if List file doesn't exist or Format is 'whois'.
 	if (!file_exists("{$pfbfolder}/{$header}.txt") || $format == 'whois') {
-		$log = "\t\t\t\t\t\t\tUpdate Found\n";
+		$log = "\t\t\t\t\t\t\tUpdate found\n";
 		pfb_logger("{$log}", 1);
 		$pfb['update_cron'] = TRUE;
 		return;
@@ -183,7 +183,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 	// Compare previously downloaded file timestamp with remote timestamp
 	if (file_exists($local_file)) {
 		if ($format == 'rsync') {
-			$log = "\t\t\t\t( rsync )\t\tUpdate Found\n";
+			$log = "\t\t\t\t( rsync )\t\tUpdate found\n";
 			pfb_logger("{$log}", 1);
 			$pfb['update_cron'] = TRUE;
 			unlink_if_exists("{$pfbfolder}/{$header}.txt");
@@ -234,7 +234,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 			$local_md5	= @md5_file($local_file);
 
 			if ($remote_md5 != $local_md5) {
-				$log = "\t\t\t\t( md5 changed )\t\tUpdate Found\n";
+				$log = "\t\t\t\t( md5 changed )\t\tUpdate found\n";
 				pfb_logger("{$log}", 1);
 				$pfb['update_cron'] = TRUE;
 				unlink_if_exists("{$pfbfolder}/{$header}.txt");
@@ -271,7 +271,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 		// Trigger CRON process if updates are found.
 		$pfb['update_cron'] = TRUE;
 
-		$log = "Update Found\n";
+		$log = "Update found\n";
 		pfb_logger("{$log}", 1);
 		unlink_if_exists("{$pfbfolder}/{$header}.txt");
 	}

--- a/config/pfblockerng/pfblockerng_dnsbl.xml
+++ b/config/pfblockerng/pfblockerng_dnsbl.xml
@@ -389,7 +389,7 @@
 		<field>
 			<fielddescr>Alexa TLD Inclusion</fielddescr>
 			<fieldname>alexa_inclusion</fieldname>
-			<description><![CDATA[Select the TLDs for Whitelist. ( Only showing the Top 150 TLDs )<br />
+			<description><![CDATA[Select the TLDs for Whitelist. (Only showing the Top 150 TLDs)<br />
 				<strong>Default: COM, NET, ORG, CA, CO, IO</strong><br /><br />
 				Detailed listing : <a target=_blank href="http://www.iana.org/domains/root/db">Root Zone top-level domains.</a> ]]>
 			</description>
@@ -565,7 +565,7 @@
 			<fieldname>suppression</fieldname>
 			<description><![CDATA[No Regex Entries Allowed!<br /><br />
 				Enter one &emsp; <strong>Domain Name</strong>&emsp; per line<br />
-				You may use "<strong>#</strong>" after any Domain name to add comments. example ( google.com # Suppress Google.com )<br />
+				You may use "<strong>#</strong>" after any Domain name to add comments. example (google.com # Suppress Google.com)<br />
 				This List is stored as 'Base64' format in the config.xml file.<br /><br />
 				<font color='red'>Note: </font>These entries are only suppressed when Feeds are downloaded or on a
 				<font color='red'>'Force Reload'.</font><br />

--- a/config/pfblockerng/pfblockerng_v4lists.xml
+++ b/config/pfblockerng/pfblockerng_v4lists.xml
@@ -146,7 +146,7 @@
 		<field>
 			<fielddescr>Alias Name</fielddescr>
 			<fieldname>aliasname</fieldname>
-			<description><![CDATA[Enter Alias Name ( Example: Badguys )<br />
+			<description><![CDATA[Enter Alias Name (Example: Badguys)<br />
 				Do not include <strong>'pfBlocker' or 'pfB_'</strong> in the Alias Name, it's done by package.<br />
 				<strong>International, special or space characters will be ignored in firewall alias names.
 				</strong><br />]]>
@@ -174,7 +174,7 @@
 				<ul><li><strong>'Country code'</strong>: /usr/pbi/pfblockerng-amd64/share/GeoIP/cc/US_v4.txt
 					&emsp;(Change 'US' to required code)</li></ul>
 				<ul><li><strong>'Whois'</strong>: Domain name or AS&emsp;(ie: facebook.com or AS13414)
-					&emsp;( <a target="_blank" href='https://asn.cymru.com/'>Click for ASN Lookup</a> )</li></ul>
+					&emsp;(<a target="_blank" href='https://asn.cymru.com/'>Click for ASN Lookup</a>)</li></ul>
 				<strong><u>'Header/Label'</u></strong>: This field must be <u>unique.</u> This names the file and is referenced in the widget.
 					&emsp;(ie: Spamhaus_drop, Spamhaus_edrop)<br /><br />]]>
 			</description>
@@ -439,8 +439,8 @@
 		<field>
 			<type>info</type>
 			<description><![CDATA[<font color='red'>Note: </font>&emsp;Custom List can be used in <strong>ONE</strong> of two ways:<br />
-				<ul>1. IPv4 addresses entered directly into the custom list, as per the required format.</ul>
-				<ul>2. Domain names or AS numbers, which will be converted into their respective IPv4 addresses.</ul>]]>
+				<ul>1. IPv4 addresses entered directly into the custom list, as per the required format.
+				<br />2. Domain names or AS numbers, which will be converted into their respective IPv4 addresses.</ul>]]>
 			</description>
 		</field>
 		<field>

--- a/config/pfblockerng/pfblockerng_v6lists.xml
+++ b/config/pfblockerng/pfblockerng_v6lists.xml
@@ -145,7 +145,7 @@
 		<field>
 			<fielddescr>Alias Name</fielddescr>
 			<fieldname>aliasname</fieldname>
-			<description><![CDATA[Enter Alias Name ( Example: Badguys )<br />
+			<description><![CDATA[Enter Alias Name (Example: Badguys)<br />
 				Do not include <strong>'pfBlocker' or 'pfB_'</strong> in the Alias Name, it's done by package.<br />
 				<strong>International, special or space characters will be ignored in firewall alias names.
 				</strong><br />]]>
@@ -171,7 +171,7 @@
 				<ul><li><strong>'Country code'</strong>: /usr/pbi/pfblockerng-amd64/share/GeoIP/cc/US_v6.txt
 					&emsp;(Change 'US' to required code)</li></ul>
 				<ul><li><strong>'Whois'</strong>: Domain name or AS&emsp;(ie: facebook.com or AS13414)
-					&emsp;( <a target="_blank" href='https://asn.cymru.com/'>Click for ASN Lookup</a> )</li></ul>
+					&emsp;(<a target="_blank" href='https://asn.cymru.com/'>Click for ASN Lookup</a>)</li></ul>
 				<strong><u>'Header/Label'</u></strong>: This field must be <u>unique.</u> This names the file and is referenced in the widget.
 					&emsp;(ie: Spamhaus_drop, Spamhaus_edrop)<br /><br />]]>
 			</description>
@@ -433,8 +433,8 @@
 		<field>
 			<type>info</type>
 			<description><![CDATA[<font color='red'>Note: </font>&emsp;Custom List can be used in <strong>ONE</strong> of two ways:<br />
-				<ul>1. IPv6 addresses entered directly into the custom list, as per the required format.</ul>
-				<ul>2. Domain names or AS numbers, which will be converted into their respective IPv6 addresses.</ul>]]>
+				<ul>1. IPv6 addresses entered directly into the custom list, as per the required format.
+				<br />2. Domain names or AS numbers, which will be converted into their respective IPv6 addresses.</ul>]]>
 			</description>
 		</field>
 		<field>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -118,7 +118,7 @@
 		<category>Security</category>
 		<pkginfolink>https://forum.pfsense.org/index.php?topic=86212.0</pkginfolink>
 		<config_file>https://packages.pfsense.org/packages/config/pfblockerng/pfblockerng.xml</config_file>
-		<version>2.0</version>
+		<version>2.01</version>
 		<status>RELEASE</status>
 		<required_version>2.2</required_version>
 		<maintainer>BBCan177@gmail.com</maintainer>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -118,7 +118,7 @@
 		<category>Security</category>
 		<pkginfolink>https://forum.pfsense.org/index.php?topic=86212.0</pkginfolink>
 		<config_file>https://packages.pfsense.org/packages/config/pfblockerng/pfblockerng.xml</config_file>
-		<version>2.01</version>
+		<version>2.0.1</version>
 		<status>RELEASE</status>
 		<required_version>2.2</required_version>
 		<maintainer>BBCan177@gmail.com</maintainer>


### PR DESCRIPTION
* Add missing ['host'] key to $host variable.
* Add query if download failure is due to DNSBL Block.
* Change text from IDS to IPS.
* Remove International, special or space characters from 'Alias Custom' names.
* Cosmetic text fixes.