### PR TITLE
Strip carriage returns from 'raw' openbgpd config

### DIFF
--- a/config/openbgpd/openbgpd.inc
+++ b/config/openbgpd/openbgpd.inc
@@ -66,7 +66,7 @@ function openbgpd_install_conf() {
 	if ($config['installedpackages']['openbgpd']['rawconfig'] && $config['installedpackages']['openbgpd']['rawconfig']['item']) {
 		// If there is a raw config specified in the config.xml, use that instead of the assisted config
 		$conffile = implode("\n", $config['installedpackages']['openbgpd']['rawconfig']['item']);
-		// OpenBGPd will error if carriage return are included for each line.
+		// OpenBGPd will error if carriage returns endings exist.
 		$conffile = str_replace("\r", "", $conffile);
 		//$conffile = $config['installedpackages']['openbgpd']['rawconfig'];
 	} else {

--- a/config/openbgpd/openbgpd.inc
+++ b/config/openbgpd/openbgpd.inc
@@ -66,6 +66,8 @@ function openbgpd_install_conf() {
 	if ($config['installedpackages']['openbgpd']['rawconfig'] && $config['installedpackages']['openbgpd']['rawconfig']['item']) {
 		// If there is a raw config specified in the config.xml, use that instead of the assisted config
 		$conffile = implode("\n", $config['installedpackages']['openbgpd']['rawconfig']['item']);
+		// OpenBGPd will error if carriage return are included for each line.
+		$conffile = str_replace("\r", "", $conffile);
 		//$conffile = $config['installedpackages']['openbgpd']['rawconfig'];
 	} else {
 		// Generate bgpd.conf based on the assistant


### PR DESCRIPTION
On Windows, copy & pasting text into the raw config text box can include carriage returns. This causes OpenBGPd to error unexpectedly with a generic "syntax error"
