### PR TITLE
Improved squid3 reverse-proxy security

### DIFF
--- a/config/squid3/34/squid_reverse.inc
+++ b/config/squid3/34/squid_reverse.inc
@@ -4,7 +4,7 @@
 	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2012 Martin Fuchs
 	Copyright (C) 2012-2014 Marcello Coutinho
-	Copyright (C) 2013 Gekkenhuis
+	Copyright (C) 2013-2015 Gekkenhuis
 	Copyright (C) 2015 ESF, LLC
 	All rights reserved.
 
@@ -121,6 +121,23 @@ function squid_resync_reverse() {
 	// Ignore Internal Certificate Validation
 	$sslflags = ($settings['reverse_ignore_ssl_valid'] == "on" ? "sslflags=DONT_VERIFY_PEER" : "");
 
+	// Reverse Proxy security settings
+	$ciphers = "cipher=EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:HIGH:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS";
+	$options = "options=NO_SSLv2,NO_SSLv3,SINGLE_DH_USE,CIPHER_SERVER_PREFERENCE";
+
+	if (isset($settings["dhparams_size"])) {
+		if ($settings['dhparams_size'] == '1024') {
+			$dhparams = "dhparams=/etc/dh-parameters.1024";
+		} else if ($settings['dhparams_size'] == '2048') {
+			$dhparams = "dhparams=/etc/dh-parameters.2048";
+		} else if ($settings['dhparams_size'] == '4096') {
+			$dhparams = "dhparams=/etc/dh-parameters.4096";
+		}
+	} else {
+		// Fallback dhparams option
+		$dhparams = "dhparams=/etc/dh-parameters.2048";
+	}
+
 	foreach (explode(",", $ifaces) as $i => $iface) {
 		$real_ifaces[] = squid_get_real_interface_address($iface);
 		if ($real_ifaces[$i][0]) {
@@ -130,7 +147,7 @@ function squid_resync_reverse() {
 			}
 			//HTTPS
 			if (!empty($settings['reverse_https'])) {
-				$conf .= "https_port {$real_ifaces[$i][0]}:{$https_port} accel cert={$reverse_crt} key={$reverse_key} {$clientca_opts} defaultsite={$https_defsite} vhost\n";
+				$conf .= "https_port {$real_ifaces[$i][0]}:{$https_port} accel cert={$reverse_crt} key={$reverse_key} {$clientca_opts} {$dhparams} {$ciphers} {$options} defaultsite={$https_defsite} vhost\n";
 			}
 		}
 	}
@@ -144,7 +161,7 @@ function squid_resync_reverse() {
 			}
 			//HTTPS
 			if (!empty($settings['reverse_https'])) {
-				$conf .= "https_port {$reip}:{$https_port} accel cert={$reverse_crt} key={$reverse_key} defaultsite={$https_defsite} vhost\n";
+				$conf .= "https_port {$reip}:{$https_port} accel cert={$reverse_crt} key={$reverse_key} {$dhparams} {$ciphers} {$options} defaultsite={$https_defsite} vhost\n";
 			}
 		}
 	}

--- a/config/squid3/34/squid_reverse.inc
+++ b/config/squid3/34/squid_reverse.inc
@@ -101,7 +101,8 @@ function squid_resync_reverse() {
 			if ($crl != false) {
 				if (base64_decode($crl['text'])) {
 					file_put_contents(SQUID_CONFBASE . "/{$settings['reverse_ssl_clientcrl']}.crl", sq_text_area_decode($crl['text']));
-					$clientca_opts .= " crlfile=" . SQUID_CONFBASE . "/{$settings['reverse_ssl_clientcrl']}.crl sslflags=VERIFY_CRL";
+					$clientca_opts .= " crlfile=" . SQUID_CONFBASE . "/{$settings['reverse_ssl_clientcrl']}.crl";
+					$sslflags_https_port_iface = "sslflags=VERIFY_CRL";
 				}
 			}
 		}
@@ -119,23 +120,47 @@ function squid_resync_reverse() {
 	$https_defsite = (empty($settings['reverse_https_defsite']) ? $settings['reverse_external_fqdn'] : $settings['reverse_https_defsite']);
 
 	// Ignore Internal Certificate Validation
-	$sslflags = ($settings['reverse_ignore_ssl_valid'] == "on" ? "sslflags=DONT_VERIFY_PEER" : "");
+	$sslflags_cache_peer = ($settings['reverse_ignore_ssl_valid'] == "on" ? "sslflags=DONT_VERIFY_PEER" : "");
 
-	// Reverse Proxy security settings
-	$ciphers = "cipher=EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:HIGH:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS";
-	$options = "options=NO_SSLv2,NO_SSLv3,SINGLE_DH_USE,CIPHER_SERVER_PREFERENCE";
-
+	// Reverse Proxy HTTPS security settings
 	if (isset($settings["dhparams_size"])) {
-		if ($settings['dhparams_size'] == '1024') {
-			$dhparams = "dhparams=/etc/dh-parameters.1024";
-		} else if ($settings['dhparams_size'] == '2048') {
+		if ($settings['dhparams_size'] == '2048' && file_exists("/etc/dh-parameters.2048")) {
 			$dhparams = "dhparams=/etc/dh-parameters.2048";
-		} else if ($settings['dhparams_size'] == '4096') {
+		} else if ($settings['dhparams_size'] == '4096' && file_exists("/etc/dh-parameters.4096")) {
 			$dhparams = "dhparams=/etc/dh-parameters.4096";
 		}
-	} else {
+	} else if (file_exists("/etc/dh-parameters.2048")) {
 		// Fallback dhparams option
 		$dhparams = "dhparams=/etc/dh-parameters.2048";
+	}
+
+	// Without DHParams file and settings below squid will not work correct
+	if (isset($dhparams) && !empty($dhparams)) {
+		if ($settings['reverse_compatibility_mode'] == 'modern') {
+			// Modern
+			$ciphers = "cipher=ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK";
+			$options = "options=NO_SSLv2,NO_SSLv3,NO_TLSv1,SINGLE_DH_USE,CIPHER_SERVER_PREFERENCE";
+		} else if ($settings['reverse_compatibility_mode'] == 'intermediate') {
+			// Intermediate
+			$ciphers = "cipher=ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
+			$options = "options=NO_SSLv2,NO_SSLv3,SINGLE_DH_USE,CIPHER_SERVER_PREFERENCE";
+		}
+	}
+
+	if (!empty($settings['disable_session_reuse'])) {
+		// reverse_ssl_clientcrl doesn't set the sslflags on
+		// reverse_ip https_port so we cannot use the same variable
+		$sslflags_https_port_reverse = "sslflags=NO_SESSION_REUSE";
+	
+		// Check or the sslflags for the interface https_port
+		// are already set by reverse_ssl_clientcrl setting
+		if(!empty($sslflags_https_port_iface)) {
+			// Append the sslflags
+			$sslflags_https_port_iface .= ",NO_SESSION_REUSE";
+		} else {
+			// Set the sslflags
+			$sslflags_https_port_iface = $sslflags_https_port_reverse;
+		}
 	}
 
 	foreach (explode(",", $ifaces) as $i => $iface) {
@@ -147,7 +172,10 @@ function squid_resync_reverse() {
 			}
 			//HTTPS
 			if (!empty($settings['reverse_https'])) {
-				$conf .= "https_port {$real_ifaces[$i][0]}:{$https_port} accel cert={$reverse_crt} key={$reverse_key} {$clientca_opts} {$dhparams} {$ciphers} {$options} defaultsite={$https_defsite} vhost\n";
+				// Squid will fail when the line length exceeds 1024 characters, this can happen because of the long ciphersuite so break the line
+				$conf .= "https_port {$real_ifaces[$i][0]}:{$https_port} accel cert={$reverse_crt} key={$reverse_key} {$clientca_opts} {$sslflags_https_port_iface} {$dhparams} {$ciphers} \\\n";
+				$conf .= " {$options} defaultsite={$https_defsite} vhost\n";
+				$conf .= "\n";
 			}
 		}
 	}
@@ -161,7 +189,7 @@ function squid_resync_reverse() {
 			}
 			//HTTPS
 			if (!empty($settings['reverse_https'])) {
-				$conf .= "https_port {$reip}:{$https_port} accel cert={$reverse_crt} key={$reverse_key} {$dhparams} {$ciphers} {$options} defaultsite={$https_defsite} vhost\n";
+				$conf .= "https_port {$reip}:{$https_port} accel cert={$reverse_crt} key={$reverse_key} {$sslflags_https_port_reverse} {$dhparams} {$ciphers} {$options} defaultsite={$https_defsite} vhost\n";
 			}
 		}
 	}
@@ -173,7 +201,7 @@ function squid_resync_reverse() {
 			$casnr = 0;
 			foreach ($reverse_owa_ip as $reowaip) {
 				$casnr++;
-				$conf .= "cache_peer {$reowaip} parent 443 0 proxy-only no-query no-digest originserver login=PASSTHRU connection-auth=on ssl {$sslflags} front-end-https=on name=OWA_HOST_443_{$casnr}_pfs\n";
+				$conf .= "cache_peer {$reowaip} parent 443 0 proxy-only no-query no-digest originserver login=PASSTHRU connection-auth=on ssl {$sslflags_cache_peer} front-end-https=on name=OWA_HOST_443_{$casnr}_pfs\n";
 				$conf .= "cache_peer {$reowaip} parent 80 0 proxy-only no-query no-digest originserver login=PASSTHRU connection-auth=on name=OWA_HOST_80_{$casnr}_pfs\n";
 			}
 		}
@@ -186,7 +214,7 @@ function squid_resync_reverse() {
 				$conf_peer = "#{$rp['description']}\n";
 				$conf_peer .= "cache_peer {$rp['ip']} parent {$rp['port']} 0 proxy-only no-query no-digest originserver login=PASSTHRU connection-auth=on round-robin ";
 				if ($rp['protocol'] == 'HTTPS') {
-					$conf_peer .= "ssl {$sslflags} front-end-https=auto ";
+					$conf_peer .= "ssl {$sslflags_cache_peer} front-end-https=auto ";
 				}
 				$conf_peer .= "name=rvp_{$rp['name']}\n\n";
 

--- a/config/squid3/34/squid_reverse_general.xml
+++ b/config/squid3/34/squid_reverse_general.xml
@@ -11,6 +11,7 @@
 	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2012-2014 Marcello Coutinho
 	Copyright (C) 2015 ESF, LLC
+	Copyright (C) 2015 Gekkenhuis
 	All rights reserved.
 */
 /* ====================================================================================== */
@@ -273,20 +274,44 @@
 			<default_value>none</default_value>
 		</field>
 		<field>
-			<fielddescr>DHParams key size</fielddescr>
-			<fieldname>dhparams_size</fieldname>
+			<name>Squid Reverse Security Settings</name>
+			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Compatibility mode</fielddescr>
+			<fieldname>reverse_compatibility_mode</fieldname>
 			<description>
 				<![CDATA[
-				DH parameters are used for temporary/ephemeral DH key exchanges. They improve security by enabling the use of DHE ciphers.<br/>
-				The pre-generated DH parameters keys provided with pfSense are used.
+				The compatibility mode determines which ciphersuite and TLS versions are supported.<br/>
+				Modern is for modern clients only (post FF 27, Chrome 22, IE 11 etc.). If you need to support older clients use the Intermediate setting.<br/><br/>
+				<strong><span class="errmsg">Warning: </span>Clients like IE 6 and Java 6 are not supported anymore!</strong><br/>
+				The compatibility mode is based on <a href="https://wiki.mozilla.org/Security/Server_Side_TLS" target="_blank">Mozilla's</a> documentation.
 				]]>
 			</description>
 			<type>select</type>
 			<options>
 				<option>
-					<name>1024</name>
-					<value>1024</value>
+					<name>Modern</name>
+					<value>modern</value>
 				</option>
+				<option>
+					<name>Intermediate</name>
+					<value>intermediate</value>
+				</option>
+			</options>
+			<size>1</size>
+			<default_value>modern</default_value>
+		</field>
+		<field>
+			<fielddescr>DHParams key size</fielddescr>
+			<fieldname>dhparams_size</fieldname>
+			<description>
+				<![CDATA[
+				DH parameters are used for temporary/ephemeral DH key exchanges. They improve security by enabling the use of DHE ciphers.<br/>
+				]]>
+			</description>
+			<type>select</type>
+			<options>
 				<option>
 					<name>2048</name>
 					<value>2048</value>
@@ -298,6 +323,19 @@
 			</options>
 			<size>1</size>
 			<default_value>2048</default_value>
+		</field>
+		<field>  
+			<fielddescr>Disable session resumption (caching)</fielddescr>  
+			<fieldname>disable_session_reuse</fieldname>  
+			<description>  
+				<![CDATA[
+				Don't allow session reuse.<br/><br/>
+				The current recommendation for web servers is to enable session resumption and benefit from the performance improvement, but to restart servers daily when possible. This ensure that sessions get purged and ticket keys get renewed on a regular basis.<br/><br/>
+				<strong><span class="errmsg">Warning: </span>Disabling session resumption will increase the clients latency and the server load but can improve security for Perfect Forward Secrecy (DHE and ECDH).</strong>
+				]]>  
+			</description>  
+			<type>checkbox</type>  
+			<default_value>off</default_value>  
 		</field>
 		<field>
 			<name>OWA Reverse Proxy General Settings</name>

--- a/config/squid3/34/squid_reverse_general.xml
+++ b/config/squid3/34/squid_reverse_general.xml
@@ -43,7 +43,7 @@
 	]]>
 	</copyright>
 	<name>squidreversegeneral</name>
-	<version>0.4.8</version>
+	<version>0.4.9</version>
 	<title>Reverse Proxy Server: General</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<tabs>

--- a/config/squid3/34/squid_reverse_general.xml
+++ b/config/squid3/34/squid_reverse_general.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidreversegeneral</name>
-	<version>0.4.5</version>
+	<version>0.4.8</version>
 	<title>Reverse Proxy Server: General</title>
 	<include_file>/usr/local/pkg/squid.inc</include_file>
 	<tabs>
@@ -265,12 +265,39 @@
 				<input name='refresh_crl' id='refresh_crl' type='submit' value='Refresh CRL' />
 				]]>
 			</description>
-	    	<type>select_source</type>
+			<type>select_source</type>
 			<source><![CDATA[$config['crl']]]></source>
 			<source_name>descr</source_name>
 			<source_value>refid</source_value>
 			<show_disable_value>none</show_disable_value>
 			<default_value>none</default_value>
+		</field>
+		<field>
+			<fielddescr>DHParams key size</fielddescr>
+			<fieldname>dhparams_size</fieldname>
+			<description>
+				<![CDATA[
+				DH parameters are used for temporary/ephemeral DH key exchanges. They improve security by enabling the use of DHE ciphers.<br/>
+				The pre-generated DH parameters keys provided with pfSense are used.
+				]]>
+			</description>
+			<type>select</type>
+			<options>
+				<option>
+					<name>1024</name>
+					<value>1024</value>
+				</option>
+				<option>
+					<name>2048</name>
+					<value>2048</value>
+				</option>
+				<option>
+					<name>4096</name>
+					<value>4096</value>
+				</option>
+			</options>
+			<size>1</size>
+			<default_value>2048</default_value>
 		</field>
 		<field>
 			<name>OWA Reverse Proxy General Settings</name>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1091,7 +1091,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php?topic=100167.0</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Services</category>
-		<version>0.4.8</version>
+		<version>0.4.9</version>
 		<status>RC</status>
 		<required_version>2.2</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1091,7 +1091,7 @@
 		<pkginfolink>https://forum.pfsense.org/index.php?topic=100167.0</pkginfolink>
 		<website>http://www.squid-cache.org/</website>
 		<category>Services</category>
-		<version>0.4.7</version>
+		<version>0.4.8</version>
 		<status>RC</status>
 		<required_version>2.2</required_version>
 		<maintainer>marcellocoutinho@gmail.com fernando@netfilter.com.br seth.mos@dds.nl mfuchs77@googlemail.com jimp@pfsense.org</maintainer>


### PR DESCRIPTION
- Added strong ciphers
- Disabled SSLv2 and SSLv3 options
- Added SINGLE_DH_USE and CIPHER_SERVER_PREFERENCE options
- Added use of DHParam file