### PR TITLE
Fixing evaluation of some pool configuration items

### DIFF
--- a/config/haproxy-devel/pkg/haproxy.inc
+++ b/config/haproxy-devel/pkg/haproxy.inc
@@ -956,17 +956,17 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 		}
 		fwrite ($fd, "\tbalance\t\t\t{$pool['balance']}{$parameters}\n");
 	}
-	if (!$pool['connection_timeout']) {
+	if ($pool['connection_timeout'] === "") {
 		$pool['connection_timeout'] = 30000;
 	}
 	fwrite ($fd, "\ttimeout connect\t\t" . $pool['connection_timeout'] . "\n");
 
-	if (!$pool['server_timeout']) {
+	if ($pool['server_timeout'] === "") {
 		$pool['server_timeout'] = 30000;
 	}
 	fwrite ($fd, "\ttimeout server\t\t" . $pool['server_timeout'] . "\n");
 
-	if (!$pool['retries']) {
+	if ($pool['retries'] === "") {
 		$pool['retries'] = 3;
 	}
 	fwrite ($fd, "\tretries\t\t\t" . $pool['retries'] . "\n");

--- a/config/haproxy1_5/pkg/haproxy.inc
+++ b/config/haproxy1_5/pkg/haproxy.inc
@@ -641,15 +641,15 @@ function write_backend($configpath, $fd, $name, $pool, $backendsettings) {
 	if($pool['balance'])
 		fwrite ($fd, "\tbalance\t\t\t" . $pool['balance'] . "\n");
 
-	if(!$pool['connection_timeout'])
+	if($pool['connection_timeout'] === "")
 		$pool['connection_timeout'] = 30000;
 	fwrite ($fd, "\ttimeout connect\t\t" . $pool['connection_timeout'] . "\n");
 
-	if(!$pool['server_timeout'])
+	if($pool['server_timeout'] === "")
 		$pool['server_timeout'] = 30000;
 	fwrite ($fd, "\ttimeout server\t\t" . $pool['server_timeout'] . "\n");
 
-	if(!$pool['retries'])
+	if($pool['retries'] === "")
 		$pool['retries'] = 3;
 	fwrite ($fd, "\tretries\t\t\t" . $pool['retries'] . "\n");
 


### PR DESCRIPTION
With the previous evaluation mechanism, setting retries to 0 would get evaluated as uninitialized, so set to default 3.
This is a huge problem in cases where HAProxy should NOT retry at all.

Given that items in $pool should already be string-ified, evaluation boils down to whether it's an empty string or not, without consideration of nullness.