### PR TITLE
Stop syncing nmap package with FreeBSD-ports repo

### DIFF
--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -819,6 +819,7 @@
 		<build_pbi>
 			<port>security/nmap</port>
 		</build_pbi>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>imspector</name>


### PR DESCRIPTION
All PBI crap removed in https://github.com/pfsense/FreeBSD-ports/pull/4