### PR TITLE
nut: add generic nutdrv_qx driver

### DIFF
--- a/config/nut/nut.xml
+++ b/config/nut/nut.xml
@@ -348,6 +348,10 @@
 					<value>blazer_usb01</value>
 				</option>
 				<option>
+					<name>Generic USB UPS (Viewpower/qx)</name>
+					<value>nutdrv_qx01</value>
+				</option>
+				<option>
 					<name>Inform GUARD Line Interactive</name>
 					<value>powercom00</value>
 				</option>


### PR DESCRIPTION
Works slightly better than blazer_usb for various UPSes based on "Viewpower" or "Voltronic".