### PR TITLE
Fix certs from external CAs not being usable to create clients

### DIFF
--- a/config/openvpn-client-export/openvpn-client-export.inc
+++ b/config/openvpn-client-export/openvpn-client-export.inc
@@ -128,6 +128,13 @@ function openvpn_client_export_validate_config($srvid, $usrid, $crtid) {
 		$input_errors[] = "Could not locate server certificate.";
 	} else {
 		$server_ca = ca_chain($server_cert);
+		if (!$server_ca && array_key_exists('caref', $settings)) {
+			$server_ca = lookup_ca($settings['caref']);
+
+			if($server_ca) {
+				$server_ca = base64_decode($server_ca['crt']);
+			}
+		}
 		if (!$server_ca) {
 			$input_errors[] = "Could not locate the CA reference for the server certificate.";
 		}


### PR DESCRIPTION
The certificates I use, generated by FreeIPA and imported into pfsense, are currently not usable when exporting clients as, internally, there is no caref from an imported certificate to an imported CA.

This changes the behavior of the client export package a little to find certificates where their issuer matches the subject of the VPN server's CA certificate.
