### PR TITLE
Allow to select OSPF Network Type in the Quagga OSPFd > Interface Set…

### DIFF
--- a/config/quagga_ospfd/quagga_ospfd.inc
+++ b/config/quagga_ospfd/quagga_ospfd.inc
@@ -109,6 +109,9 @@ function quagga_ospfd_install_conf() {
 			foreach ($config['installedpackages']['quaggaospfdinterfaces']['config'] as $conf) {
 				$realif = get_real_interface($conf['interface']);
 				$conffile .= "interface {$realif}\n" ;
+				if (!empty($conf['networktype'])) {
+					$conffile .= "  ip ospf network {$conf['networktype']}\n";
+				}
 				if (!empty($conf['metric'])) {
 					$conffile .= "  ip ospf cost {$conf['metric']}\n";
 				}

--- a/config/quagga_ospfd/quagga_ospfd.xml
+++ b/config/quagga_ospfd/quagga_ospfd.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>quagga_ospfd</name>
-	<version>0.6.9</version>
+	<version>0.6.10</version>
 	<title>Services: Quagga OSPFd</title>
 	<include_file>/usr/local/pkg/quagga_ospfd.inc</include_file>
 	<aftersaveredirect>pkg_edit.php?xml=quagga_ospfd.xml&amp;id=0</aftersaveredirect>

--- a/config/quagga_ospfd/quagga_ospfd_interfaces.xml
+++ b/config/quagga_ospfd/quagga_ospfd_interfaces.xml
@@ -107,6 +107,20 @@
 			<source_value>value</source_value>
 			<required/>
 		</field>
+ 		<field>
+			<fielddescr>Network Type</fielddescr>
+			<fieldname>networktype</fieldname>
+			<description>Select OSPF Network Type of the interface.</description>
+			<type>select</type>
+			<default_value></default_value>
+			<options>
+				<option><value></value><name>Not specified (default)</name></option>
+				<option><value>broadcast</value><name>Broadcast</name></option>
+				<option><value>non-broadcast</value><name>Non-Broadcast</name></option>
+				<option><value>point-to-multipoint</value><name>Point-to-Multipoint</name></option>
+				<option><value>point-to-point</value><name>Point-to-Point</name></option>
+			</options>
+		</field>
 		<field>
 			<fielddescr>Metric</fielddescr>
 			<fieldname>metric</fieldname>


### PR DESCRIPTION
…tings

To run OSPF over OpenVPN/TUN between RouterOS (client) and pfSense (server) I have to set OpenVPN-interface-network-type to 'Point-To-Point' on both sides, having "...netmask mismatch" otherways.
Two confusing things: 1) I do not know what network type is default to Quagga OSPFd, so my default is 'not specified'. 2) Name and description of my drop-down box for English is not my native language.
Thanks.