### PR TITLE
Fix against code execution attack

### DIFF
--- a/config/squidGuard/squidguard_blacklist.php
+++ b/config/squidGuard/squidguard_blacklist.php
@@ -64,14 +64,12 @@ function squidguard_blacklist_AJAX_response( $request )
 
     # Actions
     if ($request['blacklist_download_start'])
-        {
-                $url = $request['blacklist_url'];
-                if ( preg_match('/["\'\s\n\r\(\);]+/', $url )){
-                        $status = "Error: Bad blacklist URL";
-                        squidguard_update_log($status,"");
-                }else{
-                	squidguard_blacklist_update_start( $url ); # update start
-                }
+    {
+    	if( squidguard_blacklist_update_start( $request['blacklist_url'] ) === false ) # update start
+    	{
+    		$status = "Blacklist update error. Please check URL";                                                                                                                  
+		squidguard_update_log($status,"");
+    	}                                                                                                                                                                          
     }
     elseif ($request['blacklist_download_cancel']){	squidguard_blacklist_update_cancel();	}                           # update cancel
     elseif ($request['blacklist_restore_default']){	squidguard_blacklist_restore_arcdb();	}                           # restore default db

--- a/config/squidGuard/squidguard_blacklist.php
+++ b/config/squidGuard/squidguard_blacklist.php
@@ -69,11 +69,13 @@ function squidguard_blacklist_AJAX_response( $request )
                 if ( preg_match('/["\'\s\n\r\(\);]+/', $url )){
                         $status = "Error: Bad blacklist URL";
                         squidguard_update_log($status,"");
-                }else   squidguard_blacklist_update_start( $url ); # update start
+                }else{
+                	squidguard_blacklist_update_start( $url ); # update start
+                }
     }
-    elseif ($request['blacklist_download_cancel']) squidguard_blacklist_update_cancel();                           # update cancel
-    elseif ($request['blacklist_restore_default']) squidguard_blacklist_restore_arcdb();                           # restore default db
-    elseif ($request['blacklist_clear_log'])       squidguard_blacklist_update_clearlog();                         # clear log
+    elseif ($request['blacklist_download_cancel']){	squidguard_blacklist_update_cancel();	}                           # update cancel
+    elseif ($request['blacklist_restore_default']){	squidguard_blacklist_restore_arcdb();	}                           # restore default db
+    elseif ($request['blacklist_clear_log']){		squidguard_blacklist_update_clearlog();	}                         # clear log
  
     # Activity
     # Rebuild progress /check SG rebuild process/
@@ -102,7 +104,9 @@ function squidguard_blacklist_AJAX_response( $request )
 
     if (empty($status) && file_exists(SGUPD_STATFILE)) {
         $status = file_get_contents(SGUPD_STATFILE);
-        if ($sz && $sz != 100) $status .= "Completed {$sz} %";
+        if ($sz && $sz != 100){
+        	$status .= "Completed {$sz} %";
+        }
     }
     if ($status) {
         $status = str_replace("\n", "\\r\\n", trim($status));

--- a/config/squidGuard/squidguard_blacklist.php
+++ b/config/squidGuard/squidguard_blacklist.php
@@ -58,11 +58,19 @@ if ($_REQUEST['getactivity'])
 function squidguard_blacklist_AJAX_response( $request )
 {
     $res = '';
+    $status = '';
     $sz  = 0;
     $pcaption = '&nbsp;';
 
     # Actions
-    if     ($request['blacklist_download_start'])  squidguard_blacklist_update_start( $request['blacklist_url'] ); # update start
+    if ($request['blacklist_download_start'])
+        {
+                $url = $request['blacklist_url'];
+                if ( preg_match('/["\'\s\n\r\(\);]+/', $url )){
+                        $status = "Error: Bad blacklist URL";
+                        squidguard_update_log($status,"");
+                }else   squidguard_blacklist_update_start( $url ); # update start
+    }
     elseif ($request['blacklist_download_cancel']) squidguard_blacklist_update_cancel();                           # update cancel
     elseif ($request['blacklist_restore_default']) squidguard_blacklist_restore_arcdb();                           # restore default db
     elseif ($request['blacklist_clear_log'])       squidguard_blacklist_update_clearlog();                         # clear log
@@ -92,8 +100,7 @@ function squidguard_blacklist_AJAX_response( $request )
     $res .= "el('widthb').width = {$szright};";
     $res .= "el('progress_text').innerHTML = '{$sz} %';";
 
-    $status = '';
-    if (file_exists(SGUPD_STATFILE)) {
+    if (empty($status) && file_exists(SGUPD_STATFILE)) {
         $status = file_get_contents(SGUPD_STATFILE);
         if ($sz && $sz != 100) $status .= "Completed {$sz} %";
     }


### PR DESCRIPTION
There isn't a check against an improper of user input (blacklist URL) and PHP code (thus system commands) could be executed as root. Example of a _special_ URL: `","");passthru('/usr/bin/id > /tmp/id');//`
