### PR TITLE
Logic simplifications

### DIFF
--- a/config/systempatches/patches.inc
+++ b/config/systempatches/patches.inc
@@ -183,16 +183,11 @@ function bootup_apply_patches() {
 	$a_patches = &$config['installedpackages']['patches']['item'];
 
 	foreach ($a_patches as $patch) {
-		/* Skip the patch if it should not be automatically applied. */
-		if (!isset($patch['autoapply'])) {
-			continue;
-		}
-		/* If the patch can be reverted it is already applied, so skip it. */
-		if (!patch_test_revert($patch)) {
-			/* Only attempt to apply if it can be applied. */
-			if (patch_test_apply($patch)) {
-				patch_apply($patch);
-			}
+		/* Skip if it should not be automatically applied;
+		   only attempt to apply if it can be applied;
+		   and	if it can be reverted it is presumably already applied, so skip it. */
+		if (isset($patch['autoapply']) && patch_test_apply($patch) && !patch_test_revert($patch)) {  
+			patch_apply($patch);
 		}
 	}
 }
@@ -200,36 +195,38 @@ function bootup_apply_patches() {
 function patch_add_shellcmd() {
 	global $config;
 	$a_earlyshellcmd = &$config['system']['earlyshellcmd'];
-	if (!is_array($a_earlyshellcmd)) {
-		$a_earlyshellcmd = array();
-	}
 	$found = false;
-	foreach ($a_earlyshellcmd as $idx => $cmd) {
-		if (stristr($cmd, "apply_patches.php")) {
-			$found = true;
+	if (is_array($a_earlyshellcmd)) {
+		foreach ($a_earlyshellcmd as $idx => $cmd) {
+			if (stristr($cmd, "apply_patches.php")) {
+				$found = true;
+			}
 		}
+	} else {
+		$a_earlyshellcmd = array();
 	}
 	if (!$found) {
 		$a_earlyshellcmd[] = "/usr/local/bin/php -f /usr/local/bin/apply_patches.php";
-		write_config("System Patches package added a shellcmd");
+		write_config("System Patches package added an early shellcmd: apply patches");
 	}
 }
 
 function patch_remove_shellcmd() {
 	global $config;
 	$a_earlyshellcmd = &$config['system']['earlyshellcmd'];
-	if (!is_array($a_earlyshellcmd)) {
-		$a_earlyshellcmd = array();
-	}
-	$removed = false;
-	foreach ($a_earlyshellcmd as $idx => $cmd) {
-		if (stristr($cmd, "apply_patches.php")) {
-			unset($a_earlyshellcmd[$idx]);
-			$removed = true;
+	if (is_array($a_earlyshellcmd)) {
+		$removed = false;
+		foreach ($a_earlyshellcmd as $idx => $cmd) {
+			if (stristr($cmd, "apply_patches.php")) {
+				unset($a_earlyshellcmd[$idx]);
+				$removed = true;
+			}
 		}
-	}
-	if ($removed) {
-		write_config("System Patches package removed a shellcmd");
+		if ($removed) {
+			write_config("System Patches package removed existing early shellcmd: apply patches");
+		}
+	} else {
+		$a_earlyshellcmd = array();
 	}
 }
 

--- a/config/systempatches/patches.inc
+++ b/config/systempatches/patches.inc
@@ -202,10 +202,9 @@ function patch_add_shellcmd() {
 				$found = true;
 			}
 		}
-	} else {
-		$a_earlyshellcmd = array();
 	}
 	if (!$found) {
+		// Implicitly creates array if needed
 		$a_earlyshellcmd[] = "/usr/local/bin/php -f /usr/local/bin/apply_patches.php";
 		write_config("System Patches package added an early shellcmd: apply patches");
 	}

--- a/config/systempatches/patches.inc
+++ b/config/systempatches/patches.inc
@@ -225,8 +225,6 @@ function patch_remove_shellcmd() {
 		if ($removed) {
 			write_config("System Patches package removed existing early shellcmd: apply patches");
 		}
-	} else {
-		$a_earlyshellcmd = array();
 	}
 }
 


### PR DESCRIPTION
1) Nested IF statements can be combined
2) Add/remove shellcmd contains logic that only needs to run if the early shellcmd array does/doesn't exist
3) Logs should be non-vague ("...added/removed a shellcmd" is better if it states the command added/removed, and for removal, clarify it removed an existing command)