### PR TITLE
pfBlockerNG - Mods

### DIFF
--- a/config/pfblockerng/pfblockerng.inc
+++ b/config/pfblockerng/pfblockerng.inc
@@ -198,9 +198,9 @@ function pfb_global() {
 	$pfb['24hour']		= $pfb['config']['pfb_dailystart'];		// Start hour of the 'Once a day' schedule
 	$pfb['iplocal']		= $config['interfaces']['lan']['ipaddr'];	// Lan IP address
 	$pfb['dnsbl']		= $pfb['dnsblconfig']['pfb_dnsbl'];		// Enabled state of DNSBL
-	$pfb['dnsbl_port']	= $pfb['dnsblconfig']['pfb_dnsport']	?: '';	// Lighttpd web server http port setting
-	$pfb['dnsbl_port_ssl']	= $pfb['dnsblconfig']['pfb_dnsport_ssl']?: '';	// Lighttpd web server https port setting
-	$pfb['dnsbl_alexa']	= $pfb['dnsblconfig']['alexa_enable']; // Alexa whitelist
+	$pfb['dnsbl_port']	= $pfb['dnsblconfig']['pfb_dnsport'];		// Lighttpd web server http port setting
+	$pfb['dnsbl_port_ssl']	= $pfb['dnsblconfig']['pfb_dnsport_ssl'];	// Lighttpd web server https port setting
+	$pfb['dnsbl_alexa']	= $pfb['dnsblconfig']['alexa_enable'];		// Alexa whitelist
 
 	// Restore previous download on failure (default to 'on')
 	$pfb['restore']		= $pfb['config']['restore_feed'] != '' ? $pfb['config']['restore_feed'] : 'on';
@@ -236,6 +236,7 @@ pfb_global();
 
 // DNSBL Lighttpd HTTPS Daemon (Scans Lighttpd dnsbl_error.log for requested https domain names)
 if ($argv[1] == 'dnsbl') {
+	set_time_limit(0);
 	pfb_livetail($pfb['dnserrlog'], 'dnsbl');
 	exit;
 }
@@ -1778,7 +1779,7 @@ function sync_package_pfblockerng($cron='') {
 		log_error('[pfBlockerNG] Sync terminated during boot process.');
 		return;
 	}
-	syslog(LOG_NOTICE, '[pfBlockerNG] Starting sync process.');
+	syslog(LOG_NOTICE, '[pfBlockerNG] Starting cron process.');
 
 	// Reloads existing lists without downloading new lists when defined 'on'
 	$pfb['reuse'] = $pfb['config']['pfb_reuse'];
@@ -4119,7 +4120,8 @@ function sync_package_pfblockerng($cron='') {
 			$log = "\n===[  Aliastables / Rules  ]================================\n\n";
 			pfb_logger("{$log}", 1);
 
-			$log = "Firewall Rule Changes found, Applying Filter Reload\n";
+			$log = "Firewall rule changes found, applying Filter Reload\n";
+			syslog(LOG_NOTICE, "[pfBlockerNG] {$log}");
 			pfb_logger("{$log}", 1);
 		}
 
@@ -4142,7 +4144,8 @@ function sync_package_pfblockerng($cron='') {
 			$log = "\n\n===[  Aliastables / Rules  ]==========================================\n\n";
 			pfb_logger("{$log}", 1);
 
-			$log = "No Changes to Firewall Rules, Skipping Filter Reload\n";
+			$log = "No changes to Firewall rules, skipping Filter Reload\n";
+			syslog(LOG_NOTICE, "[pfBlockerNG] {$log}");
 			pfb_logger("{$log}", 1);
 
 			// Only Save Aliases that have been updated.

--- a/config/pfblockerng/pfblockerng.php
+++ b/config/pfblockerng/pfblockerng.php
@@ -47,7 +47,7 @@ require_once('services.inc');
 require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');	// 'include functions' not yet merged into pfSense
 
-global $config, $pfb;
+global $config, $g, $pfb;
 
 // Extras - MaxMind/Alexa Download URLs/filenames/settings
 $pfb['extras'][0]['url']	= 'http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz';
@@ -406,7 +406,7 @@ function pfblockerng_sync_cron() {
 
 // Function to process the downloaded MaxMind database and format into Continent txt files.
 function pfblockerng_uc_countries() {
-	global $pfb;
+	global $g, $pfb;
 
 	$maxmind_cont	= "{$pfb['geoipshare']}/country_continent.csv";
 	$maxmind_cc4	= "{$pfb['geoipshare']}/GeoIPCountryWhois.csv";
@@ -564,7 +564,7 @@ function pfblockerng_uc_countries() {
 
 // Function to process Continent txt files and create Country ISO files and to Generate GUI XML files.
 function pfblockerng_get_countries() {
-	global $pfb;
+	global $g, $pfb;
 
 	$files = array (	'Africa'		=> "{$pfb['ccdir']}/Africa_v4.txt",
 				'Asia'			=> "{$pfb['ccdir']}/Asia_v4.txt",

--- a/config/pfblockerng/pfblockerng.xml
+++ b/config/pfblockerng/pfblockerng.xml
@@ -48,7 +48,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>pfblockerng</name>
-	<version>2.0</version>
+	<version>2.0.3</version>
 	<title>pfBlockerNG: General Settings</title>
 	<include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
 	<addedit_string>pfBlockerNG: Save General Settings</addedit_string>

--- a/config/pfblockerng/pfblockerng_install.inc
+++ b/config/pfblockerng/pfblockerng_install.inc
@@ -34,7 +34,7 @@
 require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 require_once('/usr/local/www/pfblockerng/pfblockerng.php');
 
-global $config, $pfb, $static_output;
+global $config, $g, $pfb, $static_output;
 pfb_global();
 
 function update_static_output($text) {
@@ -184,6 +184,7 @@ unlink_if_exists('/usr/local/sbin/lighttpd_pfb');
 link('/usr/local/sbin/lighttpd', '/usr/local/sbin/lighttpd_pfb');
 
 update_static_output(" done.\nCreating DNSBL web server start-up script...");
+$pfb['dnsbl_conf'] = '/var/unbound/pfb_dnsbl_lighty.conf';
 $rc = array();
 $rc['file'] = 'dnsbl.sh';
 $rc['start'] = <<<EOF
@@ -255,7 +256,7 @@ debug.log-condition-handling	= "enable"
 
 \$SERVER["socket"] == "0.0.0.0:{$pfb['dnsbl_port_ssl']}" {
 	ssl.engine		= "enable"
-	ssl.pemfile		= "{$pfb['dnsbl_cert']}"
+	ssl.pemfile		= "/var/unbound/dnsbl_cert.pem"
 	ssl.use-sslv2		= "disable"
 	ssl.use-sslv3		= "disable"
 	ssl.honor-cipher-order	= "enable"
@@ -273,7 +274,7 @@ EOF;
 	update_static_output(" done.\n");
 
 	update_static_output("Starting DNSBL Service...");
-	start_service('dnsbl');
+	restart_service('dnsbl');
 	update_static_output(" done.\n");
 }
 

--- a/config/pfblockerng/pfblockerng_top20.xml
+++ b/config/pfblockerng/pfblockerng_top20.xml
@@ -282,6 +282,7 @@
 				<option><name>Alias Deny</name><value>Alias_Deny</value></option>
 				<option><name>Alias Permit</name><value>Alias_Permit</value></option>
 				<option><name>Alias Match</name><value>Alias_Match</value></option>
+				<option><name>Alias Native</name><value>Alias_Native</value></option>
 			</options>
 		</field>
 		<field>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -118,7 +118,7 @@
 		<category>Security</category>
 		<pkginfolink>https://forum.pfsense.org/index.php?topic=86212.0</pkginfolink>
 		<config_file>https://packages.pfsense.org/packages/config/pfblockerng/pfblockerng.xml</config_file>
-		<version>2.0.2</version>
+		<version>2.0.3</version>
 		<status>RELEASE</status>
 		<required_version>2.2</required_version>
 		<maintainer>BBCan177@gmail.com</maintainer>


### PR DESCRIPTION
* Bump version to 2.0.3
* Add missing $g global setting.
* Explicitly define $pfb variables in the install file (php caching issue)
* Change DNSBL start_service() to restart_service()
* Add    **set_time_limit(0);**   to DNSBL php daemon session
* Add/Change syslog notice messages.
* Add 'Alias_Native' option to TOP20 Tab.