### PR TITLE
Redmine #5727 TFTP protect against empty stuff

### DIFF
--- a/config/tftp2/tftp.inc
+++ b/config/tftp2/tftp.inc
@@ -41,6 +41,19 @@ function tftp_byte_convert($bytes) {
 	return round($bytes/pow($convention, $e), 2) . ' ' . $s[$e];
 }
 
+function tftp_dir_contains_files($dir) {
+	if (!is_readable($dir)) {
+		return NULL;
+	}
+	$handle = opendir($dir);
+	while (false !== ($entry = readdir($handle))) {
+		if ($entry != "." && $entry != "..") {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
 function tftp_install_command() {
 	global $config;
 
@@ -54,7 +67,9 @@ function tftp_install_command() {
 	// Restore backup if it exists
 	if (file_exists($tftpbackup)) {
 		mwexec("/usr/bin/tar xvpfz {$tftpbackup} -C /");
-		mwexec("/bin/chmod -R 0744 {$tftpdir}/*");
+		if (tftp_dir_contains_files($tftpdir)) {
+			mwexec("/bin/chmod -R 0744 {$tftpdir}/*");
+		}
 	}
 	unset($tftpdir, $tftpbackup);
 }

--- a/config/tftp2/tftp.xml
+++ b/config/tftp2/tftp.xml
@@ -43,7 +43,7 @@
 	]]>
 	</copyright>
 	<name>tftpsettings</name>
-	<version>2.2.4</version>
+	<version>2.2.5</version>
 	<title>TFTP: Settings</title>
 	<include_file>/usr/local/pkg/tftp.inc</include_file>
 	<menu>

--- a/config/tftp2/tftp_files.php
+++ b/config/tftp2/tftp_files.php
@@ -76,7 +76,9 @@ if ($_GET['a'] == "other") {
 			//echo "The file $filename exists";
 			conf_mount_rw();
 			mwexec("/usr/bin/tar -xpzC / -f {$backup_path}");
-			mwexec("/bin/chmod -R 744 {$files_dir}/*");
+			if (tftp_dir_contains_files($files_dir)) {
+				mwexec("/bin/chmod -R 744 {$files_dir}/*");
+			}
 			header( 'Location: tftp_files.php?savemsg=Backup+has+been+restored.' ) ;
 			conf_mount_ro();
 		} else {
@@ -92,7 +94,9 @@ if ($_POST['submit'] == "Save") {
 		write_config();
 		send_event("filter reload");
 	} else {
-		unset($config['installedpackages']['tftpd']['config'][0]['tftpdinterface']);
+		if (isset($config['installedpackages']['tftpd']['config'][0]['tftpdinterface'])) {
+			unset($config['installedpackages']['tftpd']['config'][0]['tftpdinterface']);
+		}
 		write_config();
 		send_event("filter reload");
 	}
@@ -102,7 +106,9 @@ if (($_POST['submit'] == "Upload") && is_uploaded_file($_FILES['ulfile']['tmp_na
 	conf_mount_rw();
 	move_uploaded_file($_FILES['ulfile']['tmp_name'], "{$files_dir}/{$_FILES['ulfile']['name']}");
 	$savemsg = "Uploaded file to {$files_dir}/" . htmlentities($_FILES['ulfile']['name']);
-	mwexec('/bin/chmod -R 744 {$files_dir}/*');
+	if (tftp_dir_contains_files($files_dir)) {
+		mwexec('/bin/chmod -R 744 {$files_dir}/*');
+	}
 	unset($_POST['txtCommand']);
 	conf_mount_ro();
 }

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -337,7 +337,7 @@
 		<pkginfolink/>
 		<port_category>ftp</port_category>
 		<config_file>https://packages.pfsense.org/packages/config/tftp2/tftp.xml</config_file>
-		<version>2.2.4</version>
+		<version>2.2.5</version>
 		<status>RELEASE</status>
 		<required_version>2.2</required_version>
 		<configurationfile>tftp.xml</configurationfile>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -383,7 +383,7 @@
 		<pkginfolink/>
 		<config_file>https://packages.pfsense.org/packages/config/tftp2/tftp.xml</config_file>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/8/All/</depends_on_package_base_url>
-		<version>2.2.4</version>
+		<version>2.2.5</version>
 		<status>Stable</status>
 		<required_version>2.0</required_version>
 		<configurationfile>tftp.xml</configurationfile>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -383,7 +383,7 @@
 		<pkginfolink/>
 		<config_file>https://packages.pfsense.org/packages/config/tftp2/tftp.xml</config_file>
 		<depends_on_package_base_url>https://files.pfsense.org/packages/amd64/8/All/</depends_on_package_base_url>
-		<version>2.2.4</version>
+		<version>2.2.5</version>
 		<status>Stable</status>
 		<required_version>2.0</required_version>
 		<configurationfile>tftp.xml</configurationfile>


### PR DESCRIPTION
1) If the user presses Save when there was no interface selected, and
the user has still not selected an interface, then do not attempt to
unset() tftpdinterface in the config when it is already unset.
2) If the user does backup/restore or other similar stuff when the
tftpboot directory has no files in it, then do not do chmod of the
(non-existent) files. This avoids a "No such file or directory" message
being logged.
This is for 2.1.* and 2.2.* - I will also make an equivalent PR in the other repo for 2.3