### PR TITLE
AH00526: Syntax error on line 539 of /usr/pbi/proxy_mod_security-amd6…

### DIFF
--- a/config/apache_mod_security-dev/apache_mod_security.template
+++ b/config/apache_mod_security-dev/apache_mod_security.template
@@ -95,7 +95,7 @@ SecPcreMatchLimitRecursion 1000
 # MSC_PCRE_LIMITS_EXCEEDED: PCRE match limits were exceeded.
 #
 SecRule TX:/^MSC_/ "!@streq 0" \
-        "phase:2,t:none,deny,msg:'ModSecurity internal error flagged: %{MATCHED_VAR_NAME}'"
+        "id:20005,phase:2,t:none,deny,msg:'ModSecurity internal error flagged: %{MATCHED_VAR_NAME}'"
 
 
 # -- Response body handling --------------------------------------------------

--- a/config/apache_mod_security-dev/apache_mod_security.template
+++ b/config/apache_mod_security-dev/apache_mod_security.template
@@ -25,7 +25,7 @@ SecRequestBodyAccess On
 # Initiate XML Processor in case of xml content-type
 #
 SecRule REQUEST_HEADERS:Content-Type "text/xml" \
-     "phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=XML"
+     "id:20001,phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=XML"
 
 
 # Maximum request body size we will accept for buffering. If you support
@@ -56,7 +56,7 @@ SecRequestBodyLimitAction Reject
 # or log a high-severity alert (when deployed in detection-only mode).
 #
 SecRule REQBODY_ERROR "!@eq 0" \
-"phase:2,t:none,log,deny,status:400,msg:'Failed to parse request body.',logdata:'%{reqbody_error_msg}',severity:2"
+"id:20002,phase:2,t:none,log,deny,status:400,msg:'Failed to parse request body.',logdata:'%{reqbody_error_msg}',severity:2"
 
 # By default be strict with what we accept in the multipart/form-data
 # request body. If the rule below proves to be too strict for your
@@ -64,7 +64,7 @@ SecRule REQBODY_ERROR "!@eq 0" \
 # _not_ to remove it altogether.
 #
 SecRule MULTIPART_STRICT_ERROR "!@eq 0" \
-"phase:2,t:none,log,deny,status:44,msg:'Multipart request body \
+"id:20003,phase:2,t:none,log,deny,status:44,msg:'Multipart request body \
 failed strict validation: \
 PE %{REQBODY_PROCESSOR_ERROR}, \
 BQ %{MULTIPART_BOUNDARY_QUOTED}, \
@@ -81,7 +81,7 @@ IH %{MULTIPART_FILE_LIMIT_EXCEEDED}'"
 # Did we see anything that might be a boundary?
 #
 SecRule MULTIPART_UNMATCHED_BOUNDARY "!@eq 0" \
-"phase:2,t:none,log,deny,status:44,msg:'Multipart parser detected a possible unmatched boundary.'"
+"id:20004,phase:2,t:none,log,deny,status:44,msg:'Multipart parser detected a possible unmatched boundary.'"
 
 # PCRE Tuning
 # We want to avoid a potential RegEx DoS condition


### PR DESCRIPTION
…4/etc/apache24/httpd.conf

When you start /usr/local/etc/rc.d/apache_mod_security.sh start  you receive this error. 
"AH00526: Syntax error on line 539 of /usr/pbi/proxy_mod_security-amd64/etc/apache24/httpd.conf:
ModSecurity: No action id present within the rule"  every rule needs a ID to work, that fix just make this.