### PR TITLE
Check for libldap shared objects needed by squidGuard

### DIFF
--- a/config/squidGuard/squidguard_configurator.inc
+++ b/config/squidGuard/squidguard_configurator.inc
@@ -868,6 +868,9 @@ function sg_create_config()
     $sgconf[] = "logdir {$squidguard_config[F_LOGDIR]}";
     $sgconf[] = "dbhome {$squidguard_config[F_DBHOME]}";
     if ( $squidguard_config[F_LDAPENABLE] == 'on' ) {
+    	# libldap needed
+    	if( is_pkg_installed("openldap-client") )
+            log_error("Warning! Package 'openldap-client' doesn't seems to be installed.");
         $sgconf[] = "ldapbinddn {$squidguard_config[F_LDAPBINDDN]}";
         $sgconf[] = "ldapbindpass {$squidguard_config[F_LDAPBINDPASS]}";
         $sgconf[] = "ldapprotover {$squidguard_config[F_LDAPVERSION]}";
@@ -1205,6 +1208,9 @@ function sg_create_simple_config($blk_dbhome, $blk_destlist, $redirect_to = "404
     $sgconf[] = "logdir $logdir";
     $sgconf[] = "dbhome $dbhome";
     if ( $squidguard_config[F_LDAPENABLE] == 'on' ) {
+    	# libldap needed
+    	if( is_pkg_installed("openldap-client") )
+            log_error("Warning! Package 'openldap-client' doesn't seems to be installed.");
         $sgconf[] = "ldapbinddn {$squidguard_config[F_LDAPBINDDN]}";
         $sgconf[] = "ldapbindpass {$squidguard_config[F_LDAPBINDPASS]}";
         $sgconf[] = "ldapprotover {$squidguard_config[F_LDAPVERSION]}";

--- a/config/squidGuard/squidguard_configurator.inc
+++ b/config/squidGuard/squidguard_configurator.inc
@@ -869,7 +869,7 @@ function sg_create_config()
     $sgconf[] = "dbhome {$squidguard_config[F_DBHOME]}";
     if ( $squidguard_config[F_LDAPENABLE] == 'on' ) {
     	# libldap needed
-    	if( is_pkg_installed("openldap-client") )
+    	if( !is_pkg_installed("openldap-client") )
             log_error("Warning! Package 'openldap-client' doesn't seems to be installed.");
         $sgconf[] = "ldapbinddn {$squidguard_config[F_LDAPBINDDN]}";
         $sgconf[] = "ldapbindpass {$squidguard_config[F_LDAPBINDPASS]}";
@@ -1209,7 +1209,7 @@ function sg_create_simple_config($blk_dbhome, $blk_destlist, $redirect_to = "404
     $sgconf[] = "dbhome $dbhome";
     if ( $squidguard_config[F_LDAPENABLE] == 'on' ) {
     	# libldap needed
-    	if( is_pkg_installed("openldap-client") )
+    	if( !is_pkg_installed("openldap-client") )
             log_error("Warning! Package 'openldap-client' doesn't seems to be installed.");
         $sgconf[] = "ldapbinddn {$squidguard_config[F_LDAPBINDDN]}";
         $sgconf[] = "ldapbindpass {$squidguard_config[F_LDAPBINDPASS]}";


### PR DESCRIPTION
As it says in the squidGuards docs: "In order to use LDAP functionalities the system must have the proper LDAP libraries and include files installed (openldap works fine)."