### PR TITLE
Add wildcard on vhosts package if host empty

### DIFF
--- a/config/vhosts/vhosts.inc
+++ b/config/vhosts/vhosts.inc
@@ -283,7 +283,12 @@ EOF;
 						$tmp .= "\$SERVER[\"socket\"] == \"" . $ipaddress . ":" . $port . "\" {\n";
 					}
 
-					$tmp .= "	\$HTTP[\"host\"] == \"" . $host . "\" {\n";
+					// if host empty, define wildcard regex 
+					if (empty($host)) {
+						$tmp .= "	\$HTTP[\"host\"] =~ \"^(.*)\$\" {\n";
+					} else {
+						$tmp .= "       \$HTTP[\"host\"] == \"" . $host . "\" {\n";
+					}
 					$tmp .= "		server.document-root        = \"/usr/local/vhosts/" . $directory . "\"\n";
 
 					// Enable SSL if the cert and key were both provided

--- a/config/vhosts/vhosts_php_edit.php
+++ b/config/vhosts/vhosts_php_edit.php
@@ -201,7 +201,7 @@ function openwindow(url) {
 			<td width="78%" class="vtable">
 				<input name="host" type="text" class="formfld" id="host" size="40" value="<?=htmlspecialchars($pconfig['host']);?>" />
 				<br />
-				Required. If the host is intended for internal you can use the DNS forwarder to set a host name that is valid inside the local network. Default: vhost01.local
+				Required. If the host is intended for internal you can use the DNS forwarder to set a host name that is valid inside the local network. If keep empty, host will be set on a willcard associated with the IP Address.
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
Add wildcard on vhosts package if host empty.

Currently, this package always try to define a equal ("==") condition.
If host is defined empty, config file for this host will switch to regex condition "=~" with a wildcard regex "^(.*)$"
