### PR TITLE
SquidGuard - fix ldap based groups fetch with batch mode

### DIFF
--- a/config/squidGuard/squidguard.inc
+++ b/config/squidGuard/squidguard.inc
@@ -344,9 +344,9 @@ function squidguard_resync() {
     //}
 
     squidguard_cron_install();
-    
+
     //Sync only with apply button to avoid multiples reloads on backup server while editing master config
-    if ($submit == APPLY_BTN) 
+    if ($submit == APPLY_BTN)
 		squidguard_sync_on_changes();
 }
 
@@ -894,7 +894,7 @@ function squidguard_install_command() {
 #        conf_mount_rw();
         $blklist_file = SQUIDGUARD_BLK_FILELISTPATH;
 
-     
+
         if (!file_exists($blklist_file)) {
         	# if blacklist not exists, then copy default db from samples
 #            $entries = array("ads", "aggressive", "audio-video", "drugs", "gambling", "hacking", "mail", "porn", "proxy", "violence", "warez");
@@ -999,6 +999,7 @@ function convert_pfxml_to_sgxml() {
     $sgxml[F_LDAPVERSION]      = $pfxml['ldapversion'];
     $sgxml[F_STRIPNTDOMAIN]    = $pfxml['stripntdomain'];
     $sgxml[F_STRIPREALM]       = $pfxml['striprealm'];
+    $sgxml[F_LDAPFETCH]        = $pfxml['ldapfetch'];
     $sgxml[F_BINPATH]          = SQUIDGUARD_BINPATH;
     $sgxml[F_WORKDIR]          = SQUIDGUARD_WORKDIR;
     $sgxml[F_SGCONF_XML]       = SQUIDGUARD_WORKDIR . SQUIDGUARD_CONFXML;
@@ -1019,7 +1020,7 @@ function convert_pfxml_to_sgxml() {
 
     #Clean adversiting
     $sgxml[F_ADV_BLANKIMG] = $pfxml['adv_blankimg']  == 'on' ? 'on' : 'off';
-	
+
 
     # other
     $lanip = $config['interfaces']['lan']['ipaddr'];

--- a/config/squidGuard/squidguard.xml
+++ b/config/squidGuard/squidguard.xml
@@ -10,7 +10,7 @@
 	squidguard.xml
 	part of pfSense (https://www.pfSense.org/)
 	Copyright (C) 2006-2013 Sergey Dvoriancev <dv_serg@mail.ru>
-	Copyright (C) 2015 ESF, LLC
+	Copyright (C) 2015-2016 ESF, LLC
 	All rights reserved.
 */
 /* ====================================================================================== */
@@ -42,7 +42,7 @@
 	]]>
 	</copyright>
 	<name>squidguardgeneral</name>
-	<version>1.9.17</version>
+	<version>1.9.18</version>
 	<title>Proxy filter SquidGuard: General settings</title>
 	<include_file>/usr/local/pkg/squidguard.inc</include_file>
 	<!-- Installation -->
@@ -141,6 +141,10 @@
             <item>https://packages.pfsense.org/packages/config/squidGuard/squidguard_blacklist.php</item>
 	</additional_files_needed>
 	<additional_files_needed>
+		<prefix>/usr/local/bin/</prefix>
+		<item>https://packages.pfsense.org/packages/config/squidGuard/squidguard_ldap.php</item>
+	</additional_files_needed>
+	<additional_files_needed>
             <prefix>/usr/local/www/</prefix>
             <item>https://packages.pfsense.org/packages/config/squidGuard/sgerror.php</item>
 	</additional_files_needed>
@@ -166,7 +170,7 @@
                         <fieldname>ldap_enable</fieldname>
                         <description><![CDATA[Enable options for setup ldap connection to create filters with ldap search]]></description>
                         <type>checkbox</type>
-                        <enablefields>ldapbinddn,ldapbindpass,stripntdomain,striprealm,ldapversion</enablefields>
+                        <enablefields>ldapbinddn,ldapbindpass,stripntdomain,striprealm,ldapversion,ldapbatchserver,ldapbatchou</enablefields>
                 </field>
                 <field>
                         <fielddescr>LDAP DN</fielddescr>
@@ -211,6 +215,37 @@
                                 </option>
                         </options>
                 </field>
+		<field>
+			<fielddescr>LDAP query mode</fielddescr>
+			<fieldname>ldapfetch</fieldname>
+			<type>select</type>
+			<default_value>online</default_value>
+			<options>
+				<option>
+					<name>Online</name>
+					<value>online</value>
+				</option>
+				<option>
+					<name>Batch every 5 minutes</name>
+					<value>batch</value>
+				</option>
+			</options>
+		</field>
+		<field>
+		<fielddescr>LDAP query Server in Batch mode</fielddescr>
+			<fieldname>ldapbatchserver</fieldname>
+			<description><![CDATA[Configure your LDAP server to query in batch mode]]></description>
+			<type>input</type>
+			<size>60</size>
+		</field>
+		<field>
+		<fielddescr>LDAP query base OU DN in Batch mode</fielddescr>
+			<fieldname>ldapbatchou</fieldname>
+			<description><![CDATA[Configure your LDAP DN (ex: "OU=INTERNET,DC=domain,DC=local")]]></description>
+			<type>input</type>
+			<size>60</size>
+		</field>
+
                 <field>
                         <name>Logging options</name>
                         <type>listtopic</type>

--- a/config/squidGuard/squidguard_acl.xml
+++ b/config/squidGuard/squidguard_acl.xml
@@ -107,6 +107,7 @@
 								<b>IP:</b> 192.168.0.1 - <b>Subnet:</b> 192.168.0.0/24 or 192.168.1.0/255.255.255.0 - <b>IP-Range:</b> 192.168.1.1-192.168.1.10<br>
 								<b>Domain:</b> foo.bar matches foo.bar or *.foo.bar<br>
 								<b>Username:</b> 'user1' <br>
+								<b>ldap Group Name in batch mode:</b> [Managers] <br>
                                                                 <b>Ldap search (Ldap filter must be enabled in General Settings):</b> <br>
                                                                 ldapusersearch ldap://192.168.0.100/DC=domain,DC=com?sAMAccountName?sub?(&(sAMAccountName=%s)(memberOf=CN=it%2cCN=Users%2cDC=domain%2cDC=com))<br>
                                                                 <i>Attention: these line don't have break line, all on one line</i>

--- a/config/squidGuard/squidguard_configurator.inc
+++ b/config/squidGuard/squidguard_configurator.inc
@@ -920,6 +920,7 @@ function sg_create_config()
                         elseif (is_username($sr))     $sg_tag->items[] = "user   " . str_replace("'", "", $sr);
                 		elseif (is_group($sr) && $sr_group == 0) {
 							$sg_tag->items[] = "userlist " . SQUIDGUARD_DBHOME . ".ldap/{$src[F_NAME]}";
+                                                        file_put_contents(SQUIDGUARD_DBHOME . ".ldap/{$src[F_NAME]}","",LOCK_EX);
 							$sr_group ++;
 						}
 

--- a/config/squidGuard/squidguard_configurator.inc
+++ b/config/squidGuard/squidguard_configurator.inc
@@ -919,7 +919,7 @@ function sg_create_config()
                         elseif (is_domain_valid($sr)) $sg_tag->items[] = "domain $sr";
                         elseif (is_username($sr))     $sg_tag->items[] = "user   " . str_replace("'", "", $sr);
                 		elseif (is_group($sr) && $sr_group == 0) {
-							$sg_tag->items[] = "userlist ldap/{$src[F_NAME]}";
+							$sg_tag->items[] = "userlist " . SQUIDGUARD_DBHOME . ".ldap/{$src[F_NAME]}";
 							$sr_group ++;
 						}
 

--- a/config/squidGuard/squidguard_configurator.inc
+++ b/config/squidGuard/squidguard_configurator.inc
@@ -1,7 +1,8 @@
 <?php
 # ------------------------------------------------------------------------------
 /*  squidguard_configurator.inc
-    2006-2011 Serg Dvoriancev
+    Copyright (C) 2006-2011 Serg Dvoriancev
+    Copyright (C) 2016 ESF, LLC
 
     part of pfSense (www.pfSense.com)
 
@@ -96,7 +97,7 @@ $pf_version=substr(trim(file_get_contents("/etc/version")),0,3);
 
 define('REDIRECTOR_OPTIONS_REM',   '# squidGuard options');
 define('REDIRECT_CHILDREN_OPT',    'url_rewrite_children');
-if ($pf_version >= 2.2) { 
+if ($pf_version >= 2.2) {
    define('REDIRECTOR_PROGRAM_OPT',   'url_rewrite_program');
    define('REDIRECT_BYPASS_OPT',      'url_rewrite_bypass');
    define('REDIRECTOR_PROCESS_COUNT', '16 startup=8 idle=4 concurrency=0');
@@ -262,6 +263,7 @@ define('F_LDAPBINDPASS',        'ldapbindpass');
 define('F_LDAPVERSION',         'ldapversion');
 define('F_STRIPNTDOMAIN',       'stripntdomain');
 define('F_STRIPREALM',          'striprealm');
+define('F_LDAPFETCH',           'ldapfetch');
 define('F_BINPATH',             'binpath');
 define('F_PROCCESSCOUNT',       'process_count');
 define('F_SQUIDCONFIGFILE',     'squid_configfile');
@@ -349,7 +351,7 @@ function sg_init($init = '')
         $squidguard_config[F_BINPATH]         = SQUIDGUARD_BINPATH;
         $squidguard_config[F_SQUIDCONFIGFILE] = SQUID_CONFIGFILE;
         $squidguard_config[F_PROCCESSCOUNT]   = REDIRECTOR_PROCESS_COUNT;
-        
+
     } else {
         # copy config from $init
         foreach($init as $key => $in)
@@ -867,7 +869,7 @@ function sg_create_config()
     $sgconf[] = CONFIG_SG_HEADER;
     $sgconf[] = "logdir {$squidguard_config[F_LOGDIR]}";
     $sgconf[] = "dbhome {$squidguard_config[F_DBHOME]}";
-    if ( $squidguard_config[F_LDAPENABLE] == 'on' ) {
+    if ( $squidguard_config[F_LDAPENABLE] == 'on' && $squidguard_config[F_LDAPFETCH] != "batch" ) {
         $sgconf[] = "ldapbinddn {$squidguard_config[F_LDAPBINDDN]}";
         $sgconf[] = "ldapbindpass {$squidguard_config[F_LDAPBINDPASS]}";
         $sgconf[] = "ldapprotover {$squidguard_config[F_LDAPVERSION]}";
@@ -909,12 +911,18 @@ function sg_create_config()
             # separate IP, domains, usernames
             if (strpos(trim($src[F_SOURCE]), 'ldapusersearch') === false) {
                 $tsrc = explode(" ", trim($src[F_SOURCE]));
+                $sr_group=0;
                 foreach($tsrc as $sr) {
                         $sr = trim($sr);
                         if     (empty($sr))           continue;
-                        if     (is_ipaddr_valid($sr)) $sg_tag->items[] = "ip     $sr";
+                        elseif (is_ipaddr_valid($sr)) $sg_tag->items[] = "ip     $sr";
                         elseif (is_domain_valid($sr)) $sg_tag->items[] = "domain $sr";
                         elseif (is_username($sr))     $sg_tag->items[] = "user   " . str_replace("'", "", $sr);
+                		elseif (is_group($sr) && $sr_group == 0) {
+							$sg_tag->items[] = "userlist ldap/{$src[F_NAME]}";
+							$sr_group ++;
+						}
+
                 }
             } else {
                 $sg_tag->items[] = trim($src[F_SOURCE]);
@@ -977,7 +985,7 @@ function sg_create_config()
 		  $ads_pos = strpos($ent, '_ads');
 		  if ( ($ads_pos > 0 || $adv_pos > 0) && $squidguard_config[F_ADV_BLANKIMG] == 'on')
 			     $sg_tag->items[] = "redirect " . sg_redirector_base_url($dst[F_REDIRECT], RMOD_INT_BLANKIMG);
-			
+
                 if ($squidguard_config[F_ENABLELOG] == 'on' ) {
                     $sg_tag->items[] = "log ". SQUIDGUARD_LOGFILE;
                 }
@@ -1664,6 +1672,13 @@ function is_ipaddr_valid($val)
     return is_string($val) && (is_ipaddr($val) || is_masksubnet($val) || is_subnet($val) || is_iprange_sg($val));
 }
 
+# is_group - validade if $val is in ldap group name format
+# ------------------------------------------------------------------------------
+function is_group($val) {
+	return preg_match("/^\[(.*)\]$/",$val);
+}
+
+
 # ------------------------------------------------------------------------------
 # is_domain_valid - check domain format
 # ------------------------------------------------------------------------------
@@ -1933,7 +1948,7 @@ function acl_remove_blacklist_items(&$items)
 function sg_script_logrotate()
 {
 	$lines = SQUIDGUARD_LOGROTATE_MAXCOUNT;
-	
+
 	global $squidguard_config;
 
 	$sglogname = $squidguard_config[F_LOGDIR] . "/" . SQUIDGUARD_LOGFILE;
@@ -1974,6 +1989,16 @@ function squidguard_cron_install()
     } else {
 	    install_cron_job("{$cron_cmd}", false);
     }
+
+	# ldap batch mode
+	$cron_cmd="/usr/local/bin/squidguard_ldap.php";
+	$on_off = $squidguard_config[F_LDAPFETCH] == 'batch';
+	if($on_off) {
+		install_cron_job($cron_cmd, true, "*/5", "*", "*", "*", "*", "root");
+	} else {
+		install_cron_job($cron_cmd, false);
+	}
+
 }
 
 # *****************************************************************************

--- a/config/squidGuard/squidguard_configurator.inc
+++ b/config/squidGuard/squidguard_configurator.inc
@@ -920,7 +920,13 @@ function sg_create_config()
                         elseif (is_username($sr))     $sg_tag->items[] = "user   " . str_replace("'", "", $sr);
                 		elseif (is_group($sr) && $sr_group == 0) {
 							$sg_tag->items[] = "userlist " . SQUIDGUARD_DBHOME . ".ldap/{$src[F_NAME]}";
-                                                        file_put_contents(SQUIDGUARD_DBHOME . ".ldap/{$src[F_NAME]}","",LOCK_EX);
+							if (! is_dir(SQUIDGUARD_DBHOME . ".ldap")) {
+							        mkdir(SQUIDGUARD_DBHOME . ".ldap",0755,true);
+							        chown(SQUIDGUARD_DBHOME . ".ldap",OWNER_NAME);
+							}
+							if (! file_exists (SQUIDGUARD_DBHOME . ".ldap/{$src[F_NAME]}")) {
+								file_put_contents(SQUIDGUARD_DBHOME . ".ldap/{$src[F_NAME]}","",LOCK_EX);
+							}
 							$sr_group ++;
 						}
 

--- a/config/squidGuard/squidguard_ldap.php
+++ b/config/squidGuard/squidguard_ldap.php
@@ -1,0 +1,213 @@
+#!/usr/local/bin/php
+<?php
+/* ====================================================================================== */
+/*
+ * based on http://samjlevy.com/2011/02/using-php-and-ldap-to-list-of-members-of-an-active-directory-group/
+ squidguard_ldap.xml
+ part of pfSense (https://www.pfSense.org/)
+ Copyright (C) 2012-2013 ccesario
+ Copyright (C) 2012-2016 Marcello Coutinho
+ Copyright (C) 2016 ESF, LLC
+ All rights reserved.
+ */
+/* ====================================================================================== */
+/*
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+
+ 1. Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+
+
+ THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+/* ====================================================================================== */
+
+// ldapsearch -x -h 192.168.11.1 -p 389 -b OU=Internet,DC=domain,DC=local -D CN=Proxyauth,OU=PROXY,DC=domain,DC=local -w PASS
+
+require_once("/etc/inc/util.inc");
+require_once("/etc/inc/functions.inc");
+require_once("/etc/inc/pkg-utils.inc");
+require_once("/etc/inc/globals.inc");
+
+if (is_array($config['installedpackages']['squidguardgeneral']['config'])) {
+	$sgg=$config['installedpackages']['squidguardgeneral']['config'][0];
+	if ( $sgg['squidguard_enable'] == "on" && 
+		 $sgg['ldap_enable'] == "on" && $sgg['ldapfetch'] == "batch" ) {
+		
+		if ($sg['striprealm'] == "on") {
+			$user_mask = "USER";
+		} else {
+			$user_mask = "DOMAIN\USER";
+		}
+		
+		if ($sgg['ldapbinddn'] != "") {
+			$user_bind = $sgg['ldapbinddn'];
+		} else {
+			print "SquidGuard ldapbinddn not set\n";
+			exit;
+		}
+		
+		if ($sgg['ldapbindpass'] != "") {
+			$password = $sgg['ldapbindpass'];
+		} else {
+			print "SquidGuard ldap pass not set\n";
+			exit;
+		}
+
+		if ($sgg['ldapbatchou'] != "") {
+			$ldap_dn = $sgg['ldapbatchou'];
+		} else {
+			print "SquidGuard ldap pass not set.\n";
+			exit;
+		}
+
+		if ($sgg['ldapbatchserver'] != "") {
+			$ldap_host = $sgg['ldapbatchserver'];
+		} else {
+			print "SquidGuard ldap host not set.\n";
+			exit;
+		}
+		
+	} else {
+		print "Squidguard ldap not in batch mode\n";
+		exit;
+	}
+} else {
+	print "Squidguard config not found\n";
+	exit;
+}
+#mount filesystem writable
+conf_mount_rw();
+function explode_dn($dn, $with_attributes=0) {
+	$result = ldap_explode_dn($dn, $with_attributes);
+	if (is_array($result)) {
+		foreach($result as $key => $value) {
+			$result[$key] = $value;
+		}
+	}
+	return $result;
+}
+function get_ldap_members($group,$user,$password) {
+	global $ldap_host;
+	global $ldap_dn;
+	$LDAPFieldsToFind = array("member");
+	$ldap = ldap_connect($ldap_host) or die("Could not connect to LDAP");
+	// OPTIONS TO AD
+	ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION,3);
+	ldap_set_option($ldap, LDAP_OPT_REFERRALS,0);
+	ldap_bind($ldap, $user, $password) or die("Could not bind to LDAP");
+	$results = ldap_search($ldap,$ldap_dn,"cn=" . $group,$LDAPFieldsToFind);
+	$member_list = ldap_get_entries($ldap, $results);
+	$group_member_details = array();
+	if (is_array($member_list[0])) {
+		foreach($member_list[0] as $list) {
+			if (is_array($list)) {
+				foreach($list as $member) {
+					$ldap_dn_user = preg_replace('/^cn=([^,]+),/i','',$member);
+					$member_dn = explode_dn($member);
+					if (!empty($member_dn[0])) {
+						$member_cn = str_replace("CN=","",$member_dn[0]);
+						$member_search = ldap_search($ldap, $ldap_dn_user, "(CN=" . $member_cn . ")");
+						$member_details = ldap_get_entries($ldap, $member_search);
+						// If group has another group as member (only 1 level)
+						if(is_array($member_details[0]['member'])) {
+							foreach($member_details[0]['member'] as $sub_member) {
+								$sub_ldap_dn_user = preg_replace('/^cn=([^,]+),/i','',$sub_member);
+								$sub_member_dn = explode_dn($sub_member);
+								if (!empty($sub_member_dn[0])) {
+									$sub_member_cn = str_replace("CN=","",$sub_member_dn[0]);
+									$sub_member_search = ldap_search($ldap, $sub_ldap_dn_user, "(CN=" . $sub_member_cn . ")");
+									$sub_member_details = ldap_get_entries($ldap, $sub_member_search);
+									$group_member_details[] = array($sub_member_details[0]['samaccountname'][0]);
+								}
+							}
+						} else {
+						$group_member_details[] = array($member_details[0]['samaccountname'][0]);
+						}
+					}
+				}
+			}
+		}
+	}
+	ldap_close($ldap);
+	return $group_member_details;
+}
+//Log info
+log_error("Running squidGuard LDAP batch fetch");
+// Read Pfsense config
+global $config,$g;
+$id=0;
+$apply_config=0;
+if (is_array($config['installedpackages']['squidguardacl']['config'])) {
+	foreach($config['installedpackages']['squidguardacl']['config'] as $group) {
+		$members="";
+		print "SquidGuard acl name:{$group['name']}\n";
+		$group_list=explode(" ",$group['source']);
+		if (is_array($group_list)) {
+			foreach ($group_list as $group_OU) {
+				if (preg_match ("/\[(\S+)\]/",$group_OU,$gm)){
+					echo  "Group : " . $gm[1]."\n";
+					$result = get_ldap_members($gm[1],$user_bind,$password);
+					asort($result);
+					foreach($result as $key => $value) {
+						if (preg_match ("/\w+/",$value[0])) {
+							$members .= strtolower($value[0])."\n";
+							//user_mask was used here
+							}
+					}
+				}
+		 	}
+		}
+		if (!empty($members)) {
+			$dir="/var/db/squidGuard/ldap";
+			if (!is_dir($dir)) {
+				mkdir("$dir",0775,true);
+				chown($dir, "proxy");
+			}
+			$acl_file="{$dir}/{$group['name']}";
+			if (file_exists($acl_file)) {
+				$current_acl_members = md5(file_get_contents($acl_file));
+			} else {
+				$current_acl_members = "";
+			}
+			if($current_acl_members != md5($members)) {
+				$msg_md5="md5 mismatch for {$group['name']} $current_acl_members <> ". md5($members);
+				log_error($msg_md5);
+				print "$msg_md5\n";
+				file_put_contents($acl_file,$members,LOCK_EX);
+				$apply_config++;
+			}
+		}
+		echo "\t --> Members : " . $members . "\n\n";
+		$id++;
+	}
+}
+if ($apply_config > 0) {
+	log_error("squidGuard LDAP sync: user group list from LDAP has changed, reloading squid config...");
+	print "user list from LDAP is different from current group, applying new configuration...";
+	//write_config();
+	include("/usr/local/pkg/squidguard.inc");
+	// teste a faster reload (squid -k reconfigure or killall -HUP squid)
+	if (function_exists('squid_resync')) {
+		squid_resync();
+	}
+	print "done\n";
+}
+#mount filesystem read-only
+conf_mount_ro();
+?>

--- a/config/squidGuard/squidguard_ldap.php
+++ b/config/squidGuard/squidguard_ldap.php
@@ -174,7 +174,7 @@ if (is_array($config['installedpackages']['squidguardacl']['config'])) {
 		 	}
 		}
 		if (!empty($members)) {
-			$dir="/var/db/squidGuard/ldap";
+			$dir="/var/db/squidGuard.ldap";
 			if (!is_dir($dir)) {
 				mkdir("$dir",0775,true);
 				chown($dir, "proxy");

--- a/pkg_config.10.xml
+++ b/pkg_config.10.xml
@@ -1185,7 +1185,7 @@
 		<website>http://www.squidGuard.org/</website>
 		<maintainer>dv_serg@mail.ru</maintainer>
 		<category>Network Management</category>
-		<version>1.9.18</version>
+		<version>1.9.19</version>
 		<status>BETA</status>
 		<required_version>2.2</required_version>
 		<depends_on_package_pbi>squidguard-1.4_7-##ARCH##.pbi</depends_on_package_pbi>


### PR DESCRIPTION
Current version 1.4 for 2.2 is compatible with squid3 but ldap options get erros on config if enabled.
To fix it I've included a batch mode ldap fetch that update lists every 5 minutes using php/system ldap functions. 

![batch_mode_ldap_options](https://cloud.githubusercontent.com/assets/926309/13096581/916f8796-d501-11e5-8903-02fe2fd69a1b.PNG)

Also "clean" the client(source) field and support multiple groups on same acl as well.
![group_acls](https://cloud.githubusercontent.com/assets/926309/13096582/9393ad4a-d501-11e5-88c7-cff2069e6f24.PNG)
