### PR TITLE
Enable master type zone when syncing to backup server

### DIFF
--- a/config/bind/bind_sync.xml
+++ b/config/bind/bind_sync.xml
@@ -108,12 +108,12 @@
 			<description>
 				<![CDATA[
 				Set master zone ip you want to use to sync backup server zones with master.<br />
+				Leave empty if the backup server will also be a master.
 				<strong>Note: All master zones will be configured as backup on slave servers.</strong>
 				]]>
 			</description>
 			<type>input</type>
 			<size>20</size>
-			<required/>
 		</field>
 		<field>
 			<fielddescr>Remote Server</fielddescr>


### PR DESCRIPTION
Bind package forced "slave" type on every zone that was synced to backup server. However many servers run side-by-side and should keep the master type. I had changed the code so that when there is no master zone ip configured, the sync leaves the zone type unchanged.