### PR TITLE
haproxy, fix 'host contains' should use hdr_sub instead of hdr_dir in config

### DIFF
--- a/config/haproxy-devel/haproxy.xml
+++ b/config/haproxy-devel/haproxy.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>haproxy</name>
-	<version>0.36</version>
+	<version>0.37</version>
 	<title>HAProxy</title>
 	<aftersaveredirect>/pkg_edit.php?xml=haproxy_pools.php</aftersaveredirect>
 	<include_file>/usr/local/pkg/haproxy.inc</include_file>

--- a/config/haproxy-devel/pkg/haproxy.inc
+++ b/config/haproxy-devel/pkg/haproxy.inc
@@ -59,7 +59,7 @@ $a_acltypes["host_matches"] = array('name' => 'Host matches:',
 $a_acltypes["host_regex"] = array('name' => 'Host regex:',
 				'mode' =>'http', 'syntax' => 'hdr_reg(host) -i %1$s');
 $a_acltypes["host_contains"] = array('name' => 'Host contains:',
-				'mode' => 'http', 'syntax' => 'hdr_dir(host) -i %1$s');
+				'mode' => 'http', 'syntax' => 'hdr_sub(host) -i %1$s');
 $a_acltypes["path_starts_with"] = array('name' => 'Path starts with:',
 				'mode' => 'http', 'syntax' => 'path_beg -i %1$s');
 $a_acltypes["path_ends_with"] = array('name' => 'Path ends with:',

--- a/config/haproxy/haproxy.inc
+++ b/config/haproxy/haproxy.inc
@@ -44,7 +44,7 @@ $a_acltypes[] = array('name' => 'host_matches', 'descr' => 'Host matches',
 $a_acltypes[] = array('name' => 'host_regex', 'descr' => 'Host regex',
 				'mode' =>'http', 'syntax' => 'hdr_reg(host) -i');
 $a_acltypes[] = array('name' => 'host_contains', 'descr' => 'Host contains',
-				'mode' => 'http', 'syntax' => 'hdr_dir(host) -i');
+				'mode' => 'http', 'syntax' => 'hdr_sub(host) -i');
 $a_acltypes[] = array('name' => 'path_starts_with', 'descr' => 'Path starts with',
 				'mode' => 'http', 'syntax' => 'path_beg -i');
 $a_acltypes[] = array('name' => 'path_ends_with', 'descr' => 'Path ends with',

--- a/config/haproxy/haproxy.xml
+++ b/config/haproxy/haproxy.xml
@@ -42,7 +42,7 @@
     <requirements>Describe your package requirements here</requirements>
     <faq>Currently there are no FAQ items provided.</faq>
 	<name>haproxy</name>
-	<version>1.2.4</version>
+	<version>1.2.7</version>
 	<title>HAProxy</title>
 	<aftersaveredirect>/pkg_edit.php?xml=haproxy_pools.php</aftersaveredirect>
 	<include_file>/usr/local/pkg/haproxy.inc</include_file>

--- a/config/haproxy1_5/haproxy.xml
+++ b/config/haproxy1_5/haproxy.xml
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>haproxy</name>
-	<version>0.32</version>
+	<version>0.34</version>
 	<title>HAProxy</title>
 	<aftersaveredirect>/pkg_edit.php?xml=haproxy_pools.php</aftersaveredirect>
 	<include_file>/usr/local/pkg/haproxy.inc</include_file>

--- a/config/haproxy1_5/pkg/haproxy.inc
+++ b/config/haproxy1_5/pkg/haproxy.inc
@@ -56,7 +56,7 @@ $a_acltypes["host_matches"] = array('name' => 'Host matches:',
 $a_acltypes["host_regex"] = array('name' => 'Host regex:',
 				'mode' =>'http', 'syntax' => 'hdr_reg(host) -i %1$s');
 $a_acltypes["host_contains"] = array('name' => 'Host contains:',
-				'mode' => 'http', 'syntax' => 'hdr_dir(host) -i %1$s');
+				'mode' => 'http', 'syntax' => 'hdr_sub(host) -i %1$s');
 $a_acltypes["path_starts_with"] = array('name' => 'Path starts with:',
 				'mode' => 'http', 'syntax' => 'path_beg -i %1$s');
 $a_acltypes["path_ends_with"] = array('name' => 'Path ends with:',

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -144,7 +144,7 @@
 		</descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>0.33</version>
+		<version>0.34</version>
 		<status>RELEASE</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy1_5/haproxy.xml</config_file>
@@ -159,6 +159,7 @@
 			<port>net/haproxy</port>
 		</build_pbi>
 		<build_options>WITH_OPENSSL_PORT=yes;haproxy_UNSET_FORCE=DPCRE;haproxy_SET_FORCE=OPENSSL SPCRE</build_options>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>haproxy-devel</name>
@@ -172,7 +173,7 @@
 		</descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>0.36</version>
+		<version>0.37</version>
 		<status>RELEASE</status>
 		<required_version>2.2</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>
@@ -187,6 +188,7 @@
 			<port>net/haproxy</port>
 		</build_pbi>
 		<build_options>WITH_OPENSSL_PORT=yes;net_haproxy_UNSET_FORCE=DPCRE;net_haproxy_SET_FORCE=OPENSSL SPCRE LUA CPU_AFFINITY</build_options>
+		<maximum_version>2.2.999</maximum_version>
 	</package>
 	<package>
 		<name>Apache with mod_security-dev</name>

--- a/pkg_config.8.xml
+++ b/pkg_config.8.xml
@@ -118,7 +118,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.4.24 pkg v 1.2.6</version>
+		<version>1.4.24 pkg v 1.2.7</version>
 		<status>Release</status>
 		<required_version>2.0</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy/haproxy.xml</config_file>
@@ -153,7 +153,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.31</version>
+		<version>1.5.3 pkg v 0.34</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy1_5/haproxy.xml</config_file>
@@ -177,7 +177,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.36</version>
+		<version>1.5.3 pkg v 0.37</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>

--- a/pkg_config.8.xml.amd64
+++ b/pkg_config.8.xml.amd64
@@ -118,7 +118,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.4.24 pkg v 1.2.6</version>
+		<version>1.4.24 pkg v 1.2.7</version>
 		<status>Release</status>
 		<required_version>2.0</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy/haproxy.xml</config_file>
@@ -153,7 +153,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.31</version>
+		<version>1.5.3 pkg v 0.34</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy1_5/haproxy.xml</config_file>
@@ -177,7 +177,7 @@
 				Supports ACLs for smart backend switching.]]></descr>
 		<website>http://haproxy.1wt.eu/</website>
 		<category>Services</category>
-		<version>1.5.3 pkg v 0.36</version>
+		<version>1.5.3 pkg v 0.37</version>
 		<status>Release</status>
 		<required_version>2.1</required_version>
 		<config_file>https://packages.pfsense.org/packages/config/haproxy-devel/haproxy.xml</config_file>


### PR DESCRIPTION
haproxy, fix 'host contains' should use hdr_sub instead of hdr_dir in config
