### PR TITLE
pfBlockerNG - version 2.0.4

### DIFF
--- a/config/pfblockerng/pfblockerng.inc
+++ b/config/pfblockerng/pfblockerng.inc
@@ -1784,6 +1784,7 @@ function sync_package_pfblockerng($cron='') {
 	// Reloads existing lists without downloading new lists when defined 'on'
 	$pfb['reuse'] = $pfb['config']['pfb_reuse'];
 	$pfb['reuse_dnsbl'] = '';
+	$pfb['updatednsbl'] = FALSE;	// Set flag to allow DNSBL Reload, only when called via background cmd.
 
 	// Define update process (update or reload)
 	switch ($cron) {
@@ -1801,6 +1802,7 @@ function sync_package_pfblockerng($cron='') {
 		case 'updatednsbl':
 			$pfb['reuse'] = '';
 			$pfb['reuse_dnsbl'] = 'on';
+			$pfb['updatednsbl'] = TRUE;
 			break;
 		case 'updateip':
 			$pfb['reuse'] = 'on';
@@ -2304,13 +2306,15 @@ function sync_package_pfblockerng($cron='') {
 			$dnsbl_error = TRUE;
 		}
 
-		// Determine if a DNSBL Reload is running
-		$result_cron = array();
-		exec('/bin/ps -wax', $result_cron);
-		if (preg_grep("/pfblockerng[.]php\s+?(updatednsbl)/", $result_cron)) {
-			$log = "\n ** DNSBL Update Terminated due to active pfBlockerNG cron process\n";
-			pfb_logger("{$log}", 1);
-			$dnsbl_error = TRUE;
+		if (!$pfb['updatednsbl']) {
+			// Determine if a DNSBL Reload is running
+			$result_cron = array();
+			exec('/bin/ps -wax', $result_cron);
+			if (preg_grep("/pfblockerng[.]php\s+?(updatednsbl)/", $result_cron)) {
+				$log = "\n ** DNSBL Reload Terminated due to active pfBlockerNG cron process\n";
+				pfb_logger("{$log}", 1);
+				$dnsbl_error = TRUE;
+			}
 		}
 	}
 

--- a/config/pfblockerng/pfblockerng.inc
+++ b/config/pfblockerng/pfblockerng.inc
@@ -1075,7 +1075,7 @@ function find_reported_header($ip, $pfbfolder, $exclude=FALSE) {
 
 	// Query for any active pfBlockerNG CRON jobs
 	exec('/bin/ps -wax', $result_cron);
-	if (preg_grep("/pfblockerng[.]php\s+?(cron|update)/", $result_cron)) {
+	if (preg_grep("/pfblockerng[.]php\s+?(cron|update|updatednsbl)/", $result_cron)) {
 		return array('updating..', 'CRON Task');
 	}
 	return array('', 'no match', FALSE);
@@ -1532,7 +1532,7 @@ function pfb_firewall_rule($action, $pfb_alias, $vtype='', $pfb_log, $adest='', 
 				$rule['log'] = '';
 			}
 			$rule['created'] = array('time' => (int)microtime(true), 'username' => 'Auto');
-			$rule['match_outbound'][] = $rule;
+			$pfb['match_outbound'][] = $rule;
 			if ($action != 'Match_Both') {
 				break;
 			}
@@ -1860,7 +1860,6 @@ function sync_package_pfblockerng($cron='') {
 	$pfb['dnsbl_iface']	= $pfb['dnsblconfig']['dnsbl_interface']?: 'lan';	// VIP Local Interface setting
 	$pfb['dnsbl_ip']	= $pfb['dnsblconfig']['action']		?: 'Disabled';	// Enable/Disable IP blocking from DNSBL lists
 	$pfb['dnsbl_rule']	= $pfb['dnsblconfig']['pfb_dnsbl_rule'] ?: 'Disabled';	// Auto create a Floating Pass Rule for other Lan subnets
-	$pfb['dnsbl_alexa']	= $pfb['dnsblconfig']['alexa_enable'] ?: 'Disabled';	// Enable Alexa whitelist
 	$pfb['dnsbl_alexa_cnt']	= $pfb['dnsblconfig']['alexa_count'] ?: '1000';		// Alexa whitelist domain setting
 	$pfb['dnsbl_alexa_inc']	= $pfb['dnsblconfig']['alexa_inclusion'] ?: '';		// Alexa TLDs inclusions for whitelisting
 
@@ -2163,8 +2162,8 @@ function sync_package_pfblockerng($cron='') {
 			}
 		}
 
-		$pfb['remove'] = FALSE;		// Flag to execute pfctl and rules ordering or reload of DNSBL domains
-		$pfb['summary'] = FALSE;	// Execute final summary as a list was removed
+		$pfb['remove']	= FALSE;		// Flag to execute pfctl and rules ordering or reload of DNSBL domains
+		$pfb['summary']	= FALSE;		// Execute final summary as a list was removed
 
 		// Process to remove lists from Masterfile/DB folder if they do not exist
 		if (isset($pfb['existing'])) {
@@ -2214,7 +2213,7 @@ function sync_package_pfblockerng($cron='') {
 									// Query for any active pfBlockerNG CRON jobs
 									$result_cron = array();
 									exec('/bin/ps -wax', $result_cron);
-									if (preg_grep("/pfblockerng[.]php\s+?(cron|update)/", $result_cron)) {
+									if (preg_grep("/pfblockerng[.]php\s+?(cron|update|updatednsbl)/", $result_cron)) {
 										$log = "\n ** DNSBL Reload Terminated due to active pfBlockerNG cron process\n";
 										pfb_logger("{$log}", 1);
 									} else {
@@ -2223,7 +2222,7 @@ function sync_package_pfblockerng($cron='') {
 											// Clear any existing pfBlockerNG Cron Jobs to avoid collision
 											install_cron_job('pfblockerng.php cron', false);
 											$cmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php";
-											mwexec_bg("${cmd} updatednsbl >> {$pfb['log']} 2>&1");
+											mwexec_bg("{$cmd} updatednsbl >> {$pfb['log']} 2>&1");
 										}
 									}
 								}
@@ -2301,6 +2300,15 @@ function sync_package_pfblockerng($cron='') {
 		$dnsbl_error = FALSE;
 		if (empty($pfb['dnsbl_vip']) || empty($pfb['dnsbl_port']) || empty($pfb['dnsbl_port_ssl'])) {
 			$log = "\n\n===[  DNSBL Virtual IP and/or Ports are not defined. Exiting  ]======\n";
+			pfb_logger("{$log}", 1);
+			$dnsbl_error = TRUE;
+		}
+
+		// Determine if a DNSBL Reload is running
+		$result_cron = array();
+		exec('/bin/ps -wax', $result_cron);
+		if (preg_grep("/pfblockerng[.]php\s+?(updatednsbl)/", $result_cron)) {
+			$log = "\n ** DNSBL Update Terminated due to active pfBlockerNG cron process\n";
 			pfb_logger("{$log}", 1);
 			$dnsbl_error = TRUE;
 		}

--- a/config/pfblockerng/pfblockerng.xml
+++ b/config/pfblockerng/pfblockerng.xml
@@ -48,7 +48,7 @@
 	<requirements>Describe your package requirements here</requirements>
 	<faq>Currently there are no FAQ items provided.</faq>
 	<name>pfblockerng</name>
-	<version>2.0.3</version>
+	<version>2.0.4</version>
 	<title>pfBlockerNG: General Settings</title>
 	<include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
 	<addedit_string>pfBlockerNG: Save General Settings</addedit_string>

--- a/config/pfblockerng/pfblockerng.xml
+++ b/config/pfblockerng/pfblockerng.xml
@@ -418,6 +418,8 @@
 			</description>
 			<type>select</type>
 			<options>
+				<option><name>5000</name><value>5000</value></option>
+				<option><name>10000</name><value>10000</value></option>
 				<option><name>20000</name><value>20000</value></option>
 				<option><name>40000</name><value>40000</value></option>
 				<option><name>60000</name><value>60000</value></option>
@@ -560,8 +562,9 @@
 		<field>
 			<fielddescr>Support</fielddescr>
 			<type>info</type>
-			<description><![CDATA[This package has been developed by BBcan177.<br />
-				 If you like this package, please support the developer @ BBCan177@gmail.com.]]>
+			<description><![CDATA[<a target="_blank" title="Your support is appreciated. Thank you!"
+					href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RHZUKWX2Y85ZA">
+					If you like this package, please support the developer.&emsp;<u>Paypal accepted.<u></a>]]>
 			</description>
 		</field>
 		<field>

--- a/config/pfblockerng/pfblockerng_dnsbl_lists.xml
+++ b/config/pfblockerng/pfblockerng_dnsbl_lists.xml
@@ -291,7 +291,7 @@
 			<fieldname>custom</fieldname>
 			<description><![CDATA[No Regex Entries Allowed!<br /><br />
 				Enter one &emsp; <strong>'Domain Name'</strong> &emsp; per line<br /><br />
-				You may use "<strong>#</strong>" after any Domain name to add comments. example ( ads.google.com # Block Google Ads )<br />
+				You may use "<strong>#</strong>" after any Domain name to add comments. example (ads.google.com # Block Google Ads)<br />
 				This List is stored as 'Base64' format in the config.xml file.]]>
 			</description>
 			<type>textarea</type>

--- a/config/pfblockerng/pfblockerng_install.inc
+++ b/config/pfblockerng/pfblockerng_install.inc
@@ -62,7 +62,8 @@ if ($pfs_version == '2.2') {
 } else {
 	$pfb['prefix'] = '/usr/local';
 }
-$pfb['geoipshare'] = "{$pfb['prefix']}/share/GeoIP";
+$pfb['geoipshare']	= "{$pfb['prefix']}/share/GeoIP";
+$pfb['ccdir']		= "{$pfb['prefix']}/share/GeoIP/cc";
 
 $pfb['maxmind'][0]['url']	= 'http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz';
 $pfb['maxmind'][0]['file_dwn']	= 'GeoIP.dat.gz';

--- a/config/pfblockerng/pfblockerng_threats.php
+++ b/config/pfblockerng/pfblockerng_threats.php
@@ -92,7 +92,7 @@ include('fbegin.inc');
 					<?=gettext("McAfee Threat Center");?></a><br />
 				<a target="_blank" href="https://sitecheck.sucuri.net/results/<?php echo $host; ?>">
 					<?=gettext("Securi SiteCheck");?></a><br />
-				<a target="_blank" href="https://www.dshield.org/ipinfo.html?IP=<?php echo $host; ?>">
+				<a target="_blank" href="https://www.dshield.org/ipinfo.html?ip=<?php echo $host; ?>">
 					<?=gettext("DShield Threat Lookup");?></a><br />
 				<a target="_blank" href="https://isc.sans.edu/ipinfo.html?ip=<?php echo $host; ?>">
 					<?=gettext("Internet Storm Center");?></a><br />
@@ -126,6 +126,8 @@ include('fbegin.inc');
 					<?=gettext("HerdProtect");?></a><br />
 				<a target="_blank" href="https://sitecheck.sucuri.net/results/<?php echo $domain; ?>">
 					<?=gettext("Sucuri");?></a><br />
+				<a target="_blank" href="http://www.tcpiputils.com/browse/domain/<?php echo $domain; ?>/">
+					<?=gettext("TCPUtils");?></a></td>
 
 				<?php } ?>
 

--- a/config/pfblockerng/pfblockerng_update.php
+++ b/config/pfblockerng/pfblockerng_update.php
@@ -81,8 +81,9 @@ function pfb_cron_update($type) {
 
 	// Query for any active pfBlockerNG CRON jobs
 	exec('/bin/ps -wx', $result_cron);
-	if (preg_grep("/pfblockerng[.]php\s+?(cron|update)/", $result_cron)) {
+	if (preg_grep("/pfblockerng[.]php\s+?(cron|update|updatednsbl)/", $result_cron)) {
 		pfbupdate_status(gettext("Force {$type} Terminated - Failed due to Active Running Task. Click 'View' for running process"));
+		header('Location: /pfblockerng/pfblockerng_update.php');
 		exit;
 	}
 
@@ -254,7 +255,7 @@ include_once('fbegin.inc');
 
 					// Query for any active pfBlockerNG CRON jobs
 					exec('/bin/ps -wax', $result_cron);
-					if (preg_grep("/pfblockerng[.]php\s+?(cron|update)/", $result_cron)) {
+					if (preg_grep("/pfblockerng[.]php\s+?(cron|update|updatednsbl)/", $result_cron)) {
 						echo "<font size=\"2\"><span class=\"red\">&emsp;&emsp;
 							Active pfBlockerNG CRON Job </span></font>&emsp;";
 						echo "<img src = '/themes/{$g['theme']}/images/icons/icon_pass.gif' alt='' width='15' height='15'

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -118,7 +118,7 @@
 		<category>Security</category>
 		<pkginfolink>https://forum.pfsense.org/index.php?topic=86212.0</pkginfolink>
 		<config_file>https://packages.pfsense.org/packages/config/pfblockerng/pfblockerng.xml</config_file>
-		<version>2.0.3</version>
+		<version>2.0.4</version>
 		<status>RELEASE</status>
 		<required_version>2.2</required_version>
 		<maintainer>BBCan177@gmail.com</maintainer>


### PR DESCRIPTION
* Fix 'Match Outbound' rule variable name
* Remove duplicate Alexa variable as its already in pfb_global()
* Determine if a DNSBL background reload is running before updating DNSBL
* Change "${cmd}"  variable name to  "{$cmd}"
* Add $pfb['ccdir'] explicitly due to file caching issue.
* Fix dShield URL
* Add tcpiputils to DNSBL Domain threat lookup
* Add log size settings (5000 & 10000 lines) for limited storage installations.
* Add Paypal link
* Remove extra whitespace