### PR TITLE
Stop syncing ntopng package with FreeBSD-ports repo

### DIFF
--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -317,6 +317,7 @@
 		<config_file>https://packages.pfsense.org/packages/config/ntopng/ntopng.xml</config_file>
 		<configurationfile>ntopng.xml</configurationfile>
 		<noembedded>true</noembedded>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>Notes</name>


### PR DESCRIPTION
All PBI crap removed in https://github.com/pfsense/FreeBSD-ports/pull/3