### PR TITLE
Fix the zone generator for LOC records

### DIFF
--- a/config/bind/bind.inc
+++ b/config/bind/bind.inc
@@ -517,7 +517,7 @@ EOD;
 							$hostname = (preg_match("/(MX|NS)/", $zone['row'][$y]['hosttype']) ? "@" : $zone['row'][$y]['hostname']);
 							$hosttype = $zone['row'][$y]['hosttype'];
 							$hostdst = $zone['row'][$y]['hostdst'];
-							if (preg_match("/[a-zA-Z]/", $hostdst) && !preg_match("/(TXT|SPF|AAAA)/", $hosttype)) {
+							if (preg_match("/[a-zA-Z]/", $hostdst) && !preg_match("/(TXT|SPF|AAAA|LOC)/", $hosttype)) {
 								$hostdst .= ".";
 							}
 							$hostvalue = $zone['row'][$y]['hostvalue'];

--- a/config/bind/bind.inc
+++ b/config/bind/bind.inc
@@ -898,7 +898,7 @@ function bind_sync_on_changes()
 				break;
 			case 'auto':
 				if (is_array($config['hasync'])) {
-					$hasync = $config['hasync'][0];
+					$hasync = $config['hasync'];
 					$rs[0]['ipaddress'] = $hasync['synchronizetoip'];
 					$rs[0]['username'] = $hasync['username'];
 					$rs[0]['password'] = $hasync['password'];


### PR DESCRIPTION
Currently all but TXT, SPF and AAAA are appended a "." when the value contains /[a-zA-Z]/ however at least the LOC record must be created without the "."