### PR TITLE
Prevent error message when bl update in shell

### DIFF
--- a/config/squidGuard/squidguard_configurator.inc
+++ b/config/squidGuard/squidguard_configurator.inc
@@ -1995,8 +1995,7 @@ function squidguard_ramdisk($enable)
         # create temp ramdisk
         # size 300Mb very nice for work with Archive < 30Mb
         # this is size use physical RAM + Swap file
-        if (!file_exists(SQUIDGUARD_TMP))
-            mkdir(SQUIDGUARD_TMP);
+        safe_mkdir(SQUIDGUARD_TMP);
         mwexec("/sbin/mdmfs -s {$ramsize}M md15 " . SQUIDGUARD_TMP);
         mwexec("chmod 1777 " . SQUIDGUARD_TMP);
     }

--- a/config/squidGuard/squidguard_configurator.inc
+++ b/config/squidGuard/squidguard_configurator.inc
@@ -1995,7 +1995,8 @@ function squidguard_ramdisk($enable)
         # create temp ramdisk
         # size 300Mb very nice for work with Archive < 30Mb
         # this is size use physical RAM + Swap file
-        mkdir(SQUIDGUARD_TMP);
+        if (!file_exists(SQUIDGUARD_TMP))
+            mkdir(SQUIDGUARD_TMP);
         mwexec("/sbin/mdmfs -s {$ramsize}M md15 " . SQUIDGUARD_TMP);
         mwexec("chmod 1777 " . SQUIDGUARD_TMP);
     }


### PR DESCRIPTION
When exectuting /tmp/squidGuard_blacklist_update.sh via shell (or cron), everything works but we get a warning because /tmp/squidguard already exists.
```
Warning: mkdir(): File exists in /usr/local/pkg/squidguard_configurator.inc on line 1978

Call Stack:
    0.0010     215688   1. {main}() /usr/local/bin/squidGuard_blacklist_update.sh:0
    0.6719    1860336   2. sg_reconfigure_blacklist() /usr/local/bin/squidGuard_blacklist_update.sh:5
   13.6968    9104752   3. sg_update_blacklist() /usr/local/pkg/squidguard_configurator.inc:2095
   13.7062    9105248   4. squidguard_ramdisk() /usr/local/pkg/squidguard_configurator.inc:2131
   13.7062    9105392   5. mkdir() /usr/local/pkg/squidguard_configurator.inc:1978
```