### PR TITLE
Table BGColor

### DIFF
--- a/config/squidGuard/squidguard.inc
+++ b/config/squidGuard/squidguard.inc
@@ -678,7 +678,7 @@ function make_grid_general_items($id = '')
 {
     global $squidguard_config;
 
-    $bg_color = "bgcolor='#dddddd'";
+    $bg_color = "bgcolor='#919191'";
     $res = '';
     $res .= "<table width='100%'>";
 
@@ -728,11 +728,11 @@ function make_grid_controls($type, $items, $enable_overtime = true) {
     foreach($items as $item) {
         if ($x === 0) {
             $color = '';
-            $color2 = 'style="background-color: #dddddd;"';
+            $color2 = 'style="background-color: #919191;"';
             $x = 1;
         }
         else {
-            $color = 'style="background-color: #dddddd;"';
+            $color = 'style="background-color: #919191;"';
             $color2 = '';
             $x = 0;
         }
@@ -805,7 +805,7 @@ function make_grid_controls($type, $items, $enable_overtime = true) {
 
     # header
     if (!empty($tbl)) {
-        $color = 'style="background-color: #dddddd;"';
+        $color = 'style="background-color: #919191;"';
         $thdr = '';
         $hdr1up = "<big>Target Categories</big>";
         $hdr1ov = "<big>Target Categories for off-time</big>";


### PR DESCRIPTION
the table is unreadable with current color settings and pfSense portal in dark theme.

Here are the colors I've tested: https://snag.gy/VFxeiK.jpg
#919191 is the line with "[blk_BL_automobile_bikes]"
Note that the word "access" at the end of the line is black to reflect light theme colors.

The lowest row, just above the developer tools, is the original presentation. The text is unreadable.